### PR TITLE
IDEMPIERE-3551: allow use environment variable to setting system conf…

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MSysConfig.java
+++ b/org.adempiere.base/src/org/compiere/model/MSysConfig.java
@@ -234,7 +234,15 @@ public class MSysConfig extends X_AD_SysConfig
 	 */
 	public static String getValue(String Name, String defaultValue)
 	{
-		return getValue(Name, defaultValue, 0, 0);
+        // IDEMPIERE-3551: allow setting system configuration (system level only, not client level) by environment variable over database value
+        // note: change value on database and reset cache don't effect configuration setting by this way
+        String envValue = System.getProperty(Name);
+        if (envValue == null)// value from database
+            return getValue(Name, defaultValue, 0, 0);
+        else if(envValue.trim().length() == 0)// clear configuration
+            return null;
+        else// environment configuration
+            return envValue;
 	}
 	
 	/**


### PR DESCRIPTION
this change fixed what @hengsin comment. it also improve to add ability override configuration on database by environment variable for every configuration at system level

> commit a1f1b609af8c42830110b5cf8f294447f0dec705 move "MSysConfig.getValue(MSysConfig.AUTOMATIC_PACKIN_FOLDERS);" outside of the if block. This effectively break the checking to avoid db access before db connection is up.