### PR TITLE
IDEMPIERE-4404 Wrong characters + typos in Brazilian regions

### DIFF
--- a/migration/i7.1z/oracle/202008061523_IDEMPIERE-4404.sql
+++ b/migration/i7.1z/oracle/202008061523_IDEMPIERE-4404.sql
@@ -1,0 +1,50 @@
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Aug 6, 2020, 3:15:24 PM CEST
+UPDATE C_Region SET Description='Amapá',Updated=TO_DATE('2020-08-06 15:15:24','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE C_Region_ID=443
+;
+
+-- Aug 6, 2020, 3:17:01 PM CEST
+UPDATE C_Region SET Description='Ceará',Updated=TO_DATE('2020-08-06 15:17:01','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE C_Region_ID=446
+;
+
+-- Aug 6, 2020, 3:17:14 PM CEST
+UPDATE C_Region SET Description='Espírito Santo',Updated=TO_DATE('2020-08-06 15:17:14','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE C_Region_ID=448
+;
+
+-- Aug 6, 2020, 3:17:26 PM CEST
+UPDATE C_Region SET Description='Goiás',Updated=TO_DATE('2020-08-06 15:17:26','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE C_Region_ID=449
+;
+
+-- Aug 6, 2020, 3:17:33 PM CEST
+UPDATE C_Region SET Description='Maranhão',Updated=TO_DATE('2020-08-06 15:17:33','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE C_Region_ID=450
+;
+
+-- Aug 6, 2020, 3:17:46 PM CEST
+UPDATE C_Region SET Description='Pará',Updated=TO_DATE('2020-08-06 15:17:46','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE C_Region_ID=454
+;
+
+-- Aug 6, 2020, 3:17:54 PM CEST
+UPDATE C_Region SET Description='Paraíba',Updated=TO_DATE('2020-08-06 15:17:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE C_Region_ID=455
+;
+
+-- Aug 6, 2020, 3:18:03 PM CEST
+UPDATE C_Region SET Description='Piauí',Updated=TO_DATE('2020-08-06 15:18:03','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE C_Region_ID=458
+;
+
+-- Aug 6, 2020, 3:18:09 PM CEST
+UPDATE C_Region SET Description='Paraná',Updated=TO_DATE('2020-08-06 15:18:09','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE C_Region_ID=456
+;
+
+-- Aug 6, 2020, 3:18:20 PM CEST
+UPDATE C_Region SET Description='Rondônia',Updated=TO_DATE('2020-08-06 15:18:20','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE C_Region_ID=462
+;
+
+-- Aug 6, 2020, 3:18:54 PM CEST
+UPDATE C_Region SET Description='São Paulo',Updated=TO_DATE('2020-08-06 15:18:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE C_Region_ID=465
+;
+
+SELECT register_migration_script('202008061523_IDEMPIERE-4404.sql') FROM dual
+;
+

--- a/migration/i7.1z/postgresql/202008061523_IDEMPIERE-4404.sql
+++ b/migration/i7.1z/postgresql/202008061523_IDEMPIERE-4404.sql
@@ -1,0 +1,47 @@
+-- Aug 6, 2020, 3:15:24 PM CEST
+UPDATE C_Region SET Description='Amapá',Updated=TO_TIMESTAMP('2020-08-06 15:15:24','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE C_Region_ID=443
+;
+
+-- Aug 6, 2020, 3:17:01 PM CEST
+UPDATE C_Region SET Description='Ceará',Updated=TO_TIMESTAMP('2020-08-06 15:17:01','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE C_Region_ID=446
+;
+
+-- Aug 6, 2020, 3:17:14 PM CEST
+UPDATE C_Region SET Description='Espírito Santo',Updated=TO_TIMESTAMP('2020-08-06 15:17:14','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE C_Region_ID=448
+;
+
+-- Aug 6, 2020, 3:17:26 PM CEST
+UPDATE C_Region SET Description='Goiás',Updated=TO_TIMESTAMP('2020-08-06 15:17:26','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE C_Region_ID=449
+;
+
+-- Aug 6, 2020, 3:17:33 PM CEST
+UPDATE C_Region SET Description='Maranhão',Updated=TO_TIMESTAMP('2020-08-06 15:17:33','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE C_Region_ID=450
+;
+
+-- Aug 6, 2020, 3:17:46 PM CEST
+UPDATE C_Region SET Description='Pará',Updated=TO_TIMESTAMP('2020-08-06 15:17:46','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE C_Region_ID=454
+;
+
+-- Aug 6, 2020, 3:17:54 PM CEST
+UPDATE C_Region SET Description='Paraíba',Updated=TO_TIMESTAMP('2020-08-06 15:17:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE C_Region_ID=455
+;
+
+-- Aug 6, 2020, 3:18:03 PM CEST
+UPDATE C_Region SET Description='Piauí',Updated=TO_TIMESTAMP('2020-08-06 15:18:03','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE C_Region_ID=458
+;
+
+-- Aug 6, 2020, 3:18:09 PM CEST
+UPDATE C_Region SET Description='Paraná',Updated=TO_TIMESTAMP('2020-08-06 15:18:09','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE C_Region_ID=456
+;
+
+-- Aug 6, 2020, 3:18:20 PM CEST
+UPDATE C_Region SET Description='Rondônia',Updated=TO_TIMESTAMP('2020-08-06 15:18:20','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE C_Region_ID=462
+;
+
+-- Aug 6, 2020, 3:18:54 PM CEST
+UPDATE C_Region SET Description='São Paulo',Updated=TO_TIMESTAMP('2020-08-06 15:18:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE C_Region_ID=465
+;
+
+SELECT register_migration_script('202008061523_IDEMPIERE-4404.sql') FROM dual
+;
+


### PR DESCRIPTION
This was probably caused years ago (2007) because off applying the script from commit 89c9a3b4 migration-historic/320-330/postgresql/001_add_brazilian_states.sql without the proper NLS_LANG variable set in oracle
It is important, when applying this script to set the NLS_LANG properly, suggested value is:
export NLS_LANG=AMERICAN_AMERICA.UTF8

https://idempiere.atlassian.net/browse/IDEMPIERE-4404