### PR TITLE
IDEMPIERE-4304 Saved Query duplicates if use to save after sharing

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MUserQuery.java
+++ b/org.adempiere.base/src/org/compiere/model/MUserQuery.java
@@ -261,39 +261,15 @@ public class MUserQuery extends X_AD_UserQuery
 	 */
 	public static MUserQuery getUserQueryByName(Properties ctx, int AD_Tab_ID, String name)
 	{
-		int AD_User_ID = Env.getAD_User_ID(ctx);
-		String sql = "SELECT * FROM AD_UserQuery "
-			 + "WHERE AD_Client_ID=? AND AD_Tab_ID=? AND UPPER(Name) LIKE ? AND IsActive='Y' "
-			 + "AND (AD_User_ID = ? OR AD_User_ID IS NULL) "
-			 + "ORDER BY Name";
-		int AD_Client_ID = Env.getAD_Client_ID (ctx);
-		if (name == null)
-			name = "%";
-		MUserQuery retValue = null;
-		PreparedStatement pstmt = null;
-		ResultSet rs = null;
-		try
-		{
-			pstmt = DB.prepareStatement (sql, null);
-			pstmt.setInt (1, AD_Client_ID);
-			pstmt.setInt (2, AD_Tab_ID);
-			pstmt.setString (3, name.toUpperCase());
-			pstmt.setInt (4, AD_User_ID);
-			rs = pstmt.executeQuery ();
-			if (rs.next ())
-				retValue = new MUserQuery (ctx, rs, null);
-		}
-		catch (Exception e)
-		{
-			s_log.log (Level.SEVERE, sql, e);
-		}
-		finally
-		{
-			DB.close(rs, pstmt);
-			rs = null; pstmt = null;
-		}
-		return retValue;
-	}	//	get
+		String sqlWhere = " AD_Client_ID=? AND AD_Tab_ID=? AND UPPER(Name) LIKE ? "
+			 + "AND (AD_User_ID = ? OR AD_User_ID IS NULL) ";
+
+		return new Query(ctx, Table_Name, sqlWhere, null)
+				.setParameters(Env.getAD_Client_ID (ctx), AD_Tab_ID, name.toUpperCase(), Env.getAD_User_ID(ctx))
+				.setOnlyActiveRecords(true)
+				.setOrderBy("Name")
+				.first();
+	}	//	getUserQueryByName
 
 	/**	Logger	*/
 	private static CLogger s_log = CLogger.getCLogger (MUserQuery.class);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/FindWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/FindWindow.java
@@ -1368,6 +1368,8 @@ public class FindWindow extends Window implements EventListener<Event>, ValueCha
                 	} else {
                     	cmd_saveSimple(true, shareAllUsers);
                 	}
+                	if (shareAllUsers)
+                		btnSave.setDisabled(true);
                 }
             }
             //  Confirm panel actions
@@ -1477,14 +1479,8 @@ public class FindWindow extends Window implements EventListener<Event>, ValueCha
     	}
 		else {
 			MUserQuery uq = userQueries[index-1];
-			// If global query do not allow other users to save the query 
-			if (uq.getAD_User_ID() != Env.getAD_User_ID(Env.getCtx())) {
-		        if (!MRole.PREFERENCETYPE_Client.equals(MRole.getDefault().getPreferenceType()) ||
-		        		uq.getAD_Client_ID() != Env.getAD_Client_ID(Env.getCtx())) {
-		        	btnSave.setDisabled(true);
-		        	btnShare.setDisabled(true);
-		        }
-			}
+			btnSave.setDisabled(!uq.userCanSave());
+			btnShare.setDisabled(!uq.userCanShare());
 			parseUserQuery(userQueries[index-1]);
 		}
     }
@@ -1829,7 +1825,7 @@ public class FindWindow extends Window implements EventListener<Event>, ValueCha
 					code.append( (Object) historyCombo.getSelectedItem().getValue());
 		        }
 				
-				MUserQuery uq = MUserQuery.get(Env.getCtx(), m_AD_Tab_ID, name);
+				MUserQuery uq = MUserQuery.getUserQueryByName(Env.getCtx(), m_AD_Tab_ID, name);
 				if (code.length() > 0) { // New or updated
 					if (uq == null) // Create a new record
 					{


### PR DESCRIPTION
Comments added to the ticket. 

Changes made with this commit: 

1. If a user query is shared globally the saved button is disabled to avoid creating a private duplicate.
2. A user can make a copy of the global query and save it privately. A copy is made by changing the name of the saved query in the corresponding field in the search window. This also prevents having multiple queries with the same name.
3. There was a bug when updating a global query. When you selected a shared query, modified it, and click on the share button, it was duplicated instead of updated. This has been fixed as well.