### PR TITLE
IDEMPIERE-4220 payment could not be committed due to wrong invoice date

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MPayment.java
+++ b/org.adempiere.base/src/org/compiere/model/MPayment.java
@@ -2339,7 +2339,7 @@ public class MPayment extends X_C_Payment
 			Msg.translate(getCtx(), "C_Payment_ID") + ": " + getDocumentNo() + " [1]", get_TrxName());
 		alloc.setAD_Org_ID(getAD_Org_ID());
 		alloc.setDateAcct(getDateAcct()); // in case date acct is different from datetrx in payment
-		MInvoice invoice = MInvoice.get(getCtx(), getC_Invoice_ID());
+		MInvoice invoice = new MInvoice(getCtx(), getC_Invoice_ID(), get_TrxName());
 		if (invoice.getDateAcct().after(alloc.getDateAcct())) {
 			alloc.setDateAcct(invoice.getDateAcct());
 		}


### PR DESCRIPTION
Fixes issue reported by @mschnbeck 

14:08:47.076===========> MInvoice.load: NO Data found for C_Invoice_ID=1000000 [173]
java.lang.Exception
	at org.compiere.model.PO.load(PO.java:1364)

bad trx management