### PR TITLE
IDEMPIERE-4067 : Support for Under/Over line and Blank line in finaci…

### DIFF
--- a/migration/i7.1z/oracle/201912301800_IDEMPIERE-4067.sql
+++ b/migration/i7.1z/oracle/201912301800_IDEMPIERE-4067.sql
@@ -39,7 +39,7 @@ INSERT INTO AD_Column (AD_Column_ID,Version,Name,AD_Table_ID,ColumnName,FieldLen
 ;
 
 -- Oct 16, 2019 2:43:31 PM IST
-ALTER TABLE PA_ReportLine ADD OverlineStrokeType VARCHAR2(3) DEFAULT NULL 
+ALTER TABLE PA_ReportLine ADD OverlineStrokeType VARCHAR2(3 CHAR) DEFAULT NULL 
 ;
 
 -- Oct 16, 2019 2:44:08 PM IST
@@ -51,7 +51,7 @@ INSERT INTO AD_Column (AD_Column_ID,Version,Name,AD_Table_ID,ColumnName,FieldLen
 ;
 
 -- Oct 16, 2019 2:45:39 PM IST
-ALTER TABLE PA_ReportLine ADD UnderlineStrokeType VARCHAR2(3) DEFAULT NULL 
+ALTER TABLE PA_ReportLine ADD UnderlineStrokeType VARCHAR2(3 CHAR) DEFAULT NULL 
 ;
 
 -- Oct 16, 2019 2:48:07 PM IST

--- a/migration/i7.1z/oracle/201912301800_IDEMPIERE-4067.sql
+++ b/migration/i7.1z/oracle/201912301800_IDEMPIERE-4067.sql
@@ -1,0 +1,72 @@
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Adding Over/Under line in Report
+-- Oct 16, 2019 2:39:54 PM IST
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,ColumnName,Name,PrintName,EntityType,AD_Element_UU) VALUES (203371,0,0,'Y',TO_DATE('2019-10-16 14:39:53','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2019-10-16 14:39:53','YYYY-MM-DD HH24:MI:SS'),100,'OverlineStrokeType','Overline Stroke Type','Overline Stroke Type','D','18f9193c-b4a9-4dc2-ba69-8dcefc4d8e88')
+;
+
+-- Oct 16, 2019 2:40:47 PM IST
+INSERT INTO AD_Reference (AD_Reference_ID,Name,ValidationType,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,IsOrderByValue,AD_Reference_UU) VALUES (200174,'PA_ReportLine Line Stroke Type','L',0,0,'Y',TO_DATE('2019-10-16 14:40:46','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2019-10-16 14:40:46','YYYY-MM-DD HH24:MI:SS'),100,'D','N','a66f38f4-feeb-472f-a561-0f2134214e66')
+;
+
+-- Oct 16, 2019 2:41:10 PM IST
+INSERT INTO AD_Ref_List (AD_Ref_List_ID,Name,AD_Reference_ID,Value,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,AD_Ref_List_UU) VALUES (200477,'Dotted',200174,'DT',0,0,'Y',TO_DATE('2019-10-16 14:41:10','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2019-10-16 14:41:10','YYYY-MM-DD HH24:MI:SS'),100,'D','e61955b1-37f0-45ed-8bd3-d7b72f5f730b')
+;
+
+-- Oct 16, 2019 2:41:45 PM IST
+INSERT INTO AD_Ref_List (AD_Ref_List_ID,Name,AD_Reference_ID,Value,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,AD_Ref_List_UU) VALUES (200478,'Dashed',200174,'DS',0,0,'Y',TO_DATE('2019-10-16 14:41:44','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2019-10-16 14:41:44','YYYY-MM-DD HH24:MI:SS'),100,'D','035f9d9e-4650-43e8-a0ec-e931e07270d8')
+;
+
+-- Oct 16, 2019 2:42:08 PM IST
+INSERT INTO AD_Ref_List (AD_Ref_List_ID,Name,AD_Reference_ID,Value,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,AD_Ref_List_UU) VALUES (200479,'Double Dotted',200174,'DDT',0,0,'Y',TO_DATE('2019-10-16 14:42:07','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2019-10-16 14:42:07','YYYY-MM-DD HH24:MI:SS'),100,'D','011c9ad0-34a9-4bd4-9af3-50615790ffb6')
+;
+
+-- Oct 16, 2019 2:42:22 PM IST
+INSERT INTO AD_Ref_List (AD_Ref_List_ID,Name,AD_Reference_ID,Value,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,AD_Ref_List_UU) VALUES (200480,'Double Dashed',200174,'DDS',0,0,'Y',TO_DATE('2019-10-16 14:42:22','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2019-10-16 14:42:22','YYYY-MM-DD HH24:MI:SS'),100,'D','13cd13e4-af78-4252-957e-3b1e45f33497')
+;
+
+-- Oct 16, 2019 2:42:38 PM IST
+INSERT INTO AD_Ref_List (AD_Ref_List_ID,Name,AD_Reference_ID,Value,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,AD_Ref_List_UU) VALUES (200481,'Double Solid',200174,'DSD',0,0,'Y',TO_DATE('2019-10-16 14:42:37','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2019-10-16 14:42:37','YYYY-MM-DD HH24:MI:SS'),100,'D','e39cde64-0d54-4cf9-93c1-5068c0e97ee6')
+;
+
+-- Oct 16, 2019 2:42:53 PM IST
+INSERT INTO AD_Ref_List (AD_Ref_List_ID,Name,AD_Reference_ID,Value,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,AD_Ref_List_UU) VALUES (200482,'Solid',200174,'SD',0,0,'Y',TO_DATE('2019-10-16 14:42:52','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2019-10-16 14:42:52','YYYY-MM-DD HH24:MI:SS'),100,'D','9e450ade-e54b-46e1-b96f-36c02b3090eb')
+;
+
+-- Oct 16, 2019 2:43:26 PM IST
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Reference_Value_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure) VALUES (214088,0,'Overline Stroke Type',448,'OverlineStrokeType',3,'N','N','N','N','N',0,'N',17,200174,0,0,'Y',TO_DATE('2019-10-16 14:43:26','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2019-10-16 14:43:26','YYYY-MM-DD HH24:MI:SS'),100,203371,'Y','N','D','N','N','N','Y','b1529a0e-96a5-43e6-94b6-d78feea8e8c8','Y',0,'N','N')
+;
+
+-- Oct 16, 2019 2:43:31 PM IST
+ALTER TABLE PA_ReportLine ADD OverlineStrokeType VARCHAR2(3) DEFAULT NULL 
+;
+
+-- Oct 16, 2019 2:44:08 PM IST
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,ColumnName,Name,PrintName,EntityType,AD_Element_UU) VALUES (203372,0,0,'Y',TO_DATE('2019-10-16 14:44:08','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2019-10-16 14:44:08','YYYY-MM-DD HH24:MI:SS'),100,'UnderlineStrokeType','Underline Stroke Type','Underline Stroke Type','D','36e60c3b-2eff-4d58-a530-101b2d060f4a')
+;
+
+-- Oct 16, 2019 2:45:23 PM IST
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Reference_Value_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure) VALUES (214089,0,'Underline Stroke Type',448,'UnderlineStrokeType',3,'N','N','N','N','N',0,'N',17,200174,0,0,'Y',TO_DATE('2019-10-16 14:45:23','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2019-10-16 14:45:23','YYYY-MM-DD HH24:MI:SS'),100,203372,'Y','N','D','N','N','N','Y','d3504292-068e-4126-944c-dc3d165019c0','Y',0,'N','N')
+;
+
+-- Oct 16, 2019 2:45:39 PM IST
+ALTER TABLE PA_ReportLine ADD UnderlineStrokeType VARCHAR2(3) DEFAULT NULL 
+;
+
+-- Oct 16, 2019 2:48:07 PM IST
+INSERT INTO AD_Field (AD_Field_ID,Name,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,SortNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan,NumLines,IsQuickEntry,IsDefaultFocus,IsAdvancedField) VALUES (206214,'Overline Stroke Type',376,214088,'Y',0,200,0,'N','N','N','N',0,0,'Y',TO_DATE('2019-10-16 14:48:06','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2019-10-16 14:48:06','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','04733ecb-3dc6-4fde-82ab-33434b230ca5','Y',215,1,2,1,'N','N','N')
+;
+
+-- Oct 16, 2019 2:48:25 PM IST
+INSERT INTO AD_Field (AD_Field_ID,Name,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,SortNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan,NumLines,IsQuickEntry,IsDefaultFocus,IsAdvancedField) VALUES (206215,'Underline Stroke Type',376,214089,'Y',0,210,0,'N','N','N','N',0,0,'Y',TO_DATE('2019-10-16 14:48:24','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2019-10-16 14:48:24','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','e5614dd4-9884-4053-99d5-1cb59540e412','Y',225,4,2,1,'N','N','N')
+;
+
+-- Added Line Type Blank Line
+-- Oct 16, 2019 5:29:02 PM IST
+INSERT INTO AD_Ref_List (AD_Ref_List_ID,Name,AD_Reference_ID,Value,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,AD_Ref_List_UU) VALUES (200483,'Blank line',241,'B',0,0,'Y',TO_DATE('2019-10-16 17:29:01','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2019-10-16 17:29:01','YYYY-MM-DD HH24:MI:SS'),100,'D','bb000455-9057-4c8a-a656-b0f1074e3fd3')
+;
+
+SELECT register_migration_script('201912301800_IDEMPIERE-4067.sql') FROM dual
+;
+

--- a/migration/i7.1z/postgresql/201912301800_IDEMPIERE-4067.sql
+++ b/migration/i7.1z/postgresql/201912301800_IDEMPIERE-4067.sql
@@ -1,0 +1,69 @@
+-- Adding Over/Under line in Report
+-- Oct 16, 2019 2:39:54 PM IST
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,ColumnName,Name,PrintName,EntityType,AD_Element_UU) VALUES (203371,0,0,'Y',TO_TIMESTAMP('2019-10-16 14:39:53','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2019-10-16 14:39:53','YYYY-MM-DD HH24:MI:SS'),100,'OverlineStrokeType','Overline Stroke Type','Overline Stroke Type','D','18f9193c-b4a9-4dc2-ba69-8dcefc4d8e88')
+;
+
+-- Oct 16, 2019 2:40:47 PM IST
+INSERT INTO AD_Reference (AD_Reference_ID,Name,ValidationType,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,IsOrderByValue,AD_Reference_UU) VALUES (200174,'PA_ReportLine Line Stroke Type','L',0,0,'Y',TO_TIMESTAMP('2019-10-16 14:40:46','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2019-10-16 14:40:46','YYYY-MM-DD HH24:MI:SS'),100,'D','N','a66f38f4-feeb-472f-a561-0f2134214e66')
+;
+
+-- Oct 16, 2019 2:41:10 PM IST
+INSERT INTO AD_Ref_List (AD_Ref_List_ID,Name,AD_Reference_ID,Value,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,AD_Ref_List_UU) VALUES (200477,'Dotted',200174,'DT',0,0,'Y',TO_TIMESTAMP('2019-10-16 14:41:10','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2019-10-16 14:41:10','YYYY-MM-DD HH24:MI:SS'),100,'D','e61955b1-37f0-45ed-8bd3-d7b72f5f730b')
+;
+
+-- Oct 16, 2019 2:41:45 PM IST
+INSERT INTO AD_Ref_List (AD_Ref_List_ID,Name,AD_Reference_ID,Value,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,AD_Ref_List_UU) VALUES (200478,'Dashed',200174,'DS',0,0,'Y',TO_TIMESTAMP('2019-10-16 14:41:44','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2019-10-16 14:41:44','YYYY-MM-DD HH24:MI:SS'),100,'D','035f9d9e-4650-43e8-a0ec-e931e07270d8')
+;
+
+-- Oct 16, 2019 2:42:08 PM IST
+INSERT INTO AD_Ref_List (AD_Ref_List_ID,Name,AD_Reference_ID,Value,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,AD_Ref_List_UU) VALUES (200479,'Double Dotted',200174,'DDT',0,0,'Y',TO_TIMESTAMP('2019-10-16 14:42:07','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2019-10-16 14:42:07','YYYY-MM-DD HH24:MI:SS'),100,'D','011c9ad0-34a9-4bd4-9af3-50615790ffb6')
+;
+
+-- Oct 16, 2019 2:42:22 PM IST
+INSERT INTO AD_Ref_List (AD_Ref_List_ID,Name,AD_Reference_ID,Value,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,AD_Ref_List_UU) VALUES (200480,'Double Dashed',200174,'DDS',0,0,'Y',TO_TIMESTAMP('2019-10-16 14:42:22','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2019-10-16 14:42:22','YYYY-MM-DD HH24:MI:SS'),100,'D','13cd13e4-af78-4252-957e-3b1e45f33497')
+;
+
+-- Oct 16, 2019 2:42:38 PM IST
+INSERT INTO AD_Ref_List (AD_Ref_List_ID,Name,AD_Reference_ID,Value,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,AD_Ref_List_UU) VALUES (200481,'Double Solid',200174,'DSD',0,0,'Y',TO_TIMESTAMP('2019-10-16 14:42:37','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2019-10-16 14:42:37','YYYY-MM-DD HH24:MI:SS'),100,'D','e39cde64-0d54-4cf9-93c1-5068c0e97ee6')
+;
+
+-- Oct 16, 2019 2:42:53 PM IST
+INSERT INTO AD_Ref_List (AD_Ref_List_ID,Name,AD_Reference_ID,Value,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,AD_Ref_List_UU) VALUES (200482,'Solid',200174,'SD',0,0,'Y',TO_TIMESTAMP('2019-10-16 14:42:52','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2019-10-16 14:42:52','YYYY-MM-DD HH24:MI:SS'),100,'D','9e450ade-e54b-46e1-b96f-36c02b3090eb')
+;
+
+-- Oct 16, 2019 2:43:26 PM IST
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Reference_Value_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure) VALUES (214088,0,'Overline Stroke Type',448,'OverlineStrokeType',3,'N','N','N','N','N',0,'N',17,200174,0,0,'Y',TO_TIMESTAMP('2019-10-16 14:43:26','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2019-10-16 14:43:26','YYYY-MM-DD HH24:MI:SS'),100,203371,'Y','N','D','N','N','N','Y','b1529a0e-96a5-43e6-94b6-d78feea8e8c8','Y',0,'N','N')
+;
+
+-- Oct 16, 2019 2:43:31 PM IST
+ALTER TABLE PA_ReportLine ADD COLUMN OverlineStrokeType VARCHAR(3) DEFAULT NULL 
+;
+
+-- Oct 16, 2019 2:44:08 PM IST
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,ColumnName,Name,PrintName,EntityType,AD_Element_UU) VALUES (203372,0,0,'Y',TO_TIMESTAMP('2019-10-16 14:44:08','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2019-10-16 14:44:08','YYYY-MM-DD HH24:MI:SS'),100,'UnderlineStrokeType','Underline Stroke Type','Underline Stroke Type','D','36e60c3b-2eff-4d58-a530-101b2d060f4a')
+;
+
+-- Oct 16, 2019 2:45:23 PM IST
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Reference_Value_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure) VALUES (214089,0,'Underline Stroke Type',448,'UnderlineStrokeType',3,'N','N','N','N','N',0,'N',17,200174,0,0,'Y',TO_TIMESTAMP('2019-10-16 14:45:23','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2019-10-16 14:45:23','YYYY-MM-DD HH24:MI:SS'),100,203372,'Y','N','D','N','N','N','Y','d3504292-068e-4126-944c-dc3d165019c0','Y',0,'N','N')
+;
+
+-- Oct 16, 2019 2:45:39 PM IST
+ALTER TABLE PA_ReportLine ADD COLUMN UnderlineStrokeType VARCHAR(3) DEFAULT NULL 
+;
+
+-- Oct 16, 2019 2:48:07 PM IST
+INSERT INTO AD_Field (AD_Field_ID,Name,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,SortNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan,NumLines,IsQuickEntry,IsDefaultFocus,IsAdvancedField) VALUES (206214,'Overline Stroke Type',376,214088,'Y',0,200,0,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2019-10-16 14:48:06','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2019-10-16 14:48:06','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','04733ecb-3dc6-4fde-82ab-33434b230ca5','Y',215,1,2,1,'N','N','N')
+;
+
+-- Oct 16, 2019 2:48:25 PM IST
+INSERT INTO AD_Field (AD_Field_ID,Name,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,SortNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan,NumLines,IsQuickEntry,IsDefaultFocus,IsAdvancedField) VALUES (206215,'Underline Stroke Type',376,214089,'Y',0,210,0,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2019-10-16 14:48:24','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2019-10-16 14:48:24','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','e5614dd4-9884-4053-99d5-1cb59540e412','Y',225,4,2,1,'N','N','N')
+;
+
+-- Added Line Type Blank Line
+-- Oct 16, 2019 5:29:02 PM IST
+INSERT INTO AD_Ref_List (AD_Ref_List_ID,Name,AD_Reference_ID,Value,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,AD_Ref_List_UU) VALUES (200483,'Blank line',241,'B',0,0,'Y',TO_TIMESTAMP('2019-10-16 17:29:01','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2019-10-16 17:29:01','YYYY-MM-DD HH24:MI:SS'),100,'D','bb000455-9057-4c8a-a656-b0f1074e3fd3')
+;
+
+SELECT register_migration_script('201912301800_IDEMPIERE-4067.sql') FROM dual
+;
+

--- a/org.adempiere.base/src/org/compiere/model/I_PA_ReportLine.java
+++ b/org.adempiere.base/src/org/compiere/model/I_PA_ReportLine.java
@@ -301,6 +301,24 @@ public interface I_PA_ReportLine
  lowest number comes first
 	  */
 	public int getSeqNo();
+ 
+   /** Column name OverlineStrokeType */
+    public static final String COLUMNNAME_OverlineStrokeType = "OverlineStrokeType";
+
+	/** Set Overline Stroke Type	  */
+	public void setOverlineStrokeType (String OverlineStrokeType);
+
+	/** Get Overline Stroke Type	  */
+	public String getOverlineStrokeType();
+
+    /** Column name UnderlineStrokeType */
+    public static final String COLUMNNAME_UnderlineStrokeType = "UnderlineStrokeType";
+
+	/** Set Underline Stroke Type	  */
+	public void setUnderlineStrokeType (String UnderlineStrokeType);
+
+	/** Get Underline Stroke Type	  */
+	public String getUnderlineStrokeType();
 
     /** Column name Updated */
     public static final String COLUMNNAME_Updated = "Updated";

--- a/org.adempiere.base/src/org/compiere/model/X_PA_ReportLine.java
+++ b/org.adempiere.base/src/org/compiere/model/X_PA_ReportLine.java
@@ -30,9 +30,9 @@ public class X_PA_ReportLine extends PO implements I_PA_ReportLine, I_Persistent
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20200413L;
+	private static final long serialVersionUID = -3681187042653339433L;
 
-    /** Standard Constructor */
+	/** Standard Constructor */
     public X_PA_ReportLine (Properties ctx, int PA_ReportLine_ID, String trxName)
     {
       super (ctx, PA_ReportLine_ID, trxName);
@@ -227,6 +227,8 @@ public class X_PA_ReportLine extends PO implements I_PA_ReportLine, I_Persistent
 	public static final String LINETYPE_SegmentValue = "S";
 	/** Calculation = C */
 	public static final String LINETYPE_Calculation = "C";
+	/** Blank line = B */
+	public static final String LINETYPE_BlankLine = "B";
 	/** Set Line Type.
 		@param LineType Line Type	  */
 	public void setLineType (String LineType)
@@ -490,5 +492,63 @@ public class X_PA_ReportLine extends PO implements I_PA_ReportLine, I_Persistent
 		if (ii == null)
 			 return 0;
 		return ii.intValue();
+	}
+
+	/** OverlineStrokeType AD_Reference_ID=200174 */
+	public static final int OVERLINESTROKETYPE_AD_Reference_ID=200174;
+	/** Dotted = DT */
+	public static final String OVERLINESTROKETYPE_Dotted = "DT";
+	/** Dashed = DS */
+	public static final String OVERLINESTROKETYPE_Dashed = "DS";
+	/** Double Dotted = DDT */
+	public static final String OVERLINESTROKETYPE_DoubleDotted = "DDT";
+	/** Double Dashed = DDS */
+	public static final String OVERLINESTROKETYPE_DoubleDashed = "DDS";
+	/** Double Solid = DSD */
+	public static final String OVERLINESTROKETYPE_DoubleSolid = "DSD";
+	/** Solid = SD */
+	public static final String OVERLINESTROKETYPE_Solid = "SD";
+	/** Set Overline Stroke Type.
+		@param OverlineStrokeType Overline Stroke Type	  */
+	public void setOverlineStrokeType (String OverlineStrokeType)
+	{
+
+		set_Value (COLUMNNAME_OverlineStrokeType, OverlineStrokeType);
+	}
+
+	/** Get Overline Stroke Type.
+		@return Overline Stroke Type	  */
+	public String getOverlineStrokeType () 
+	{
+		return (String)get_Value(COLUMNNAME_OverlineStrokeType);
+	}
+
+	/** UnderlineStrokeType AD_Reference_ID=200174 */
+	public static final int UNDERLINESTROKETYPE_AD_Reference_ID=200174;
+	/** Dotted = DT */
+	public static final String UNDERLINESTROKETYPE_Dotted = "DT";
+	/** Dashed = DS */
+	public static final String UNDERLINESTROKETYPE_Dashed = "DS";
+	/** Double Dotted = DDT */
+	public static final String UNDERLINESTROKETYPE_DoubleDotted = "DDT";
+	/** Double Dashed = DDS */
+	public static final String UNDERLINESTROKETYPE_DoubleDashed = "DDS";
+	/** Double Solid = DSD */
+	public static final String UNDERLINESTROKETYPE_DoubleSolid = "DSD";
+	/** Solid = SD */
+	public static final String UNDERLINESTROKETYPE_Solid = "SD";
+	/** Set Underline Stroke Type.
+		@param UnderlineStrokeType Underline Stroke Type	  */
+	public void setUnderlineStrokeType (String UnderlineStrokeType)
+	{
+
+		set_Value (COLUMNNAME_UnderlineStrokeType, UnderlineStrokeType);
+	}
+
+	/** Get Underline Stroke Type.
+		@return Underline Stroke Type	  */
+	public String getUnderlineStrokeType () 
+	{
+		return (String)get_Value(COLUMNNAME_UnderlineStrokeType);
 	}
 }

--- a/org.adempiere.base/src/org/compiere/print/DataEngine.java
+++ b/org.adempiere.base/src/org/compiere/print/DataEngine.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.sql.Clob;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -657,6 +658,9 @@ public class DataEngine
 			hasLevelNo = true;
 			if (sqlSELECT.indexOf("LevelNo") == -1)
 				sqlSELECT.append("LevelNo,");
+
+			if (tableName.equals("T_Report") && sqlSELECT.indexOf("PA_ReportLine_ID") == -1)
+				sqlSELECT.append("PA_ReportLine_ID,");
 		}
 
 		/**
@@ -836,6 +840,7 @@ public class DataEngine
 		PrintDataColumn pdc = null;
 		boolean hasLevelNo = pd.hasLevelNo();
 		int levelNo = 0;
+		int reportLineID = 0;
 		//
 		PreparedStatement pstmt = null;
 		ResultSet rs = null;
@@ -843,11 +848,30 @@ public class DataEngine
 		{
 			pstmt = DB.prepareNormalReadReplicaStatement(pd.getSQL(), m_trxName);
 			rs = pstmt.executeQuery();
+
+			boolean isExistsT_Report_PA_ReportLine_ID = false;
+			if (pd.getTableName().equals("T_Report"))
+			{
+				ResultSetMetaData rsmd = rs.getMetaData();
+				for (int i = 1; i <= rsmd.getColumnCount(); i++)
+				{
+					if (rsmd.getColumnLabel(i).equalsIgnoreCase("PA_ReportLine_ID"))
+					{
+						isExistsT_Report_PA_ReportLine_ID = true;
+						break;
+					}
+				}
+			}
+
 			//	Row Loop
 			while (rs.next())
 			{
 				if (hasLevelNo)
+				{
 					levelNo = rs.getInt("LevelNo");
+					if (isExistsT_Report_PA_ReportLine_ID)
+						reportLineID = rs.getInt("PA_ReportLine_ID");
+				}
 				else
 					levelNo = 0;
 				//	Check Group Change ----------------------------------------
@@ -923,8 +947,8 @@ public class DataEngine
 				printRunningTotal(pd, levelNo, rowNo++);
 
 				/** Report Summary FR [ 2011569 ]**/ 
