### PR TITLE
IDEMPIERE-3657 Missing buttons start/end page on detail tab

### DIFF
--- a/org.adempiere.ui.zk/theme/default/css/fragment/adwindow.css.dsp
+++ b/org.adempiere.ui.zk/theme/default/css/fragment/adwindow.css.dsp
@@ -279,6 +279,13 @@
 	}
 }
 
+@media screen and (min-width: 600px) {
+    /* Tablets and bigger */
+	.adwindow-detailpane-adtab-grid-south .z-paging ul>li {
+  		display: inline!important;
+	}
+}
+
 .activity-card {
 	border: 1px solid #d0cdc8;
 	border-top-left-radius: 2px;


### PR DESCRIPTION
The commit is to display the 'Show First' and 'Show Last' paging buttons again. The CSS is only for devices with screens larger than tablets, those two buttons on smaller screens overlap the toolbar buttons.