### PR TITLE
IDEMPIERE-4350:org.apache.tomcat.util.descriptor.DigesterFactory warn

### DIFF
--- a/org.idempiere.webservices-feature/feature.xml
+++ b/org.idempiere.webservices-feature/feature.xml
@@ -64,11 +64,9 @@
       <import plugin="com.sun.activation.jakarta.activation"/>
       <import plugin="jakarta.jws-api"/>
       <import plugin="jakarta.mail.api"/>
-      <import plugin="javax.servlet"/>
       <import plugin="jakarta.xml.bind-api"/>
       <import plugin="net.sf.jasperreports.engine"/>
       <import plugin="org.apache.commons.codec"/>
-      <import plugin="slf4j.jcl"/>
       <import plugin="org.apache.servicemix.bundles.xerces"/>
       <import plugin="org.eclipse.osgi"/>
    </requires>


### PR DESCRIPTION
eclipse don't count plugin on dependency tab (require list) of feature.xml but tycho count it