### PR TITLE
IDEMPIERE-4376:order activity workflow by ID (also time it's created)

### DIFF
--- a/org.adempiere.base/src/org/compiere/wf/MWFProcess.java
+++ b/org.adempiere.base/src/org/compiere/wf/MWFProcess.java
@@ -184,6 +184,7 @@ public class MWFProcess extends X_AD_WF_Process
 		}
 		List<MWFActivity> list = new Query(getCtx(), MWFActivity.Table_Name, whereClause.toString(), trxName)
 								.setParameters(params)
+								.setOrderBy(MWFActivity.COLUMNNAME_AD_WF_Activity_ID)
 								.list();
 		m_activities = new MWFActivity[list.size ()];
 		list.toArray (m_activities);


### PR DESCRIPTION
maybe order by seq-no of node link to activity is more stable than ID