### PR TITLE
IDEMPIERE-4475 Can't Run Junit Plugin Test with Eclipse 2020-09

### DIFF
--- a/org.idempiere.p2.targetplatform/org.idempiere.p2.targetplatform.target
+++ b/org.idempiere.p2.targetplatform/org.idempiere.p2.targetplatform.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="idempiere-200519" sequenceNumber="110">
+<target name="idempiere-201003" sequenceNumber="111">
 <locations>
 	<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
 		<repository location="https://idempiere.github.io/binary.file/p2.maven/org.idempiere.webservice.client-p2-R20190412"/>
@@ -73,6 +73,7 @@
 		<unit id="org.eclipse.jdt.feature.group" version="3.18.300.v20200305-0155"/>
 		<unit id="org.eclipse.platform.feature.group" version="4.15.0.v20200305-0155"/>
 		<unit id="org.eclipse.equinox.executable.feature.group" version="3.8.700.v20200207-2156"/>
+		<unit id="org.eclipse.pde.junit.runtime" version="3.5.700.v20200116-1804"/>
 	</location>
 	<location includeAllPlatforms="true" includeConfigurePhase="true" includeMode="slicer" includeSource="true" type="InstallableUnit">
 		<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200224183213/repository"/>


### PR DESCRIPTION
added "org.eclipse.pde.junit.runtime_3.5.700.v20200116-1804"