### PR TITLE
IDEMPIERE-3333: Respecting ReportView order by clause when there is n…

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MReportView.java
+++ b/org.adempiere.base/src/org/compiere/model/MReportView.java
@@ -1,0 +1,65 @@
+/******************************************************************************
+ * Product: iDempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2012 ComPiere, Inc. All Rights Reserved.                *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
+ * or via info@compiere.org or http://www.compiere.org/license.html           *
+ *****************************************************************************/
+package org.compiere.model;
+import java.sql.ResultSet;
+import java.util.Properties;
+
+import org.compiere.util.CCache;
+import org.compiere.util.CLogger;
+
+public class MReportView extends X_AD_ReportView {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -5674822764517548357L;
+	
+	/**	Static Logger					*/
+	private static CLogger	s_log	= CLogger.getCLogger (MReportView.class);
+	/**	Cache					*/
+	static private CCache<Integer,MReportView> s_cache = new CCache<Integer,MReportView>(Table_Name, 30, 60);
+	
+	
+	public MReportView(Properties ctx, int AD_ReportView_ID, String trxName) {
+		super(ctx, AD_ReportView_ID, trxName);
+	}
+	
+	public MReportView(Properties ctx, ResultSet rs, String trxName) {
+		super(ctx, rs, trxName);
+	}
+
+	/**
+	 * 
+	 * @param ctx
+	 * @param AD_ReportView_ID
+	 * @return
+	 */
+	public static MReportView get (Properties ctx, int AD_ReportView_ID) {
+		if(AD_ReportView_ID==0) {
+			return null;
+		}
+		
+		Integer key = Integer.valueOf(AD_ReportView_ID);
+		MReportView retValue = (MReportView)s_cache.get(key);
+		if (retValue == null)
+		{
+			retValue = new MReportView (ctx, AD_ReportView_ID, null);
+			s_cache.put(key, retValue);
+		}
+		return retValue;
+	}	//	get
+}

--- a/org.adempiere.base/src/org/compiere/print/DataEngine.java
+++ b/org.adempiere.base/src/org/compiere/print/DataEngine.java
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.model.MLookupFactory;
 import org.compiere.model.MQuery;
+import org.compiere.model.MReportView;
 import org.compiere.model.MRole;
 import org.compiere.model.MTable;
 import org.compiere.model.X_AD_ReportView;
@@ -726,10 +727,9 @@ public class DataEngine
 		}	//	order by
 		else if (format.getAD_ReportView_ID() > 0)
 		{
-			X_AD_ReportView reportView = (X_AD_ReportView) MTable.get(Env.getCtx(), X_AD_ReportView.Table_ID)
-					.getPO(format.getAD_ReportView_ID(), m_trxName);
+			X_AD_ReportView reportView = MReportView.get(Env.getCtx(),format.getAD_ReportView_ID());
 
-			if (!Util.isEmpty(reportView.getOrderByClause(), true))
+			if (reportView!=null && !Util.isEmpty(reportView.getOrderByClause(), true))
 			{
 				finalSQL.append(" ORDER BY ").append(reportView.getOrderByClause());
 			}

--- a/org.adempiere.base/src/org/compiere/print/DataEngine.java
+++ b/org.adempiere.base/src/org/compiere/print/DataEngine.java
@@ -32,6 +32,7 @@ import org.compiere.model.MLookupFactory;
 import org.compiere.model.MQuery;
 import org.compiere.model.MRole;
 import org.compiere.model.MTable;
+import org.compiere.model.X_AD_ReportView;
 import org.compiere.util.CLogMgt;
 import org.compiere.util.CLogger;
 import org.compiere.util.DB;
@@ -709,7 +710,7 @@ public class DataEngine
 		}
 
 		//	Add ORDER BY clause
-		if (orderColumns != null)
+		if (orderColumns != null && orderColumns.size() > 0)
 		{
 			for (int i = 0; i < orderColumns.size(); i++)
 			{
@@ -723,7 +724,16 @@ public class DataEngine
 				finalSQL.append(by);
 			}
 		}	//	order by
-		
+		else if (format.getAD_ReportView_ID() > 0)
+		{
+			X_AD_ReportView reportView = (X_AD_ReportView) MTable.get(Env.getCtx(), X_AD_ReportView.Table_ID)
+					.getPO(format.getAD_ReportView_ID(), m_trxName);
+
+			if (!Util.isEmpty(reportView.getOrderByClause(), true))
+			{
+				finalSQL.append(" ORDER BY ").append(reportView.getOrderByClause());
+			}
+		} // Report view order by clause.
 
 		//	Print Data
 		PrintData pd = new PrintData (ctx, reportName);


### PR DESCRIPTION
…o orderby field on print format configured.

For quick testing I suggest below steps.

1. Open Unallocated Invoice report. It is already sorted by document no
2. Click customize button and remove sort order
3. Now this report is not sorted by DocumentNo
4. Go to report view and look on record named RV_C_Invoice NotAllocated.
5.  Add DocumentNo in Sql ORDER By field
6. Cache reset and refresh Unallocated invoice report.  This time it should be sorted by document number.