-				if(!m_summary)					
-					pd.addRow(false, levelNo);
+				if (!m_summary)
+					pd.addRow(false, levelNo, reportLineID);
 				int counter = 1;
 				//	get columns
 				for (int i = 0; i < pd.getColumnInfo().length; i++)

--- a/org.adempiere.base/src/org/compiere/print/PrintData.java
+++ b/org.adempiere.base/src/org/compiere/print/PrintData.java
@@ -35,6 +35,7 @@ import javax.xml.transform.stream.StreamResult;
 import org.compiere.Adempiere;
 import org.compiere.print.util.SerializableMatrix;
 import org.compiere.print.util.SerializableMatrixImpl;
+import org.compiere.report.MReportLine;
 import org.compiere.util.CLogger;
 import org.compiere.util.DisplayType;
 import org.compiere.util.Trace;
@@ -57,7 +58,7 @@ public class PrintData implements Serializable
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = -5013410697934610197L;
+	private static final long serialVersionUID = 3493453909439452289L;
 
 	/**
 	 * 	Data Parent Constructor
@@ -802,5 +803,38 @@ public class PrintData implements Serializable
 		System.out.println("");
 		pd1.dump();
 	}	//	main
+	
+	public MReportLine getMReportLine()
+	{
+		List<Serializable> nodes = m_matrix.getRowData();
+
+		if (nodes == null || !m_hasLevelNo)
+			return null;
+
+		for (int i = 0; i < nodes.size(); i++)
+		{
+			Object o = nodes.get(i);
+			if (o instanceof PrintDataElement)
+			{
+				PrintDataElement pde = (PrintDataElement) o;
+				if (MReportLine.COLUMNNAME_PA_ReportLine_ID.equals(pde.getColumnName()))
+				{
+					Integer ii = (Integer) pde.getValue();
+					if (ii > 0)
+					{
+						return new MReportLine(m_ctx, ii, null);
+					}
+				}
+			}
+		}
+		return null;
+	} // getMReportLine
+
+	public void addRow(boolean functionRow, int levelNo, int reportLineID)
+	{
+		addRow(functionRow, levelNo);
+		if (m_hasLevelNo && reportLineID != 0)
+			addNode(new PrintDataElement("PA_ReportLine_ID", reportLineID, DisplayType.Integer, null));
+	}
 
 }	//	PrintData

--- a/org.adempiere.base/src/org/compiere/print/layout/LayoutEngine.java
+++ b/org.adempiere.base/src/org/compiere/print/layout/LayoutEngine.java
@@ -1706,7 +1706,6 @@ public class LayoutEngine implements Pageable, Printable, Doc
 		ArrayList<Integer> functionRows = new ArrayList<Integer>();
 		ArrayList<Integer> pageBreak = new ArrayList<Integer>();		
 		ArrayList<Integer> finReportSumRows = new ArrayList<Integer>();
-		ArrayList<Integer> blankRows = new ArrayList<Integer>();
 		int lastLevelNo = 0;
 
 		//	for all rows
@@ -1728,7 +1727,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 						log.finer("PageBreak row=" + row);
 				}
 			}
-			//	Summary/Line Levels for Finanial Reports
+			//	Summary/Line Levels for Financial Reports
 			else
 			{
 				levelNo = printData.getLineLevelNo();
@@ -1753,9 +1752,6 @@ public class LayoutEngine implements Pageable, Printable, Doc
 			}
 
 			MReportLine rLine = printData.getMReportLine();
-
-			if (rLine != null && MReportLine.LINETYPE_BlankLine.equals(rLine.getLineType()))
-				blankRows.add(Integer.valueOf(row));
 
 			//	for all columns
 			for (int c = 0; c < format.getItemCount(); c++)
@@ -1839,7 +1835,7 @@ public class LayoutEngine implements Pageable, Printable, Doc
 			elements, pk, pkColumnName,
 			pageNoStart, firstPage, nextPages, repeatedColumns, additionalLines,
 			rowColFont, rowColColor, rowColBackground,
-			tf, pageBreak, colSuppressRepeats, rowColReportLine, finReportSumRows, blankRows);
+			tf, pageBreak, colSuppressRepeats, rowColReportLine, finReportSumRows);
 		table.layout(0,0,false, MPrintFormatItem.FIELDALIGNMENTTYPE_LeadingLeft);
 		if (m_tableElement == null)
 			m_tableElement = table;

--- a/org.adempiere.base/src/org/compiere/report/FinReport.java
+++ b/org.adempiere.base/src/org/compiere/report/FinReport.java
@@ -313,7 +313,7 @@ public class FinReport extends SvrProcess
 		int PA_ReportLineSet_ID = m_report.getLineSet().getPA_ReportLineSet_ID();
 		StringBuilder sql = new StringBuilder ("INSERT INTO T_Report "
 			+ "(AD_PInstance_ID, PA_ReportLine_ID, Record_ID,Fact_Acct_ID, SeqNo,LevelNo, Name,Description) "
-			+ "SELECT ").append(getAD_PInstance_ID()).append(", rl.PA_ReportLine_ID, 0,0, rl.SeqNo,0, NVL(trl.Name, rl.Name) as Name, NVL(trl.Description,rl.Description) as Description "
+			+ "SELECT ").append(getAD_PInstance_ID()).append(", rl.PA_ReportLine_ID, 0,0, rl.SeqNo,0, CASE WHEN LineType='B' THEN '' ELSE NVL(trl.Name, rl.Name) END as Name, NVL(trl.Description,rl.Description) as Description "
 			+ "FROM PA_ReportLine rl "
 			+ "LEFT JOIN PA_ReportLine_Trl trl ON trl.PA_ReportLine_ID = rl.PA_ReportLine_ID AND trl.AD_Language = '" + Env.getAD_Language(Env.getCtx()) + "' "
 			+ "WHERE rl.IsActive='Y' AND rl.PA_ReportLineSet_ID=").append(PA_ReportLineSet_ID);

--- a/org.adempiere.base/src/org/compiere/report/MReportLine.java
+++ b/org.adempiere.base/src/org/compiere/report/MReportLine.java
@@ -16,6 +16,9 @@
  *****************************************************************************/
 package org.compiere.report;
 
