### PR TITLE
IDEMPIERE-4293 Excel that download from Info Window is displayed ID N…

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
@@ -71,6 +71,7 @@ import org.compiere.model.AccessSqlParser.TableInfo;
 import org.compiere.model.GridField;
 import org.compiere.model.GridFieldVO;
 import org.compiere.model.GridWindow;
+import org.compiere.model.Lookup;
 import org.compiere.model.MInfoColumn;
 import org.compiere.model.MInfoWindow;
 import org.compiere.model.MLookupFactory;
@@ -2688,14 +2689,16 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 			{
 				throw new AdempiereException(e);
 			}
-			/* not required - the info window splits the column in key name pairs
-			GridField gridField = columnInfos[col].getGridField();
-			Lookup lookup = gridField.getLookup();
-			if (val != null && lookup != null)
+			
+			if(val != null && !columnInfos[col].isKeyPairCol() 
+					&& columnInfos[col].getGridField().getLookup() != null)
 			{
-				val = lookup.getDisplay(val);
-			}
-			*/
+				Lookup lookup = columnInfos[col].getGridField().getLookup();
+				if (lookup != null)
+				{
+					val = lookup.getDisplay(val);
+				}
+			} 
 			
 			return val; 
 		}


### PR DESCRIPTION
I tested the below standard iDempiere info Windows. I think there is no problem.
*Product Info
*Business Partner Info
*Order Info
*Invoice Info
*Shipment Info
*Payment Info
*Resource Info
*Asset Info


I tested the below Display types(Reference). These downloaded value in stead of ID Number.
*Table Direct
*Table
*Search
*Product Attribute
*Locator
*Account
*Address
*Chosen Multiple Selection Serach
*Chosen Multiple Selection Table

value of List is OK too!
*List
*Payment
*Chosen Multiple Selection List

The bolow Display types(Reference) download ID Number. But I think it is no problem. I think these Display types don't use at Info Window usually.
I think that If we need, We should be another ticket.
*Assinment
*Image
*Chosen Multiple Selection Grid

I created pull request first time.
If I have mistook, please teach me it.

best regards