### PR TITLE
IDEMPIERE-4504:[JR] can't show QR code on jasper report (org/apache/b…

### DIFF
--- a/org.adempiere.report.jasper.library/META-INF/MANIFEST.MF
+++ b/org.adempiere.report.jasper.library/META-INF/MANIFEST.MF
@@ -14,7 +14,5 @@ Bundle-ClassPath: .,
  lib/jasperreports-functions.jar,
  lib/olap4j.jar,
  lib/xmpcore.jar
-DynamicImport-Package: *
-Import-Package: org.w3c.dom.events;version="[3.0.0,4.0.0)"
 Automatic-Module-Name: org.adempiere.report.jasper.library
 Bundle-Vendor: iDempiere Community


### PR DESCRIPTION
…atik/bridge/UserAgent)

1. DynamicImport don't need anymore, it's done on jasper engine already
2. seem batik-11 don't exchange object org.w3c.dom.* with svg anymore, so don't need to force it (and jasper) to use "org.w3c.dom.events version 3.0.0"
with this change all batik lib use org.w3c.dom.* from jdk so jasper engine can wire to it, so can see org.apache.batik.bridge.UserAgent

change of (2) enough to resolve this issue, next time when we get it back then down org.w3c.dom.smil to 1.0.0 to get rid of "org.w3c.dom.events version 3.0.0" will help on complete that hell