### PR TITLE
IDEMPIERE-4345 zk9 - Payment selection (Manual) open with header coll…

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WFactReconcile.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WFactReconcile.java
@@ -186,7 +186,9 @@ implements IFormController, EventListener<Event>, WTableModelListener, ValueChan
 		
 		// Parameter Panel
 		North north = new North();
-		north.setStyle("border: none; max-height: 60%;");
+		north.setStyle("border: none;");
+		if (ClientInfo.isMobile())
+			north.setStyle("max-height: 60%;");
 		mainLayout.appendChild(north);
 		north.appendChild(parameterPanel);
 		north.setCollapsible(true);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WPaySelect.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WPaySelect.java
@@ -200,7 +200,9 @@ public class WPaySelect extends PaySelect
 		bCancel.addActionListener(this);
 		//
 		North north = new North();
-		north.setStyle("border: none; max-height: 60%;");
+		north.setStyle("border: none;");
+		if (ClientInfo.isMobile())
+			north.setStyle("max-height: 60%;");
 		mainLayout.appendChild(north);
 		north.appendChild(parameterPanel);		
 		north.setSplittable(true);


### PR DESCRIPTION
…apsed

The problem was caused by ZK9. The max-height property on Desktops is setting the height to 0. On mobile it works as expected and if it is not added the parameter panel is too big for the mobile screen.