### PR TITLE
Idempiere 4258

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/WProcessCtl.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/WProcessCtl.java
@@ -182,6 +182,8 @@ public class WProcessCtl extends AbstractProcessCtl {
 			return;
 		}
 		pi.setAD_PInstance_ID (instance.getAD_PInstance_ID());
+	  } else {
+		  instance = new MPInstance(Env.getCtx(), pi.getAD_PInstance_ID(), null);
 	  }
 
 		//	Get Parameters


### PR DESCRIPTION
Tested the patch - it creates correctly the parameter "*RecordIDs*" with all the records in the window, and it doesn't throw NPE.  So, jasper reports could use this new parameter to get more than one record - but I didn't test this case, more focused on solving the NPE at this moment.