### PR TITLE
IDEMPIERE-4361:Date is subtracted by 1 day in certain cases

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WDateEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WDateEditor.java
@@ -148,7 +148,7 @@ public class WDateEditor extends WEditor implements ContextMenuListener
     {
     	// Elaine 2008/07/25
     	if(getComponent().getValue() == null) return null;
-    	return new Timestamp(getComponent().getValue().getTime());
+    	return Timestamp.valueOf(getComponent().getValue().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
     	//
     }
 
@@ -172,7 +172,7 @@ public class WDateEditor extends WEditor implements ContextMenuListener
     			getComponent().setText(value.toString());
     		} catch (Exception e) {}
     		if (getComponent().getValue() != null)
-    			oldValue = new Timestamp(getComponent().getValue().getTime());
+    			oldValue = Timestamp.valueOf(getComponent().getValue().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
     		else
     			oldValue = null;
     	}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WDateEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WDateEditor.java
@@ -162,7 +162,7 @@ public class WDateEditor extends WEditor implements ContextMenuListener
     	}
     	else if (value instanceof Timestamp)
         {
-            getComponent().setValue((Timestamp)value);
+            getComponent().setValueInLocalDateTime(((Timestamp)value).toLocalDateTime());
             oldValue = (Timestamp)value;
         }
     	else

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WDateEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WDateEditor.java
@@ -18,6 +18,7 @@
 package org.adempiere.webui.editor;
 
 import java.sql.Timestamp;
+import java.time.ZoneId;
 import java.util.Date;
 
 import org.adempiere.webui.ValuePreference;
@@ -120,7 +121,7 @@ public class WDateEditor extends WEditor implements ContextMenuListener
 
 	        if (date != null)
 	        {
-	            newValue = new Timestamp(date.getTime());
+	        	newValue = Timestamp.valueOf(date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
 	        }
 	        if (oldValue != null && newValue != null && oldValue.equals(newValue)) {
 	    	    return;

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WDatetimeEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WDatetimeEditor.java
@@ -13,6 +13,7 @@
 package org.adempiere.webui.editor;
 
 import java.sql.Timestamp;
+import java.time.ZoneId;
 import java.util.Date;
 
 import org.adempiere.webui.ValuePreference;
@@ -115,7 +116,7 @@ public class WDatetimeEditor extends WEditor implements ContextMenuListener
 
 	        if (date != null)
 	        {
-	            newValue = new Timestamp(date.getTime());
+	            newValue = Timestamp.valueOf(date.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
 	        }
 	        if (oldValue != null && newValue != null && oldValue.equals(newValue)) {
 	    	    return;
@@ -142,7 +143,7 @@ public class WDatetimeEditor extends WEditor implements ContextMenuListener
     {
     	// Elaine 2008/07/25
     	if(getComponent().getValue() == null) return null;
-    	return new Timestamp(getComponent().getValue().getTime());
+    	return Timestamp.valueOf(getComponent().getDatebox().getValue().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
     	//
     }
 
@@ -156,7 +157,7 @@ public class WDatetimeEditor extends WEditor implements ContextMenuListener
     	}
     	else if (value instanceof Timestamp)
         {
-            getComponent().setValue((Timestamp)value);
+    		getComponent().getDatebox().setValueInLocalDateTime(((Timestamp)value).toLocalDateTime());
             oldValue = (Timestamp)value;
         }
     	else
@@ -166,7 +167,7 @@ public class WDatetimeEditor extends WEditor implements ContextMenuListener
     			getComponent().setText(value.toString());
     		} catch (Exception e) {}
     		if (getComponent().getValue() != null)
-    			oldValue = new Timestamp(getComponent().getValue().getTime());
+    			oldValue = Timestamp.valueOf(getComponent().getDatebox().getValue().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
     		else
     			oldValue = null;
     	}


### PR DESCRIPTION
sun.util.calendar.ZoneInfo consider offset and "daylight saving time" changed on range 1900-2037
for out of that range then offset always return raw offset, make date incorrect 1 day on some days

offset change by history can reference at:
https://en.wikipedia.org/wiki/Time_in_Vietnam#Time_in_French_Indochina
https://www.timeanddate.com/time/zone/vietnam/hanoi

database for all change
https://www.iana.org/time-zones