### PR TITLE
IDEMPIERE-1604 - Extend features for Window Customization

### DIFF
--- a/migration/i7.1z/oracle/201809141624_IDEMPIERE-1604.sql
+++ b/migration/i7.1z/oracle/201809141624_IDEMPIERE-1604.sql
@@ -59,9 +59,9 @@ value := strings or numbers<br>
 logic operators	:= AND or OR with the previous result from left to right <br>
 operand := eq{=}, gt{&gt;}, le{&lt;}, not{~^!} <br>
 Examples: <br>
-@AD_Table_ID@=14 | @Language@!GERGER <br>
-@PriceLimit@>10 | @PriceList@>@PriceActual@<br>
-@Name@>J<br>
+'||chr(64)||'AD_Table_ID@=14 | @Language@!GERGER <br>
+'||chr(64)||'PriceLimit@>10 | @PriceList@>@PriceActual@<br>
+'||chr(64)||'Name@>J<br>
 Strings may be in single quotes (optional)',466,'DisplayLogic',2000,'N','N','N','N','N',0,'N',14,0,0,'Y',TO_DATE('2018-09-14 15:13:52','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2018-09-14 15:13:52','YYYY-MM-DD HH24:MI:SS'),100,283,'Y','N','D','N','N','N','Y','e0cd374f-5d30-4113-be73-a8d79ef48cca','Y',0,'N','N')
 ;
 
@@ -110,9 +110,9 @@ value := strings or numbers<br>
 logic operators	:= AND or OR with the previous result from left to right <br>
 operand := eq{=}, gt{&gt;}, le{&lt;}, not{~^!} <br>
 Examples: <br>
-@AD_Table_ID@=14 | @Language@!GERGER <br>
-@PriceLimit@>10 | @PriceList@>@PriceActual@<br>
-@Name@>J<br>
+'||chr(64)||'AD_Table_ID@=14 | @Language@!GERGER <br>
+'||chr(64)||'PriceLimit@>10 | @PriceList@>@PriceActual@<br>
+'||chr(64)||'Name@>J<br>
 Strings may be in single quotes (optional)',394,213695,'Y',2000,170,'N','N','N','N',0,0,'Y',TO_DATE('2018-09-14 15:16:43','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2018-09-14 15:16:43','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','1af31bdc-9a18-4438-a2bd-a1677a7425ec','Y',170,5,3)
 ;
 

