### PR TITLE
IDEMPIERE-4294 Cannot install wildcard certificate #resolve IDEMPIERE…

### DIFF
--- a/org.adempiere.server-feature/jettyhome/etc/jetty-ssl-context-template.xml
+++ b/org.adempiere.server-feature/jettyhome/etc/jetty-ssl-context-template.xml
@@ -4,7 +4,7 @@
 <!-- ============================================================= -->
 <!-- SSL ContextFactory configuration                              -->
 <!-- ============================================================= -->
-<Configure id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory">
+<Configure id="sslContextFactory" class="org.eclipse.jetty.util.ssl.SslContextFactory$Server">
   <Set name="Provider"></Set>
   <Set name="KeyStorePath"><Property name="jetty.base" default="." />/<Property name="jetty.sslContext.keyStorePath" deprecated="jetty.keystore" default="etc/keystore"/></Set>
   <Set name="KeyStorePassword"><Property name="jetty.sslContext.keyStorePassword" deprecated="jetty.keystore.password" default="@ADEMPIERE_KEYSTOREPASS@"/></Set>


### PR DESCRIPTION
…-4294

Solve java.lang.IllegalStateException: KeyStores with multiple certificates are not supported on the base class org.eclipse.jetty.util.ssl.SslContextFactory.