### PR TITLE
IDEMPIERE-1146 + IDEMPIERE-3234  / Centralized ID not working with na…

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MSequence.java
+++ b/org.adempiere.base/src/org/compiere/model/MSequence.java
@@ -62,9 +62,6 @@ public class MSequence extends X_AD_Sequence
 	
 	private static final String NoYearNorMonth = "-";
 
-	/**
-	 *  @deprecated please use DB.getNextID (int, String, String)
-	 */
 	public static int getNextID (int AD_Client_ID, String TableName)
 	{
 		return getNextID(AD_Client_ID, TableName, null);
@@ -75,10 +72,8 @@ public class MSequence extends X_AD_Sequence
 	 *	Get next number for Key column = 0 is Error.
 	 *  @param AD_Client_ID client
 	 *  @param TableName table name
-	 * 	@param trxName deprecated (NOT USED!!)
+	 * 	@param trxName
 	 *  @return next no or (-1=not found, -2=error)
-	 *  
-	 *  @deprecated please use DB.getNextID (int, String, String)
 	 */
 	public static int getNextID (int AD_Client_ID, String TableName, String trxName)
 	{

--- a/org.adempiere.base/src/org/compiere/util/DB.java
+++ b/org.adempiere.base/src/org/compiere/util/DB.java
@@ -1826,30 +1826,6 @@ public final class DB
 	@SuppressWarnings("deprecation")
 	public static int getNextID (int AD_Client_ID, String TableName, String trxName)
 	{
-		boolean SYSTEM_NATIVE_SEQUENCE = MSysConfig.getBooleanValue(MSysConfig.SYSTEM_NATIVE_SEQUENCE,false);
-		//	Check AdempiereSys
-		boolean adempiereSys = false;
-		if (Ini.isClient()) 
-		{
-			adempiereSys = Ini.isPropertyBool(Ini.P_ADEMPIERESYS);
-		} 
-		else
-		{
-			String sysProperty = Env.getCtx().getProperty("AdempiereSys", "N");
-			adempiereSys = "y".equalsIgnoreCase(sysProperty) || "true".equalsIgnoreCase(sysProperty);
-		}
-
-		if(SYSTEM_NATIVE_SEQUENCE && !adempiereSys)
-		{
-			int m_sequence_id = CConnection.get().getDatabase().getNextID(TableName+"_SQ", trxName);
-			if (m_sequence_id == -1) {
-				// try to create the sequence and try again
-				MSequence.createTableSequence(Env.getCtx(), TableName, trxName, true);
-				m_sequence_id = CConnection.get().getDatabase().getNextID(TableName+"_SQ", trxName);
-			}
-			return m_sequence_id;
-		}
-
 		return MSequence.getNextID (AD_Client_ID, TableName, trxName); // it is ok to call deprecated method here
 	}	//	getNextID
 

--- a/org.adempiere.base/src/org/compiere/util/DB.java
+++ b/org.adempiere.base/src/org/compiere/util/DB.java
@@ -1823,7 +1823,6 @@ public final class DB
 	 * 	@param trxName optional Transaction Name
 	 *  @return next no
 	 */
-	@SuppressWarnings("deprecation")
 	public static int getNextID (int AD_Client_ID, String TableName, String trxName)
 	{
 		return MSequence.getNextID (AD_Client_ID, TableName, trxName); // it is ok to call deprecated method here


### PR DESCRIPTION
Hi guys, I did some tests on those two tickets and noticed the code was distributed in a bad way (part on DB and part on MSequence), and also it was not good the way it was written.

So, I refactored the method MSequence.getNextID:
- to take into account first the priorities to get the ID from http
- to error in case somebody wants to get an official ID locally
- to get properly native sequence IDs on excluded tables on official
- and get the IDs from AD_Sequence at the end if not http/native

Found a performance issue calling MTable and MTable.getColumns, so I decided to implement a Cache of tables with EntityType column, that made the class to behave fast.