### PR TITLE
IDEMPIERE-4256 [2pack] issue with export org (non office id)

### DIFF
--- a/org.adempiere.pipo/src/org/adempiere/pipo2/AbstractElementHandler.java
+++ b/org.adempiere.pipo/src/org/adempiere/pipo2/AbstractElementHandler.java
@@ -379,7 +379,6 @@ public abstract class AbstractElementHandler implements ElementHandler {
     protected List<String> defaultExcludeList(String tableName) {
     	List<String> excludes = new ArrayList<String>();
     	excludes.add("ad_client_id");
-    	excludes.add("ad_org_id");
     	excludes.add("created");
     	excludes.add("createdby");
     	excludes.add("updated");

--- a/org.adempiere.pipo/src/org/adempiere/pipo2/PoExporter.java
+++ b/org.adempiere.pipo/src/org/adempiere/pipo2/PoExporter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import javax.xml.transform.sax.TransformerHandler;
 
 import org.adempiere.exceptions.AdempiereException;
+import org.compiere.model.I_AD_Org;
 import org.compiere.model.MTable;
 import org.compiere.model.MTree;
 import org.compiere.model.PO;
@@ -183,12 +184,12 @@ public class PoExporter {
 		if (AD_Client_ID == 0)
 		{
 			addString("AD_Client_ID", "0", new AttributesImpl());
-			if (excludes == null || !excludes.contains("AD_Org_ID"))
+			if (excludes == null || !excludes.contains("ad_org_id"))
 				addString("AD_Org_ID", "0", new AttributesImpl());
 		}
 		else
 		{
-			if (excludes == null || !excludes.contains("AD_Org_ID"))
+			if (excludes == null || !excludes.contains("ad_org_id"))
 			{
 				int AD_Org_ID = po.getAD_Org_ID();
 				if (AD_Org_ID == 0)
@@ -201,7 +202,8 @@ public class PoExporter {
 						addString("AD_Org_ID", "@AD_Org_ID@", new AttributesImpl());
 					else {
 						addTableReference("AD_Client_ID", X_AD_Client.Table_Name, new AttributesImpl());
-						addTableReference("AD_Org_ID", X_AD_Org.Table_Name, new AttributesImpl());
+						if (!(I_AD_Org.Table_Name.equals(po.get_TableName())))
+							addTableReference("AD_Org_ID", X_AD_Org.Table_Name, new AttributesImpl());
 					}
 				}
 			}


### PR DESCRIPTION
Incorporate patch from hieplq - not to export ad_org_id for ad_org table
Fix typo for ad_org_id exclude check. Remove ad_org_id from exclude list to maintain backward compatiblity.