### PR TITLE
IDEMPIERE-4395 Cannot save valid strings in oracle - ORA-12899: value…

### DIFF
--- a/org.adempiere.base/src/org/compiere/db/AdempiereDatabase.java
+++ b/org.adempiere.base/src/org/compiere/db/AdempiereDatabase.java
@@ -380,7 +380,14 @@ public interface AdempiereDatabase
 	 * @return variable length character data type name
 	 */
 	public String getVarcharDataType();
-	
+
+	/**
+	 * @return variable length character data type suffix
+	 */
+	public default String getVarcharLengthSuffix() {
+		return "";
+	};
+
 	/**
 	 * 
 	 * @return binary large object data type name
@@ -460,6 +467,7 @@ public interface AdempiereDatabase
 	 * @return alter column sql
 	 */
 	public String getSQLModify (MTable table, MColumn column, boolean setNullOption);
-		
+
+	
 }   //  AdempiereDatabase
 

--- a/org.adempiere.base/src/org/compiere/dbPort/Convert.java
+++ b/org.adempiere.base/src/org/compiere/dbPort/Convert.java
@@ -384,7 +384,7 @@ public abstract class Convert
 	
 				} catch (Exception e) {
 					String error = "Error expression: " + regex + " - " + e;
-					log.info(error);
+					log.warning(error);
 					m_conversionError = error;
 				}
 			}

--- a/org.adempiere.base/src/org/compiere/util/DisplayType.java
+++ b/org.adempiere.base/src/org/compiere/util/DisplayType.java
@@ -624,7 +624,7 @@ public final class DisplayType
 	{
 		if (columnName.equals("EntityType")
 			|| columnName.equals ("AD_Language"))
-			return getDatabase().getVarcharDataType() + "(" + fieldLength + ")";
+			return getDatabase().getVarcharDataType() + "(" + fieldLength + getDatabase().getVarcharLengthSuffix() + ")";
 		//	ID
 		if (DisplayType.isID(displayType))
 		{
@@ -640,7 +640,7 @@ public final class DisplayType
 			else if (fieldLength < 4)
 				return getDatabase().getCharacterDataType()+"(" + fieldLength + ")";
 			else	//	EntityType, AD_Language	fallback
-				return getDatabase().getVarcharDataType()+"(" + fieldLength + ")";
+				return getDatabase().getVarcharDataType()+"(" + fieldLength + getDatabase().getVarcharLengthSuffix() + ")";
 		}
 		//
 		if (displayType == DisplayType.Integer)
@@ -660,10 +660,10 @@ public final class DisplayType
 			if (fieldLength == 1)
 				return getDatabase().getCharacterDataType()+"(" + fieldLength + ")";
 			else
-				return getDatabase().getVarcharDataType()+"(" + fieldLength + ")";
+				return getDatabase().getVarcharDataType()+"(" + fieldLength + getDatabase().getVarcharLengthSuffix() + ")";
 		}
 		if (displayType == DisplayType.Color)
-			return getDatabase().getVarcharDataType()+"(" + fieldLength + ")";
+			return getDatabase().getVarcharDataType()+"(" + fieldLength + getDatabase().getVarcharLengthSuffix() + ")";
 		if (displayType == DisplayType.Button)
 		{
 			if (columnName.endsWith("_ID"))
@@ -685,7 +685,7 @@ public final class DisplayType
 		if (columnName.endsWith("_ID"))
 			return getDatabase().getNumericDataType()+"(10)";
 
-		return getDatabase().getVarcharDataType()+"(" + fieldLength + ")";
+		return getDatabase().getVarcharDataType()+"(" + fieldLength + getDatabase().getVarcharLengthSuffix() + ")";
 	}	//	getSQLDataType
 
 	/**

--- a/org.compiere.db.oracle.provider/src/org/compiere/db/DB_Oracle.java
+++ b/org.compiere.db.oracle.provider/src/org/compiere/db/DB_Oracle.java
@@ -1371,6 +1371,13 @@ public class DB_Oracle implements AdempiereDatabase
 		return "VARCHAR2";
 	}
 
+	/**
+	 * @return variable length character data type suffix
+	 */
+	public String getVarcharLengthSuffix() {
+		return " CHAR";
+	};
+
 	@Override
 	public String getBlobDataType() {
 		return "BLOB";

--- a/org.compiere.db.postgresql.provider/src/org/compiere/dbPort/ConvertMap_PostgreSQL.java
+++ b/org.compiere.db.postgresql.provider/src/org/compiere/dbPort/ConvertMap_PostgreSQL.java
@@ -40,7 +40,11 @@ public final class ConvertMap_PostgreSQL {
 		//  Data Types
 		s_pg.put("\\bNUMBER\\b",                "NUMERIC");
 		s_pg.put("\\bDATE\\b",                  "TIMESTAMP");
+
 		s_pg.put("\\bVARCHAR2\\b",              "VARCHAR");
+		// because map is ordered this replacement is executed after VARCHAR2 above, so here we have just VARCHAR
+		s_pg.put("\\bVARCHAR\\b( *\\( *[1-9][0-9]*)  *CHAR\\)", "VARCHAR$1)");
+
 		s_pg.put("\\bNVARCHAR2\\b",             "VARCHAR");
 		s_pg.put("\\bNCHAR\\b",                 "CHAR");
         //begin vpj-cd e-evolution 03/11/2005 PostgreSQL


### PR DESCRIPTION
… too large for column

[IDEMPIERE-4395](IDEMPIERE-4395)

Hi @hengsin - can you please peer review this commit?

I tested it in oracle, postgres and native postgresql and it works fine.  Migration scripts are also correctly generated.

But I'm not sure if the approach is the best, or if you have a better suggestion.
Instead of writing a complex algorithm on the convert layer, I simply added a regular expression to replace the string "VARCHAR2(30 CHAR)" with "VARCHAR(30)" - for this, I used a pattern that was not used before reusing a group of the pattern being replaced.

Applying this fix will help for new columns created with the migration script or 2packs, but I'm working on a possible fix for the whole database in [IDEMPIERE-3862](https://idempiere.atlassian.net/browse/IDEMPIERE-3862), I had an initial script, but it became too complex as there are indexes and constraints that require attention - we can postpone that, but at least stop the problem with the new columns, and users requiring this can also synchronize the specific column they need to fix.