### PR TITLE
IDEMPIERE-2941 - Add ESC support on Window Tabs

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/part/WindowContainer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/part/WindowContainer.java
@@ -50,6 +50,7 @@ import org.zkoss.zul.Menuitem;
  */
 public class WindowContainer extends AbstractUIPart implements EventListener<Event>
 {
+    public static final int VK_ESC            = 0x1B;
 	private static final String OPTION_CLOSE = "Close";
 	private static final String OPTION_CLOSE_OTHER_WINDOWS = "CloseOtherWindows";
 	private static final String OPTION_CLOSE_WINDOWS_TO_THE_LEFT = "CloseWindowsToTheLeft";
@@ -94,6 +95,7 @@ public class WindowContainer extends AbstractUIPart implements EventListener<Eve
         tabbox = new Tabbox();
         tabbox.addEventListener("onPageAttached", this);
         tabbox.addEventListener("onPageDetached", this);
+        tabbox.addEventListener(Events.ON_CANCEL, this);
         tabbox.setSupportTabDragDrop(!isMobile());
         tabbox.setActiveBySeq(true);
         tabbox.setCheckVisibleOnlyForNextActive(!isMobile());
@@ -662,8 +664,15 @@ public class WindowContainer extends AbstractUIPart implements EventListener<Eve
 					&& tabbox.getSelectedTab() != null && tabbox.getSelectedTab().getPreviousSibling() != null) {
 				tabbox.setSelectedTab((org.zkoss.zul.Tab)tabbox.getSelectedTab().getPreviousSibling());
 				keyEvent.stopPropagation();
+			 
+// IDEMPIERE-2941 - global event Listener for 0x1B (ESC) keycode (Propagation problem)
+//			}else if (keyEvent.getKeyCode() == VK_ESC && tabbox.getSelectedTab() != null && getSelectedTab().isClosable()) {
+//				closeActiveWindow();
+//				keyEvent.stopPropagation();
 			}
-		}
+		}else if (event.getName().equals(Events.ON_CANCEL) && tabbox.getSelectedTab() != null && getSelectedTab().isClosable()) {	//IDEMPIERE-2941 do not close not closable tabs (Home)
+			closeActiveWindow();
+    	}
 		
 	}
 }


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-2941

State WIP. 

Added 2 Esc listeners for windows only.

Currently active is using `Events.ON_CANCEL` which has limitation that it will be fired only from focused children component.
1- Use Case (Working): 
1. Login to Garden World
1. Open Sales Order Window
1. Set Focus On Description Field in Sales Order ()
1. Hit Esc. Sales Order Should Close.

2- Use Case (Not Working): 
1. Login to Garden World
1. Open Sales Order Window
1. Set Focus On Menu Search Bar in Header
1. Hit Esc. Sales Order Will Not Close.

Commented Code is using Ctrl_Keys and is listening for keyCode 0x1B (ESC). This listener is global, both Use Cases above are closing Windows. Issue with global listener is that we need to control event propagation and check for popup windows (modals). Is there any good idea how to controll global key events?
Failing Use Case with uncommented lines 669 - 671:
1. Login to Garden World
1. Open Sales Order Window
1. Open Existing Order (Draft/In Progress)
1. Open Business Partner Info Window (to set Business Partner in Sales Order)
1. Set forcus on Search Key in Business Partner Info Window
1. Hit Esc. Info Window and Sales Order will Close.

