### PR TITLE
IDEMPIERE-1035 hard to find exceptions when using restrictive rights …

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/AbstractADWindowContent.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/AbstractADWindowContent.java
@@ -2804,7 +2804,12 @@ public abstract class AbstractADWindowContent extends AbstractUIPart implements 
 			if (adTabbox.getSelectedGridTab().getRecord_ID() <= 0)
 				return;
 			else
-				AEnv.startWorkflowProcess(adTabbox.getSelectedGridTab().getAD_Table_ID(), adTabbox.getSelectedGridTab().getRecord_ID());
+				try {
+					AEnv.startWorkflowProcess(adTabbox.getSelectedGridTab().getAD_Table_ID(), adTabbox.getSelectedGridTab().getRecord_ID());
+				} catch (Exception e) {
+					CLogger.get().saveError("Error", e);
+					throw new ApplicationException(e.getMessage());
+				}
 		}
 	}
 	//

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/AbstractADWindowContent.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/AbstractADWindowContent.java
@@ -2808,7 +2808,7 @@ public abstract class AbstractADWindowContent extends AbstractUIPart implements 
 					AEnv.startWorkflowProcess(adTabbox.getSelectedGridTab().getAD_Table_ID(), adTabbox.getSelectedGridTab().getRecord_ID());
 				} catch (Exception e) {
 					CLogger.get().saveError("Error", e);
-					throw new ApplicationException(e.getMessage());
+					throw new ApplicationException(e.getMessage(), e);
 				}
 		}
 	}


### PR DESCRIPTION
This commit improves the error message when a role has no access workflows and the toolbar button is clicked. 

The current message is:
![1035-BeforeError](https://user-images.githubusercontent.com/12065321/80744759-761bc580-8b1f-11ea-8d57-a45cee3844f7.jpg)

The message after the commit is:
![1035-AfterError](https://user-images.githubusercontent.com/12065321/80744767-79af4c80-8b1f-11ea-88c7-fab78f1fa6bf.jpg)

To test this you can create a new user with a role that only has access to Sales Order. Log in as that user with that role -> open a Sales Order window -> click on the workflow button.