--- a/migration/i7.1z/oracle/201809141624_IDEMPIERE-1604.sql
+++ b/migration/i7.1z/oracle/201809141624_IDEMPIERE-1604.sql
@@ -1,0 +1,162 @@
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- IDEMPIERE-1604 Improvement on Window Customization
+-- 14/09/2018 14h56min16s BRT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure) VALUES (213691,0,'Sql WHERE','Fully qualified SQL WHERE clause','The Where Clause indicates the SQL WHERE clause to use for record selection. The WHERE clause is added to the query. Fully qualified means "tablename.columnname".',466,'WhereClause',2000,'N','N','N','N','N',0,'N',14,0,0,'Y',TO_DATE('2018-09-14 14:56:16','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2018-09-14 14:56:16','YYYY-MM-DD HH24:MI:SS'),100,630,'Y','N','D','N','N','N','Y','9cd3e72b-9a57-4744-9d79-386e9473e573','Y',0,'N','N')
+;
+
+-- 14/09/2018 14h56min26s BRT
+ALTER TABLE AD_UserDef_Tab ADD WhereClause VARCHAR2(2000) DEFAULT NULL 
+;
+
+-- 14/09/2018 14h57min39s BRT
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan,NumLines,IsQuickEntry,IsDefaultFocus,IsAdvancedField) VALUES (205828,'Sql WHERE','Fully qualified SQL WHERE clause','The Where Clause indicates the SQL WHERE clause to use for record selection. The WHERE clause is added to the query. Fully qualified means "tablename.columnname".',394,213691,'Y',2000,130,'N','N','N','N',0,0,'Y',TO_DATE('2018-09-14 14:57:39','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2018-09-14 14:57:39','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','653c7f21-fdd7-4522-949e-fa9336e53e4b','Y',130,1,5,1,'N','N','Y')
+;
+
+-- 14/09/2018 15h2min36s BRT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure) VALUES (213692,0,'Sql ORDER BY','Fully qualified ORDER BY clause','The ORDER BY Clause indicates the SQL ORDER BY clause to use for record selection',466,'OrderByClause',2000,'N','N','N','N','N',0,'N',10,0,0,'Y',TO_DATE('2018-09-14 15:02:36','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2018-09-14 15:02:36','YYYY-MM-DD HH24:MI:SS'),100,475,'Y','N','D','N','N','N','Y','0ec1d7fc-9ff4-4c53-a848-1c8dbafa6975','Y',0,'N','N')
+;
+
+-- 14/09/2018 15h2min43s BRT
+ALTER TABLE AD_UserDef_Tab ADD OrderByClause VARCHAR2(2000) DEFAULT NULL 
+;
+
+-- 14/09/2018 15h3min40s BRT
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan,NumLines,IsQuickEntry,IsDefaultFocus,IsAdvancedField) VALUES (205830,'Sql ORDER BY','Fully qualified ORDER BY clause','The ORDER BY Clause indicates the SQL ORDER BY clause to use for record selection',394,213692,'Y',2000,140,'N','N','N','N',0,0,'Y',TO_DATE('2018-09-14 15:03:39','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2018-09-14 15:03:39','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','c1ededed-6887-4eaf-9c5b-7ca01da3d86a','Y',140,1,5,1,'N','N','Y')
+;
+
+-- 14/09/2018 15h12min4s BRT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,FKConstraintType) VALUES (213693,0,'Process','Process or Report','The Process field identifies a unique Process or Report in the system.',466,'AD_Process_ID',22,'N','N','N','N','N',0,'N',19,0,0,'Y',TO_DATE('2018-09-14 15:12:04','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2018-09-14 15:12:04','YYYY-MM-DD HH24:MI:SS'),100,117,'Y','N','D','N','N','N','Y','67634d35-a8e1-4667-8c74-529d74c36145','Y',0,'N','N','N')
+;
+
+-- 14/09/2018 15h12min22s BRT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure) VALUES (213694,0,'Sequence','Method of ordering records; lowest number comes first','The Sequence indicates the order of records',466,'SeqNo',22,'N','N','N','N','N',0,'N',11,0,0,'Y',TO_DATE('2018-09-14 15:12:22','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2018-09-14 15:12:22','YYYY-MM-DD HH24:MI:SS'),100,566,'Y','N','D','N','N','N','Y','c7e49398-e62b-46f5-8217-3f7fb82a3173','Y',0,'N','N')
+;
+
+-- 14/09/2018 15h12min26s BRT
+ALTER TABLE AD_UserDef_Tab ADD SeqNo NUMBER(10) DEFAULT NULL 
+;
+
+-- 14/09/2018 15h12min40s BRT
+UPDATE AD_Column SET FKConstraintName='ADProcess_ADUserDefTab', FKConstraintType='N',Updated=TO_DATE('2018-09-14 15:12:40','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=213693
+;
+
+-- 14/09/2018 15h12min40s BRT
+ALTER TABLE AD_UserDef_Tab ADD AD_Process_ID NUMBER(10) DEFAULT NULL 
+;
+
+-- 14/09/2018 15h12min40s BRT
+ALTER TABLE AD_UserDef_Tab ADD CONSTRAINT ADProcess_ADUserDefTab FOREIGN KEY (AD_Process_ID) REFERENCES ad_process(ad_process_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- 14/09/2018 15h13min52s BRT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure) VALUES (213695,0,'Display Logic','If the Field is displayed, the result determines if the field is actually displayed','format := {expression} [{logic} {expression}]<br> 
+expression := @{context}@{operand}{value} or @{context}@{operand}{value}<br> 
+logic := {|}|{&}<br>
+context := any global or window context <br>
+value := strings or numbers<br>
+logic operators	:= AND or OR with the previous result from left to right <br>
+operand := eq{=}, gt{&gt;}, le{&lt;}, not{~^!} <br>
+Examples: <br>
+@AD_Table_ID@=14 | @Language@!GERGER <br>
+@PriceLimit@>10 | @PriceList@>@PriceActual@<br>
+@Name@>J<br>
+Strings may be in single quotes (optional)',466,'DisplayLogic',2000,'N','N','N','N','N',0,'N',14,0,0,'Y',TO_DATE('2018-09-14 15:13:52','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2018-09-14 15:13:52','YYYY-MM-DD HH24:MI:SS'),100,283,'Y','N','D','N','N','N','Y','e0cd374f-5d30-4113-be73-a8d79ef48cca','Y',0,'N','N')
+;
+
+-- 14/09/2018 15h13min56s BRT
+ALTER TABLE AD_UserDef_Tab ADD DisplayLogic VARCHAR2(2000) DEFAULT NULL 
+;
+
+-- 14/09/2018 15h15min28s BRT
+UPDATE AD_Column SET IsMandatory='N', AD_Reference_ID=17, AD_Reference_Value_ID=319,Updated=TO_DATE('2018-09-14 15:15:28','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=6385
+;
+
+-- 14/09/2018 15h15min32s BRT
+ALTER TABLE AD_UserDef_Tab MODIFY IsReadOnly CHAR(1) DEFAULT NULL 
+;
+
+-- 14/09/2018 15h15min32s BRT
+ALTER TABLE AD_UserDef_Tab MODIFY IsReadOnly NULL
+;
+
+-- 14/09/2018 15h15min58s BRT
+UPDATE AD_Column SET IsMandatory='N', AD_Reference_ID=17, AD_Reference_Value_ID=319,Updated=TO_DATE('2018-09-14 15:15:58','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=6384
+;
+
+-- 14/09/2018 15h16min2s BRT
+ALTER TABLE AD_UserDef_Tab MODIFY IsSingleRow CHAR(1) DEFAULT NULL 
+;
+
+-- 14/09/2018 15h16min2s BRT
+ALTER TABLE AD_UserDef_Tab MODIFY IsSingleRow NULL
+;
+
+-- 14/09/2018 15h16min43s BRT
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (205831,'Process','Process or Report','The Process field identifies a unique Process or Report in the system.',394,213693,'Y',22,150,'N','N','N','N',0,0,'Y',TO_DATE('2018-09-14 15:16:42','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2018-09-14 15:16:42','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','a6f7ec54-1d7d-4940-bc13-bfc974ea1775','Y',150,2)
+;
+
+-- 14/09/2018 15h16min43s BRT
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (205832,'Sequence','Method of ordering records; lowest number comes first','The Sequence indicates the order of records',394,213694,'N',22,160,'N','N','N','N',0,0,'Y',TO_DATE('2018-09-14 15:16:43','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2018-09-14 15:16:43','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','8648c11e-9390-4d62-8e0b-1ff0d554f092','Y',160,2)
+;
+
+-- 14/09/2018 15h16min43s BRT
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan,NumLines) VALUES (205833,'Display Logic','If the Field is displayed, the result determines if the field is actually displayed','format := {expression} [{logic} {expression}]<br> 
+expression := @{context}@{operand}{value} or @{context}@{operand}{value}<br> 
+logic := {|}|{&}<br>
+context := any global or window context <br>
+value := strings or numbers<br>
+logic operators	:= AND or OR with the previous result from left to right <br>
+operand := eq{=}, gt{&gt;}, le{&lt;}, not{~^!} <br>
+Examples: <br>
+@AD_Table_ID@=14 | @Language@!GERGER <br>
+@PriceLimit@>10 | @PriceList@>@PriceActual@<br>
+@Name@>J<br>
+Strings may be in single quotes (optional)',394,213695,'Y',2000,170,'N','N','N','N',0,0,'Y',TO_DATE('2018-09-14 15:16:43','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2018-09-14 15:16:43','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','1af31bdc-9a18-4438-a2bd-a1677a7425ec','Y',170,5,3)
+;
+
+-- 14/09/2018 15h18min56s BRT
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=40, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, XPosition=4, IsToolbarButton=NULL,Updated=TO_DATE('2018-09-14 15:18:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=5035
+;
+
+-- 14/09/2018 15h18min56s BRT
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=100, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, XPosition=1, IsToolbarButton=NULL,Updated=TO_DATE('2018-09-14 15:18:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=205831
+;
+
+-- 14/09/2018 15h18min56s BRT
+UPDATE AD_Field SET IsDisplayed='N', SeqNo=110, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, XPosition=4, IsToolbarButton=NULL,Updated=TO_DATE('2018-09-14 15:18:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=205832
+;
+
+-- 14/09/2018 15h18min56s BRT
+UPDATE AD_Field SET SeqNo=120, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, XPosition=1, IsToolbarButton=NULL,Updated=TO_DATE('2018-09-14 15:18:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=5039
+;
+
+-- 14/09/2018 15h18min56s BRT
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=130, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, XPosition=4, IsToolbarButton=NULL,Updated=TO_DATE('2018-09-14 15:18:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=5040
+;
+
+-- 14/09/2018 15h18min57s BRT
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=140, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, XPosition=1, ColumnSpan=5, NumLines=2, IsToolbarButton=NULL,Updated=TO_DATE('2018-09-14 15:18:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=205833
+;
+
+-- 14/09/2018 15h18min57s BRT
+UPDATE AD_Field SET SeqNo=150, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, NumLines=2, IsToolbarButton=NULL,Updated=TO_DATE('2018-09-14 15:18:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=200003
+;
+
+-- 14/09/2018 15h18min57s BRT
+UPDATE AD_Field SET SeqNo=160, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, NumLines=2, IsToolbarButton=NULL,Updated=TO_DATE('2018-09-14 15:18:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=205828
+;
+
+-- 14/09/2018 15h18min57s BRT
+UPDATE AD_Field SET SeqNo=170, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, NumLines=2, IsToolbarButton=NULL,Updated=TO_DATE('2018-09-14 15:18:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=205830
+;
+
+-- 14/09/2018 15h18min57s BRT
+UPDATE AD_Field SET SeqNo=0, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_DATE('2018-09-14 15:18:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=204616
+;
+
+-- 14/09/2018 15h18min57s BRT
+SELECT Register_Migration_Script ('201809141624_IDEMPIERE-1604.sql') FROM DUAL
+;
+

--- a/migration/i7.1z/oracle/201809141624_IDEMPIERE-1604.sql
+++ b/migration/i7.1z/oracle/201809141624_IDEMPIERE-1604.sql
@@ -7,7 +7,7 @@ INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,Co
 ;
 
 -- 14/09/2018 14h56min26s BRT
-ALTER TABLE AD_UserDef_Tab ADD WhereClause VARCHAR2(2000) DEFAULT NULL 
+ALTER TABLE AD_UserDef_Tab ADD WhereClause VARCHAR2(2000 CHAR) DEFAULT NULL 
 ;
 
 -- 14/09/2018 14h57min39s BRT
@@ -19,7 +19,7 @@ INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,Co
 ;
 
 -- 14/09/2018 15h2min43s BRT
-ALTER TABLE AD_UserDef_Tab ADD OrderByClause VARCHAR2(2000) DEFAULT NULL 
+ALTER TABLE AD_UserDef_Tab ADD OrderByClause VARCHAR2(2000 CHAR) DEFAULT NULL 
 ;
 
 -- 14/09/2018 15h3min40s BRT
@@ -66,7 +66,7 @@ Strings may be in single quotes (optional)',466,'DisplayLogic',2000,'N','N','N',
 ;
 
 -- 14/09/2018 15h13min56s BRT
-ALTER TABLE AD_UserDef_Tab ADD DisplayLogic VARCHAR2(2000) DEFAULT NULL 
+ALTER TABLE AD_UserDef_Tab ADD DisplayLogic VARCHAR2(2000 CHAR) DEFAULT NULL 
 ;
 
 -- 14/09/2018 15h15min28s BRT

--- a/migration/i7.1z/postgresql/201809141624_IDEMPIERE-1604.sql
+++ b/migration/i7.1z/postgresql/201809141624_IDEMPIERE-1604.sql
@@ -1,0 +1,158 @@
+-- IDEMPIERE-1604 Improvement on Window Customization
+-- 14/09/2018 14h56min16s BRT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure) VALUES (213691,0,'Sql WHERE','Fully qualified SQL WHERE clause','The Where Clause indicates the SQL WHERE clause to use for record selection. The WHERE clause is added to the query. Fully qualified means "tablename.columnname".',466,'WhereClause',2000,'N','N','N','N','N',0,'N',14,0,0,'Y',TO_TIMESTAMP('2018-09-14 14:56:16','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2018-09-14 14:56:16','YYYY-MM-DD HH24:MI:SS'),100,630,'Y','N','D','N','N','N','Y','9cd3e72b-9a57-4744-9d79-386e9473e573','Y',0,'N','N')
+;
+
+-- 14/09/2018 14h56min26s BRT
+ALTER TABLE AD_UserDef_Tab ADD COLUMN WhereClause VARCHAR(2000) DEFAULT NULL 
+;
+
+-- 14/09/2018 14h57min39s BRT
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan,NumLines,IsQuickEntry,IsDefaultFocus,IsAdvancedField) VALUES (205828,'Sql WHERE','Fully qualified SQL WHERE clause','The Where Clause indicates the SQL WHERE clause to use for record selection. The WHERE clause is added to the query. Fully qualified means "tablename.columnname".',394,213691,'Y',2000,130,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2018-09-14 14:57:39','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2018-09-14 14:57:39','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','653c7f21-fdd7-4522-949e-fa9336e53e4b','Y',130,1,5,1,'N','N','Y')
+;
+
+-- 14/09/2018 15h2min36s BRT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure) VALUES (213692,0,'Sql ORDER BY','Fully qualified ORDER BY clause','The ORDER BY Clause indicates the SQL ORDER BY clause to use for record selection',466,'OrderByClause',2000,'N','N','N','N','N',0,'N',10,0,0,'Y',TO_TIMESTAMP('2018-09-14 15:02:36','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2018-09-14 15:02:36','YYYY-MM-DD HH24:MI:SS'),100,475,'Y','N','D','N','N','N','Y','0ec1d7fc-9ff4-4c53-a848-1c8dbafa6975','Y',0,'N','N')
+;
+
+-- 14/09/2018 15h2min43s BRT
+ALTER TABLE AD_UserDef_Tab ADD COLUMN OrderByClause VARCHAR(2000) DEFAULT NULL 
+;
+
+-- 14/09/2018 15h3min40s BRT
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan,NumLines,IsQuickEntry,IsDefaultFocus,IsAdvancedField) VALUES (205830,'Sql ORDER BY','Fully qualified ORDER BY clause','The ORDER BY Clause indicates the SQL ORDER BY clause to use for record selection',394,213692,'Y',2000,140,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2018-09-14 15:03:39','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2018-09-14 15:03:39','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','c1ededed-6887-4eaf-9c5b-7ca01da3d86a','Y',140,1,5,1,'N','N','Y')
+;
+
+-- 14/09/2018 15h12min4s BRT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,FKConstraintType) VALUES (213693,0,'Process','Process or Report','The Process field identifies a unique Process or Report in the system.',466,'AD_Process_ID',22,'N','N','N','N','N',0,'N',19,0,0,'Y',TO_TIMESTAMP('2018-09-14 15:12:04','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2018-09-14 15:12:04','YYYY-MM-DD HH24:MI:SS'),100,117,'Y','N','D','N','N','N','Y','67634d35-a8e1-4667-8c74-529d74c36145','Y',0,'N','N','N')
+;
+
+-- 14/09/2018 15h12min22s BRT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure) VALUES (213694,0,'Sequence','Method of ordering records; lowest number comes first','The Sequence indicates the order of records',466,'SeqNo',22,'N','N','N','N','N',0,'N',11,0,0,'Y',TO_TIMESTAMP('2018-09-14 15:12:22','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2018-09-14 15:12:22','YYYY-MM-DD HH24:MI:SS'),100,566,'Y','N','D','N','N','N','Y','c7e49398-e62b-46f5-8217-3f7fb82a3173','Y',0,'N','N')
+;
+
+-- 14/09/2018 15h12min26s BRT
+ALTER TABLE AD_UserDef_Tab ADD COLUMN SeqNo NUMERIC(10) DEFAULT NULL 
+;
+
+-- 14/09/2018 15h12min40s BRT
+UPDATE AD_Column SET FKConstraintName='ADProcess_ADUserDefTab', FKConstraintType='N',Updated=TO_TIMESTAMP('2018-09-14 15:12:40','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=213693
+;
+
+-- 14/09/2018 15h12min40s BRT
+ALTER TABLE AD_UserDef_Tab ADD COLUMN AD_Process_ID NUMERIC(10) DEFAULT NULL 
+;
+
+-- 14/09/2018 15h12min40s BRT
+ALTER TABLE AD_UserDef_Tab ADD CONSTRAINT ADProcess_ADUserDefTab FOREIGN KEY (AD_Process_ID) REFERENCES ad_process(ad_process_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- 14/09/2018 15h13min52s BRT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure) VALUES (213695,0,'Display Logic','If the Field is displayed, the result determines if the field is actually displayed','format := {expression} [{logic} {expression}]<br> 
+expression := @{context}@{operand}{value} or @{context}@{operand}{value}<br> 
+logic := {|}|{&}<br>
+context := any global or window context <br>
+value := strings or numbers<br>
+logic operators	:= AND or OR with the previous result from left to right <br>
+operand := eq{=}, gt{&gt;}, le{&lt;}, not{~^!} <br>
+Examples: <br>
+@AD_Table_ID@=14 | @Language@!GERGER <br>
+@PriceLimit@>10 | @PriceList@>@PriceActual@<br>
+@Name@>J<br>
+Strings may be in single quotes (optional)',466,'DisplayLogic',2000,'N','N','N','N','N',0,'N',14,0,0,'Y',TO_TIMESTAMP('2018-09-14 15:13:52','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2018-09-14 15:13:52','YYYY-MM-DD HH24:MI:SS'),100,283,'Y','N','D','N','N','N','Y','e0cd374f-5d30-4113-be73-a8d79ef48cca','Y',0,'N','N')
+;
+
+-- 14/09/2018 15h13min56s BRT
+ALTER TABLE AD_UserDef_Tab ADD COLUMN DisplayLogic VARCHAR(2000) DEFAULT NULL 
+;
+
+-- 14/09/2018 15h15min28s BRT
+UPDATE AD_Column SET IsMandatory='N', AD_Reference_ID=17, AD_Reference_Value_ID=319,Updated=TO_TIMESTAMP('2018-09-14 15:15:28','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=6385
+;
+
+-- 14/09/2018 15h15min32s BRT
+INSERT INTO t_alter_column values('ad_userdef_tab','IsReadOnly','CHAR(1)',null,'NULL')
+;
+
+-- 14/09/2018 15h15min32s BRT
+INSERT INTO t_alter_column values('ad_userdef_tab','IsReadOnly',null,'NULL',null)
+;
+
+-- 14/09/2018 15h15min58s BRT
+UPDATE AD_Column SET IsMandatory='N', AD_Reference_ID=17, AD_Reference_Value_ID=319,Updated=TO_TIMESTAMP('2018-09-14 15:15:58','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=6384
+;
+
+-- 14/09/2018 15h16min2s BRT
+INSERT INTO t_alter_column values('ad_userdef_tab','IsSingleRow','CHAR(1)',null,'NULL')
+;
+
+-- 14/09/2018 15h16min2s BRT
+INSERT INTO t_alter_column values('ad_userdef_tab','IsSingleRow',null,'NULL',null)
+;
+
+-- 14/09/2018 15h16min43s BRT
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (205831,'Process','Process or Report','The Process field identifies a unique Process or Report in the system.',394,213693,'Y',22,150,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2018-09-14 15:16:42','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2018-09-14 15:16:42','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','a6f7ec54-1d7d-4940-bc13-bfc974ea1775','Y',150,2)
+;
+
+-- 14/09/2018 15h16min43s BRT
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (205832,'Sequence','Method of ordering records; lowest number comes first','The Sequence indicates the order of records',394,213694,'N',22,160,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2018-09-14 15:16:43','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2018-09-14 15:16:43','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','8648c11e-9390-4d62-8e0b-1ff0d554f092','Y',160,2)
+;
+
+-- 14/09/2018 15h16min43s BRT
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan,NumLines) VALUES (205833,'Display Logic','If the Field is displayed, the result determines if the field is actually displayed','format := {expression} [{logic} {expression}]<br> 
+expression := @{context}@{operand}{value} or @{context}@{operand}{value}<br> 
+logic := {|}|{&}<br>
+context := any global or window context <br>
+value := strings or numbers<br>
+logic operators	:= AND or OR with the previous result from left to right <br>
+operand := eq{=}, gt{&gt;}, le{&lt;}, not{~^!} <br>
+Examples: <br>
+@AD_Table_ID@=14 | @Language@!GERGER <br>
+@PriceLimit@>10 | @PriceList@>@PriceActual@<br>
+@Name@>J<br>
+Strings may be in single quotes (optional)',394,213695,'Y',2000,170,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2018-09-14 15:16:43','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2018-09-14 15:16:43','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','1af31bdc-9a18-4438-a2bd-a1677a7425ec','Y',170,5,3)
+;
+
+-- 14/09/2018 15h18min56s BRT
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=40, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, XPosition=4, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2018-09-14 15:18:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=5035
+;
+
+-- 14/09/2018 15h18min56s BRT
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=100, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, XPosition=1, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2018-09-14 15:18:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=205831
+;
+
+-- 14/09/2018 15h18min56s BRT
+UPDATE AD_Field SET IsDisplayed='N', SeqNo=110, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, XPosition=4, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2018-09-14 15:18:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=205832
+;
+
+-- 14/09/2018 15h18min56s BRT
+UPDATE AD_Field SET SeqNo=120, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, XPosition=1, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2018-09-14 15:18:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=5039
+;
+
+-- 14/09/2018 15h18min56s BRT
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=130, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, XPosition=4, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2018-09-14 15:18:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=5040
+;
+
+-- 14/09/2018 15h18min57s BRT
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=140, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, XPosition=1, ColumnSpan=5, NumLines=2, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2018-09-14 15:18:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=205833
+;
+
+-- 14/09/2018 15h18min57s BRT
+UPDATE AD_Field SET SeqNo=150, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, NumLines=2, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2018-09-14 15:18:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=200003
+;
+
+-- 14/09/2018 15h18min57s BRT
+UPDATE AD_Field SET SeqNo=160, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, NumLines=2, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2018-09-14 15:18:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=205828
+;
+
+-- 14/09/2018 15h18min57s BRT
+UPDATE AD_Field SET SeqNo=170, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, NumLines=2, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2018-09-14 15:18:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=205830
+;
+
+-- 14/09/2018 15h18min57s BRT
+UPDATE AD_Field SET SeqNo=0, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2018-09-14 15:18:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=204616
+;
+
+-- 14/09/2018 15h18min57s BRT
+SELECT Register_Migration_Script ('201809141624_IDEMPIERE-1604.sql') FROM DUAL
+;

--- a/org.adempiere.base.callout/src/org/compiere/model/CalloutWindowCustomization.java
+++ b/org.adempiere.base.callout/src/org/compiere/model/CalloutWindowCustomization.java
@@ -84,9 +84,6 @@ public class CalloutWindowCustomization extends CalloutEngine
 		ud_tab.setName(tab.get_Translation("Name", lang));
 		ud_tab.setDescription(tab.get_Translation("Description", lang));
 		ud_tab.setHelp(tab.get_Translation("Help", lang));
-		
-		ud_tab.setIsSingleRow(tab.isSingleRow()); 
-		ud_tab.setIsReadOnly(tab.isReadOnly()); 
 
 		return NO_ERROR;
 	}	//	tab

--- a/org.adempiere.base/src/org/compiere/model/GridTabVO.java
+++ b/org.adempiere.base/src/org/compiere/model/GridTabVO.java
@@ -151,6 +151,8 @@ public class GridTabVO implements Evaluatee, Serializable
 			
 			//	DisplayLogic
 			vo.DisplayLogic = rs.getString("DisplayLogic");
+			if (userDef != null && userDef.getDisplayLogic() != null)
+				vo.DisplayLogic = userDef.getDisplayLogic();
 			
 			//	Access Level
 			vo.AccessLevel = rs.getString("AccessLevel");
@@ -175,11 +177,11 @@ public class GridTabVO implements Evaluatee, Serializable
 			
 			if (rs.getString("IsReadOnly").equals("Y"))
 				vo.IsReadOnly = true;
-			if (userDef != null && userDef.get_ValueAsString("ReadOnlyLogic") != null)
-				vo.IsReadOnly = userDef.isReadOnly();
+			if (userDef != null && userDef.getIsReadOnly() != null)
+				vo.IsReadOnly = MUserDefTab.ISREADONLY_Yes.equals(userDef.getIsReadOnly());
 			vo.ReadOnlyLogic = rs.getString("ReadOnlyLogic");
-			if (userDef != null)
-				vo.ReadOnlyLogic = userDef.get_ValueAsString("ReadOnlyLogic");
+			if (userDef != null && userDef.getReadOnlyLogic() != null)
+				vo.ReadOnlyLogic = userDef.getReadOnlyLogic();
 			
 			if (rs.getString("IsInsertRecord").equals("N"))
 				vo.IsInsertRecord = false;
@@ -199,8 +201,8 @@ public class GridTabVO implements Evaluatee, Serializable
 
 			if (rs.getString("IsSingleRow").equals("Y"))
 				vo.IsSingleRow = true;
-			if (userDef != null)
-				vo.IsSingleRow = userDef.isSingleRow();
+			if (userDef != null && userDef.getIsSingleRow() != null)
+				vo.IsSingleRow = MUserDefTab.ISSINGLEROW_Yes.equals(userDef.getIsSingleRow());
 
 			if (rs.getString("HasTree").equals("Y"))
 				vo.HasTree = true;
@@ -236,14 +238,25 @@ public class GridTabVO implements Evaluatee, Serializable
 			if (vo.WhereClause.trim().length() > 0) {
 				vo.WhereClause = "("+vo.WhereClause+")";
 			}
-
+			//	Make sure the tab where is not replaced
+			if (userDef != null && userDef.getWhereClause() != null && !userDef.getWhereClause().trim().isEmpty())
+			{
+				if (vo.WhereClause.trim().length() > 0)
+					vo.WhereClause += " AND ";
+				vo.WhereClause += " (" + userDef.getWhereClause() + ")";
+			}
+			
 			vo.OrderByClause = rs.getString("OrderByClause");
 			if (vo.OrderByClause == null)
 				vo.OrderByClause = "";
+			if (userDef != null && userDef.getOrderByClause() != null && !userDef.getOrderByClause().trim().isEmpty())
+				vo.OrderByClause = userDef.getOrderByClause();
 
 			vo.AD_Process_ID = rs.getInt("AD_Process_ID");
 			if (rs.wasNull())
 				vo.AD_Process_ID = 0;
+			if (userDef != null && userDef.getAD_Process_ID() > 0)
+				vo.AD_Process_ID = userDef.getAD_Process_ID();
 			vo.AD_Image_ID = rs.getInt("AD_Image_ID");
 			if (rs.wasNull())
 				vo.AD_Image_ID = 0;

--- a/org.adempiere.base/src/org/compiere/model/I_AD_UserDef_Tab.java
+++ b/org.adempiere.base/src/org/compiere/model/I_AD_UserDef_Tab.java
@@ -62,6 +62,21 @@ public interface I_AD_UserDef_Tab
 	  */
 	public int getAD_Org_ID();
 
+    /** Column name AD_Process_ID */
+    public static final String COLUMNNAME_AD_Process_ID = "AD_Process_ID";
+
+	/** Set Process.
+	  * Process or Report
+	  */
+	public void setAD_Process_ID (int AD_Process_ID);
+
+	/** Get Process.
+	  * Process or Report
+	  */
+	public int getAD_Process_ID();
+
+	public org.compiere.model.I_AD_Process getAD_Process() throws RuntimeException;
+
     /** Column name AD_Tab_ID */
     public static final String COLUMNNAME_AD_Tab_ID = "AD_Tab_ID";
 
@@ -135,6 +150,19 @@ public interface I_AD_UserDef_Tab
 	  */
 	public String getDescription();
 
+    /** Column name DisplayLogic */
+    public static final String COLUMNNAME_DisplayLogic = "DisplayLogic";
+
+	/** Set Display Logic.
+	  * If the Field is displayed, the result determines if the field is actually displayed
+	  */
+	public void setDisplayLogic (String DisplayLogic);
+
+	/** Get Display Logic.
+	  * If the Field is displayed, the result determines if the field is actually displayed
+	  */
+	public String getDisplayLogic();
+
     /** Column name Help */
     public static final String COLUMNNAME_Help = "Help";
 
@@ -180,12 +208,12 @@ public interface I_AD_UserDef_Tab
 	/** Set Read Only.
 	  * Field is read only
 	  */
-	public void setIsReadOnly (boolean IsReadOnly);
+	public void setIsReadOnly (String IsReadOnly);
 
 	/** Get Read Only.
 	  * Field is read only
 	  */
-	public boolean isReadOnly();
+	public String getIsReadOnly();
 
     /** Column name IsSingleRow */
     public static final String COLUMNNAME_IsSingleRow = "IsSingleRow";
@@ -193,12 +221,12 @@ public interface I_AD_UserDef_Tab
 	/** Set Single Row Layout.
 	  * Default for toggle between Single- and Multi-Row (Grid) Layout
 	  */
-	public void setIsSingleRow (boolean IsSingleRow);
+	public void setIsSingleRow (String IsSingleRow);
 
 	/** Get Single Row Layout.
 	  * Default for toggle between Single- and Multi-Row (Grid) Layout
 	  */
-	public boolean isSingleRow();
+	public String getIsSingleRow();
 
     /** Column name Name */
     public static final String COLUMNNAME_Name = "Name";
@@ -213,6 +241,19 @@ public interface I_AD_UserDef_Tab
 	  */
 	public String getName();
 
+    /** Column name OrderByClause */
+    public static final String COLUMNNAME_OrderByClause = "OrderByClause";
+
+	/** Set Sql ORDER BY.
+	  * Fully qualified ORDER BY clause
+	  */
+	public void setOrderByClause (String OrderByClause);
+
+	/** Get Sql ORDER BY.
+	  * Fully qualified ORDER BY clause
+	  */
+	public String getOrderByClause();
+
     /** Column name ReadOnlyLogic */
     public static final String COLUMNNAME_ReadOnlyLogic = "ReadOnlyLogic";
 
@@ -225,6 +266,21 @@ public interface I_AD_UserDef_Tab
 	  * Logic to determine if field is read only (applies only when field is read-write)
 	  */
 	public String getReadOnlyLogic();
+
+    /** Column name SeqNo */
+    public static final String COLUMNNAME_SeqNo = "SeqNo";
+
+	/** Set Sequence.
+	  * Method of ordering records;
+ lowest number comes first
+	  */
+	public void setSeqNo (int SeqNo);
+
+	/** Get Sequence.
+	  * Method of ordering records;
+ lowest number comes first
+	  */
+	public int getSeqNo();
 
     /** Column name Updated */
     public static final String COLUMNNAME_Updated = "Updated";
@@ -241,4 +297,17 @@ public interface I_AD_UserDef_Tab
 	  * User who updated this records
 	  */
 	public int getUpdatedBy();
+
+    /** Column name WhereClause */
+    public static final String COLUMNNAME_WhereClause = "WhereClause";
+
+	/** Set Sql WHERE.
+	  * Fully qualified SQL WHERE clause
+	  */
+	public void setWhereClause (String WhereClause);
+
+	/** Get Sql WHERE.
+	  * Fully qualified SQL WHERE clause
+	  */
+	public String getWhereClause();
 }

--- a/org.adempiere.base/src/org/compiere/model/X_AD_UserDef_Tab.java
+++ b/org.adempiere.base/src/org/compiere/model/X_AD_UserDef_Tab.java
@@ -30,7 +30,7 @@ public class X_AD_UserDef_Tab extends PO implements I_AD_UserDef_Tab, I_Persiste
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20200413L;
+	private static final long serialVersionUID = 20200922L;
 
     /** Standard Constructor */
     public X_AD_UserDef_Tab (Properties ctx, int AD_UserDef_Tab_ID, String trxName)
@@ -42,8 +42,6 @@ public class X_AD_UserDef_Tab extends PO implements I_AD_UserDef_Tab, I_Persiste
 			setAD_UserDef_Tab_ID (0);
 			setAD_UserDef_Win_ID (0);
 			setIsMultiRowOnly (false);
-			setIsReadOnly (false);
-			setIsSingleRow (false);
         } */
     }
 
@@ -74,6 +72,34 @@ public class X_AD_UserDef_Tab extends PO implements I_AD_UserDef_Tab, I_Persiste
         .append(get_ID()).append(",Name=").append(getName()).append("]");
       return sb.toString();
     }
+
+	public org.compiere.model.I_AD_Process getAD_Process() throws RuntimeException
+    {
+		return (org.compiere.model.I_AD_Process)MTable.get(getCtx(), org.compiere.model.I_AD_Process.Table_Name)
+			.getPO(getAD_Process_ID(), get_TrxName());	}
+
+	/** Set Process.
+		@param AD_Process_ID 
+		Process or Report
+	  */
+	public void setAD_Process_ID (int AD_Process_ID)
+	{
+		if (AD_Process_ID < 1) 
+			set_Value (COLUMNNAME_AD_Process_ID, null);
+		else 
+			set_Value (COLUMNNAME_AD_Process_ID, Integer.valueOf(AD_Process_ID));
+	}
+
+	/** Get Process.
+		@return Process or Report
+	  */
+	public int getAD_Process_ID () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_AD_Process_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
 
 	public org.compiere.model.I_AD_Tab getAD_Tab() throws RuntimeException
     {
@@ -187,6 +213,23 @@ public class X_AD_UserDef_Tab extends PO implements I_AD_UserDef_Tab, I_Persiste
 		return (String)get_Value(COLUMNNAME_Description);
 	}
 
+	/** Set Display Logic.
+		@param DisplayLogic 
+		If the Field is displayed, the result determines if the field is actually displayed
+	  */
+	public void setDisplayLogic (String DisplayLogic)
+	{
+		set_Value (COLUMNNAME_DisplayLogic, DisplayLogic);
+	}
+
+	/** Get Display Logic.
+		@return If the Field is displayed, the result determines if the field is actually displayed
+	  */
+	public String getDisplayLogic () 
+	{
+		return (String)get_Value(COLUMNNAME_DisplayLogic);
+	}
+
 	/** Set Comment/Help.
 		@param Help 
 		Comment or Hint
@@ -228,52 +271,52 @@ public class X_AD_UserDef_Tab extends PO implements I_AD_UserDef_Tab, I_Persiste
 		return false;
 	}
 
+	/** IsReadOnly AD_Reference_ID=319 */
+	public static final int ISREADONLY_AD_Reference_ID=319;
+	/** Yes = Y */
+	public static final String ISREADONLY_Yes = "Y";
+	/** No = N */
+	public static final String ISREADONLY_No = "N";
 	/** Set Read Only.
 		@param IsReadOnly 
 		Field is read only
 	  */
-	public void setIsReadOnly (boolean IsReadOnly)
+	public void setIsReadOnly (String IsReadOnly)
 	{
-		set_Value (COLUMNNAME_IsReadOnly, Boolean.valueOf(IsReadOnly));
+
+		set_Value (COLUMNNAME_IsReadOnly, IsReadOnly);
 	}
 
 	/** Get Read Only.
 		@return Field is read only
 	  */
-	public boolean isReadOnly () 
+	public String getIsReadOnly () 
 	{
-		Object oo = get_Value(COLUMNNAME_IsReadOnly);
-		if (oo != null) 
-		{
-			 if (oo instanceof Boolean) 
-				 return ((Boolean)oo).booleanValue(); 
-			return "Y".equals(oo);
-		}
-		return false;
+		return (String)get_Value(COLUMNNAME_IsReadOnly);
 	}
 
+	/** IsSingleRow AD_Reference_ID=319 */
+	public static final int ISSINGLEROW_AD_Reference_ID=319;
+	/** Yes = Y */
+	public static final String ISSINGLEROW_Yes = "Y";
+	/** No = N */
+	public static final String ISSINGLEROW_No = "N";
 	/** Set Single Row Layout.
 		@param IsSingleRow 
 		Default for toggle between Single- and Multi-Row (Grid) Layout
 	  */
-	public void setIsSingleRow (boolean IsSingleRow)
+	public void setIsSingleRow (String IsSingleRow)
 	{
-		set_Value (COLUMNNAME_IsSingleRow, Boolean.valueOf(IsSingleRow));
+
+		set_Value (COLUMNNAME_IsSingleRow, IsSingleRow);
 	}
 
 	/** Get Single Row Layout.
 		@return Default for toggle between Single- and Multi-Row (Grid) Layout
 	  */
-	public boolean isSingleRow () 
+	public String getIsSingleRow () 
 	{
-		Object oo = get_Value(COLUMNNAME_IsSingleRow);
-		if (oo != null) 
-		{
-			 if (oo instanceof Boolean) 
-				 return ((Boolean)oo).booleanValue(); 
-			return "Y".equals(oo);
-		}
-		return false;
+		return (String)get_Value(COLUMNNAME_IsSingleRow);
 	}
 
 	/** Set Name.
@@ -293,6 +336,23 @@ public class X_AD_UserDef_Tab extends PO implements I_AD_UserDef_Tab, I_Persiste
 		return (String)get_Value(COLUMNNAME_Name);
 	}
 
+	/** Set Sql ORDER BY.
+		@param OrderByClause 
+		Fully qualified ORDER BY clause
+	  */
+	public void setOrderByClause (String OrderByClause)
+	{
+		set_Value (COLUMNNAME_OrderByClause, OrderByClause);
+	}
+
+	/** Get Sql ORDER BY.
+		@return Fully qualified ORDER BY clause
+	  */
+	public String getOrderByClause () 
+	{
+		return (String)get_Value(COLUMNNAME_OrderByClause);
+	}
+
 	/** Set Read Only Logic.
 		@param ReadOnlyLogic 
 		Logic to determine if field is read only (applies only when field is read-write)
@@ -308,5 +368,42 @@ public class X_AD_UserDef_Tab extends PO implements I_AD_UserDef_Tab, I_Persiste
 	public String getReadOnlyLogic () 
 	{
 		return (String)get_Value(COLUMNNAME_ReadOnlyLogic);
+	}
+
+	/** Set Sequence.
+		@param SeqNo 
+		Method of ordering records; lowest number comes first
+	  */
+	public void setSeqNo (int SeqNo)
+	{
+		set_Value (COLUMNNAME_SeqNo, Integer.valueOf(SeqNo));
+	}
+
+	/** Get Sequence.
+		@return Method of ordering records; lowest number comes first
+	  */
+	public int getSeqNo () 
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_SeqNo);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Sql WHERE.
+		@param WhereClause 
+		Fully qualified SQL WHERE clause
+	  */
+	public void setWhereClause (String WhereClause)
+	{
+		set_Value (COLUMNNAME_WhereClause, WhereClause);
+	}
+
+	/** Get Sql WHERE.
+		@return Fully qualified SQL WHERE clause
+	  */
+	public String getWhereClause () 
+	{
+		return (String)get_Value(COLUMNNAME_WhereClause);
 	}
 }


### PR DESCRIPTION
This will extend the window customization functionality.
Single Row layout and Read Only fields on window customization are now Lists, so it can be empty. This way the default behaviour will be preserved. You are now able to customize the WHERE clause (it will be appended to original WHERE clause for security reasons), process, order by, display logic and read only logic