### PR TITLE
IDEMPIERE-4397 Hide ProcessModalDialog in Autostart

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/ProcessModalDialog.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/ProcessModalDialog.java
@@ -179,6 +179,15 @@ public class ProcessModalDialog extends AbstractProcessDialog implements EventLi
 		getParameterPanel().restoreContext();
 		this.detach();
 	}	//	dispose
+	
+	@Override
+	public void autoStart() 	
+	{	
+		this.setBorder("none");	
+		this.setTitle(null);
+		this.getFirstChild().setVisible(false);	
+		super.autoStart();	
+	}	
 
 	@Override
 	public void showBusyDialog() {


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-4397

Hide ProcessModelDialog except BusyDialog when ProcessModelDialog is opened as Autostart.

Autostart Test Cases.
**Test Case 1: (Print Report)**
1. Open Sales Order Window in Garden World
1. Find Completed Sales Order
1. Click Print Button
1. Only BusyDialog should be shown when opening Print Report

**Test Case 2: (Complete Order)**
1. Open Sales Order Window in GardenWorld
1. Create new Sales Order with lines
1. Click Doc Action Button
1. Set Any Doc Action and Confirm
1. Only BusyDialog should be shown when processing Document

**Test Case 3: (Process Silent Run with Defaults)**
1. Open Sales Order Window in GardenWorld
1. Find Any Completed Order
1. Go To OrderLine
1. Click Process Button and start **Process OrderLine Create Shipment**
1. Only BusyDialog should be shown when processing Process.