### PR TITLE
IDEMPIERE-4359 : EMailTest process : customization of email sent

### DIFF
--- a/migration/i7.1z/oracle/202007071145_IDEMPIERE-4359.sql
+++ b/migration/i7.1z/oracle/202007071145_IDEMPIERE-4359.sql
@@ -1,0 +1,10 @@
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- IDEMPIERE-4359 : EMailTest process : customization of email sent
+-- Jul 7, 2020, 11:49:12 AM CEST
+INSERT INTO AD_SysConfig (AD_SysConfig_ID,AD_Client_ID,AD_Org_ID,Created,Updated,CreatedBy,UpdatedBy,IsActive,Name,Value,Description,EntityType,ConfigurationLevel,AD_SysConfig_UU) VALUES (200155,0,0,TO_DATE('2020-07-07 11:49:12','YYYY-MM-DD HH24:MI:SS'),TO_DATE('2020-07-07 11:49:12','YYYY-MM-DD HH24:MI:SS'),0,0,'Y','EMAIL_TEST_MAILTEXT_ID','0','Mail template used by EMailTest process (see https://idempiere.atlassian.net/browse/IDEMPIERE-4359) ; if 0, content of email is hardcoded','D','C','44d88d3b-d74a-43ca-b9b7-1ba8c0255dda')
+;
+
+SELECT register_migration_script('202007071145_IDEMPIERE-4359.sql') FROM dual
+;

--- a/migration/i7.1z/postgresql/202007071145_IDEMPIERE-4359.sql
+++ b/migration/i7.1z/postgresql/202007071145_IDEMPIERE-4359.sql
@@ -1,0 +1,7 @@
+-- IDEMPIERE-4359 : EMailTest process : customization of email sent
+-- Jul 7, 2020, 11:49:12 AM CEST
+INSERT INTO AD_SysConfig (AD_SysConfig_ID,AD_Client_ID,AD_Org_ID,Created,Updated,CreatedBy,UpdatedBy,IsActive,Name,Value,Description,EntityType,ConfigurationLevel,AD_SysConfig_UU) VALUES (200155,0,0,TO_TIMESTAMP('2020-07-07 11:49:12','YYYY-MM-DD HH24:MI:SS'),TO_TIMESTAMP('2020-07-07 11:49:12','YYYY-MM-DD HH24:MI:SS'),0,0,'Y','EMAIL_TEST_MAILTEXT_ID','0','Mail template used by EMailTest process (see https://idempiere.atlassian.net/browse/IDEMPIERE-4359) ; if 0, content of email is hardcoded','D','C','44d88d3b-d74a-43ca-b9b7-1ba8c0255dda')
+;
+
+SELECT register_migration_script('202007071145_IDEMPIERE-4359.sql') FROM dual
+;

--- a/org.adempiere.base.process/src/org/compiere/process/EMailTest.java
+++ b/org.adempiere.base.process/src/org/compiere/process/EMailTest.java
@@ -22,6 +22,7 @@ import java.util.logging.Level;
 import org.compiere.model.MClient;
 import org.compiere.util.Env;
 import org.compiere.util.Ini;
+import org.compiere.util.Util;
 
 /**
  *	Client EMail Test
@@ -71,7 +72,7 @@ public class EMailTest extends SvrProcess
 				addLog(0, null, null, "Not Found Directory: " + client.getDocumentDir());
 		}
 		
-		return clientTest;
+		return Util.isEmpty(clientTest) ? "OK" : clientTest;
 	}	//	doIt
 	
 }	//	EMailTest

--- a/org.adempiere.base/src/org/compiere/model/MClient.java
+++ b/org.adempiere.base/src/org/compiere/model/MClient.java
@@ -466,9 +466,18 @@ public class MClient extends X_AD_Client
 		}	
 		//
 		String systemName = MSystem.get(getCtx()).getName();
+		StringBuilder subject = new StringBuilder(systemName).append(" EMail Test");
 		StringBuilder msgce = new StringBuilder(systemName).append(" EMail Test: ").append(toString());
-		EMail email = createEMail (getRequestEMail(),
-				systemName + " EMail Test",msgce.toString());
+
+		int mailtextID = MSysConfig.getIntValue(MSysConfig.EMAIL_TEST_MAILTEXT_ID, 0, getAD_Client_ID());
+		if (mailtextID > 0) {
+			MMailText mt = new MMailText(getCtx(), mailtextID, get_TrxName());
+			mt.setPO(this);
+			subject = new StringBuilder(mt.getMailHeader());
+			msgce = new StringBuilder(mt.getMailText(true));
+		}
+
+		EMail email = createEMail (getRequestEMail(), subject.toString(), msgce.toString());
 		if (email == null){
 			StringBuilder msgreturn = new StringBuilder("Could not create EMail: ").append(getName());
 			return msgreturn.toString();
@@ -487,7 +496,7 @@ public class MClient extends X_AD_Client
 			if (EMail.SENT_OK.equals (msg))
 			{
 				if (log.isLoggable(Level.INFO)) log.info("Sent Test EMail to " + getRequestEMail());
-				return "OK";
+				return "";
 			}
 			else
 			{

--- a/org.adempiere.base/src/org/compiere/model/MSysConfig.java
+++ b/org.adempiere.base/src/org/compiere/model/MSysConfig.java
@@ -43,7 +43,7 @@ public class MSysConfig extends X_AD_SysConfig
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = -3283099328590831741L;
+	private static final long serialVersionUID = -1766118478735242840L;
 
 	public static final String ADDRESS_VALIDATION = "ADDRESS_VALIDATION";
     public static final String ALERT_SEND_ATTACHMENT_AS_XLS = "ALERT_SEND_ATTACHMENT_AS_XLS";
@@ -94,6 +94,7 @@ public class MSysConfig extends X_AD_SysConfig
     public static final String DPViews_ShowInfoAccount = "DPViews_ShowInfoAccount";
     public static final String DPViews_ShowInfoSchedule = "DPViews_ShowInfoSchedule";
     public static final String EMAIL_NOTIFY_2PACK = "EMAIL_NOTIFY_2PACK";
+    public static final String EMAIL_TEST_MAILTEXT_ID = "EMAIL_TEST_MAILTEXT_ID";
     public static final String ENABLE_PAYMENTBOX_BUTTON = "ENABLE_PAYMENTBOX_BUTTON";
     public static final String GRIDTABLE_LOAD_TIMEOUT_IN_SECONDS = "GRIDTABLE_LOAD_TIMEOUT_IN_SECONDS";
     public static final String HTML_REPORT_THEME = "HTML_REPORT_THEME";


### PR DESCRIPTION
Ability to define a dedicated mail template for the EMailTest process (via a client level SysConfig).
Output of the process was wrong (always successful even when the email was not sent)