+import java.awt.BasicStroke;
+import java.awt.Stroke;
+import java.math.BigDecimal;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.ArrayList;
@@ -38,7 +41,10 @@ public class MReportLine extends X_PA_ReportLine
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = -3957315092529097396L;
+	private static final long serialVersionUID = -6310984172477566729L;
+
+	private BasicStroke			overline_Stroke;
+	private Stroke				underline_Stroke;
 
 	/**
 	 * 	Constructor
@@ -422,5 +428,104 @@ public class MReportLine extends X_PA_ReportLine
 		return retValue;
 	}	//	copy
 
+	/**
+	 * Get overline style 0 - none, 1 - single, 2 - double
+	 * 
+	 * @return int - Style No
+	 */
+	public int getOverline( )
+	{
+		if (OVERLINESTROKETYPE_Dotted.equals(getOverlineStrokeType())	|| OVERLINESTROKETYPE_Solid.equals(getOverlineStrokeType())
+			|| OVERLINESTROKETYPE_Dashed.equals(getOverlineStrokeType()))
+			return 1;
+		else if (OVERLINESTROKETYPE_DoubleDotted.equals(getOverlineStrokeType())	|| OVERLINESTROKETYPE_DoubleSolid.equals(getOverlineStrokeType())
+					|| OVERLINESTROKETYPE_DoubleDashed.equals(getOverlineStrokeType()))
+			return 2;
+		return 0;
+	} // getOverline
+
+	/**
+	 * Get OverLine Stroke
+	 * 
+	 * @return line based on line (1/2 of) width and stroke (default dotted 1/2p
+	 */
+	public Stroke getOverlineStroke(BigDecimal stroke)
+	{
+		if (overline_Stroke == null)
+		{
+			float width = stroke.floatValue() / 2;
+			// . . .
+			if (UNDERLINESTROKETYPE_Dotted.equals(getOverlineStrokeType()) || UNDERLINESTROKETYPE_DoubleDotted.equals(getOverlineStrokeType()))
+				overline_Stroke = new BasicStroke(width, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 1.0f, getPatternDotted(width), 0.0f);
+			// -
+			else if (UNDERLINESTROKETYPE_Solid.equals(getOverlineStrokeType()) || UNDERLINESTROKETYPE_DoubleSolid.equals(getOverlineStrokeType()))
+				overline_Stroke = new BasicStroke(width);
+			// - -
+			else if (UNDERLINESTROKETYPE_Dashed.equals(getOverlineStrokeType()) || UNDERLINESTROKETYPE_DoubleDashed.equals(getOverlineStrokeType()))
+				overline_Stroke = new BasicStroke(width, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 1.0f, getPatternDashed(width), 0.0f);
+		}
+		return overline_Stroke;
+	} // getUnderine_Stroke
+
+	/**
+	 * Get underline style 0 - none 1 - single 2 - double
+	 * 
+	 * @return int - Style No
+	 */
+	public int getUnderline( )
+	{
+		if (UNDERLINESTROKETYPE_Dotted.equals(getUnderlineStrokeType())	|| UNDERLINESTROKETYPE_Solid.equals(getUnderlineStrokeType())
+			|| UNDERLINESTROKETYPE_Dashed.equals(getUnderlineStrokeType()))
+			return 1;
+		else if (UNDERLINESTROKETYPE_DoubleDotted.equals(getUnderlineStrokeType())	|| UNDERLINESTROKETYPE_DoubleSolid.equals(getUnderlineStrokeType())
+					|| UNDERLINESTROKETYPE_DoubleDashed.equals(getUnderlineStrokeType()))
+			return 2;
+		return 0;
+	} // getUnderline
+
+	/**
+	 * Get UnderLine Stroke
+	 * 
+	 * @return line based on line (1/2 of) width and stroke (default dotted 1/2p
+	 */
+	public Stroke getUnderlineStroke(BigDecimal stroke)
+	{
+		if (underline_Stroke == null)
+		{
+			float width = stroke.floatValue() / 2;
+			// . . .
+			if (UNDERLINESTROKETYPE_Dotted.equals(getUnderlineStrokeType()) || UNDERLINESTROKETYPE_DoubleDotted.equals(getUnderlineStrokeType()))
+				underline_Stroke = new BasicStroke(width, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 1.0f, getPatternDotted(width), 0.0f);
+			// -
+			else if (UNDERLINESTROKETYPE_Solid.equals(getUnderlineStrokeType()) || UNDERLINESTROKETYPE_DoubleSolid.equals(getUnderlineStrokeType()))
+				underline_Stroke = new BasicStroke(width);
+			// - -
+			else if (UNDERLINESTROKETYPE_Dashed.equals(getUnderlineStrokeType()) || UNDERLINESTROKETYPE_DoubleDashed.equals(getUnderlineStrokeType()))
+				underline_Stroke = new BasicStroke(width, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 1.0f, getPatternDashed(width), 0.0f);
+		}
+		return underline_Stroke;
+	} // getUnderine_Stroke
+
+	/**
+	 * Get Pattern Dotted . . . .
+	 * 
+	 * @param width - Width of line
+	 * @return pattern
+	 */
+	private float[] getPatternDotted(float width)
+	{
+		return new float[] { 2 * width, 2 * width };
+	} // getPatternDotted
+
+	/**
+	 * Get Pattern Dashed - - - -
+	 * 
+	 * @param width - Width of line
+	 * @return pattern
+	 */
+	private float[] getPatternDashed(float width)
+	{
+		return new float[] { 10 * width, 4 * width };
+	} // getPatternDashed
 
 }	//	MReportLine

--- a/org.adempiere.base/src/org/compiere/report/MReportLine.java
+++ b/org.adempiere.base/src/org/compiere/report/MReportLine.java
@@ -351,7 +351,16 @@ public class MReportLine extends X_PA_ReportLine
 	{
 		return LINETYPE_SegmentValue.equals(getLineType());
 	}
-	
+
+	/**
+	 * Line Type Blank Line
+	 * @return true if Blank Line
+	 */
+	public boolean isLineTypeBlankLine() 
+	{
+		return LINETYPE_BlankLine.equals(getLineType());
+	}
+
 	/**
 	 * 	Calculation Type Range
 	 *	@return true if range


### PR DESCRIPTION
…al report line.

For testing, After applying migration script, Report Line Set -> Report line has two new field
1. Overline Stroke type
2. Underline Stroke Type
Selecting value on this field and refreshing PDF report will shows elected type of lines on column section.

Also in Line Type there is new option Blank line visible. Selecting it will make blank line printed.

Original work done by @pawlbouden from Adaxa in adaxasuite. Logilite has bring his work to iDempiere.
