### PR TITLE
IDEMPIERE-4288 zk9 - Editor-Dialog: Not Allowed to set height and row…

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WTextEditorDialog.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WTextEditorDialog.java
@@ -118,7 +118,7 @@ public class WTextEditorDialog extends Window implements EventListener<Event>{
 		tabPanels.appendChild(tabPanel);
 		textBox = new Textbox(text);
 		textBox.setCols(80);
-		textBox.setRows(30);
+		textBox.setMultiline(true);
 		ZKUpdateUtil.setHeight(textBox, "100%");
 		textBox.setEnabled(editable);
 		ZKUpdateUtil.setHflex(textBox, "1");


### PR DESCRIPTION
Textbox in the ZK9-Editor is set to multiline. 
Tested and display is fine.

Tests:
changed the size.
changed the size to fullscreen.
filled the textbox with long text.
also as html
