### PR TITLE
IDEMPIERE-4442 FIX NPE when locatorField is Empty

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WLocatorDialog.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WLocatorDialog.java
@@ -659,7 +659,8 @@ public class WLocatorDialog extends Window implements EventListener<Event>
 		if (m_change)
 		{
 			Integer locator_id = (Integer) locatorField.getValue();
-			return locator_id == m_M_Locator_ID;
+			if(locator_id != null)
+				return locator_id == m_M_Locator_ID;
 		}
 		return m_change;
 	} // getChange


### PR DESCRIPTION
Fix NPE when we confirm Locator Dialog with empty Locator Field.

To test:
1. Open any Product which have its Locator selected.
2. Deselect Locator through Locator Dialog.