### PR TITLE
IDEMPIERE-4311 Implement cache for MAccount(C_ValidCombination)

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MAccount.java
+++ b/org.adempiere.base/src/org/compiere/model/MAccount.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.logging.Level;
 
+import org.compiere.util.CCache;
 import org.compiere.util.CLogger;
 import org.compiere.util.Env;
 
@@ -40,6 +41,8 @@ public class MAccount extends X_C_ValidCombination
 	 * 
 	 */
 	private static final long serialVersionUID = 7980515458720808532L;
+	
+	private static final CCache<Integer, MAccount> s_cache = new CCache<Integer, MAccount>(Table_Name, 100);
 
 	/*
 	 * Deprecated - use the same method with trxName instead
@@ -365,8 +368,20 @@ public class MAccount extends X_C_ValidCombination
 	 */
 	public static MAccount get (Properties ctx, int C_ValidCombination_ID)
 	{
-		//	Maybe later cache
-		return new MAccount(ctx, C_ValidCombination_ID, null);
+		MAccount account = s_cache.get(C_ValidCombination_ID);
+		if (account != null && account.getCtx() == ctx)
+			return account;
+		
+		account = new MAccount(ctx, C_ValidCombination_ID, null);
+		if (account.getC_ValidCombination_ID() == C_ValidCombination_ID) 
+		{
+			s_cache.put(C_ValidCombination_ID, account);
+			return account;
+		}
+		else
+		{
+			return null;
+		}
 	}   //  getAccount
 
 	/**

--- a/org.adempiere.base/src/org/compiere/model/MAccountLookup.java
+++ b/org.adempiere.base/src/org/compiere/model/MAccountLookup.java
@@ -145,12 +145,9 @@ public final class MAccountLookup extends Lookup implements Serializable
 		if (ID == C_ValidCombination_ID)	//	already loaded
 			return true;
 		
-		final String whereClause = "C_ValidCombination_ID=?";
-		MAccount account = new Query(Env.getCtx(),I_C_ValidCombination.Table_Name,whereClause,null)
-		.setParameters(ID)
-		.firstOnly();
+		MAccount account = MAccount.get(Env.getCtx(), ID);
 		
-		if(account == null)
+		if(account == null || account.getC_ValidCombination_ID() != ID)
 			return false;
 		
 		C_ValidCombination_ID = account.getC_ValidCombination_ID();


### PR DESCRIPTION
Implement cache for MAccount.get(ctx, C_ValidCombination_ID)