### PR TITLE
IDEMPIERE-2902

### DIFF
--- a/migration/i7.1z/oracle/201804111700_TicketAP2-19.sql
+++ b/migration/i7.1z/oracle/201804111700_TicketAP2-19.sql
@@ -1,0 +1,27 @@
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Apr 10, 2018 7:56:35 PM GMT+08:00
+-- Radio Group List
+INSERT INTO AD_Reference (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_UU,Created,CreatedBy,EntityType,IsActive,IsOrderByValue,Name,Updated,UpdatedBy,ValidationType) VALUES (0,0,200152,'bde88a42-3601-499e-a2ee-2185eb6fc785',TO_DATE('2018-04-10 19:56:29','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','N','Radio Group List',TO_DATE('2018-04-10 19:56:29','YYYY-MM-DD HH24:MI:SS'),100,'D')
+;
+
+-- Apr 10, 2018 7:57:56 PM GMT+08:00
+UPDATE AD_Val_Rule SET Code='AD_Reference.ValidationType=CASE WHEN  @AD_Reference_ID@ IN (17,28,200152) THEN ''L'' ELSE ''T'' END',Updated=TO_DATE('2018-04-10 19:57:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Val_Rule_ID=115
+;
+
+-- Apr 10, 2018 8:00:03 PM GMT+08:00
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=30 | @AD_Reference_ID@=28 | @AD_Reference_ID@=200152', AD_Val_Rule_ID=NULL, AD_Reference_Value_ID=NULL, IsToolbarButton=NULL,Updated=TO_DATE('2018-04-10 20:00:03','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=171
+;
+
+-- Apr 10, 2018 8:01:28 PM GMT+08:00
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=30 | @AD_Reference_ID@=28 | @AD_Reference_ID@=200152', AD_Val_Rule_ID=NULL, AD_Reference_Value_ID=NULL, IsToolbarButton=NULL,Updated=TO_DATE('2018-04-10 20:01:28','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=54402
+;
+
+-- Apr 10, 2018 8:02:27 PM GMT+08:00
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=30 | @AD_Reference_ID@=28 | @AD_Reference_ID@=200152', AD_Val_Rule_ID=NULL, AD_Reference_Value_ID=NULL, IsToolbarButton=NULL,Updated=TO_DATE('2018-04-10 20:02:27','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=200855
+;
+
+SELECT register_migration_script('201804111700_TicketAP2-19.sql') FROM dual
+;
+

--- a/migration/i7.1z/oracle/202010241339_IDEMPIERE-2902.sql
+++ b/migration/i7.1z/oracle/202010241339_IDEMPIERE-2902.sql
@@ -1,0 +1,79 @@
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- IDEMPIERE-2902 UX: Implement Radio buttons
+-- Oct 24, 2020, 12:46:20 PM CEST
+UPDATE AD_Val_Rule SET Code='AD_Reference.ValidationType=CASE WHEN  @AD_Reference_ID@ IN (17,28,200152,200161) THEN ''L'' ELSE ''T'' END',Updated=TO_DATE('2020-10-24 12:46:20','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Val_Rule_ID=115
+;
+
+-- Oct 24, 2020, 12:47:54 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=30 | @AD_Reference_ID@=28 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_DATE('2020-10-24 12:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=171
+;
+
+-- Oct 24, 2020, 12:48:35 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=30 | @AD_Reference_ID@=28 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_DATE('2020-10-24 12:48:35','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=54402
+;
+
+-- Oct 24, 2020, 12:49:14 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=30 | @AD_Reference_ID@=28 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_DATE('2020-10-24 12:49:14','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=200855
+;
+
+-- Oct 24, 2020, 12:58:30 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=30 | @AD_Reference_ID@=28 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_DATE('2020-10-24 12:58:30','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=10225
+;
+
+-- Oct 24, 2020, 12:59:32 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=30 | @AD_Reference_ID@=28 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_DATE('2020-10-24 12:59:32','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=201622
+;
+
+-- Oct 24, 2020, 1:01:26 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=30 | @AD_Reference_ID@=28 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163 & @AttributeValueType@=''R''', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_DATE('2020-10-24 13:01:26','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=204144
+;
+
+-- Oct 24, 2020, 1:01:51 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=30 | @AD_Reference_ID@=28 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_DATE('2020-10-24 13:01:51','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=201895
+;
+
+-- Oct 24, 2020, 1:22:34 PM CEST
+UPDATE AD_Column SET AD_Reference_ID=200152,Updated=TO_DATE('2020-10-24 13:22:34','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=53002
+;
+
+-- Oct 24, 2020, 1:26:26 PM CEST
+UPDATE AD_Column SET AD_Reference_ID=200152,Updated=TO_DATE('2020-10-24 13:26:26','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=200989
+;
+
+-- Oct 24, 2020, 1:29:27 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=19 | @AD_Reference_ID@=28 | @AD_Reference_ID@=30 | @AD_Reference_ID@=200012 | @AD_Reference_ID@=31 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_DATE('2020-10-24 13:29:27','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=172
+;
+
+-- Oct 24, 2020, 1:29:46 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=19 | @AD_Reference_ID@=28 | @AD_Reference_ID@=30 | @AD_Reference_ID@=200012 | @AD_Reference_ID@=31 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_DATE('2020-10-24 13:29:45','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206091
+;
+
+-- Oct 24, 2020, 1:31:42 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=19 | @AD_Reference_ID@=28 | @AD_Reference_ID@=30 | @AD_Reference_ID@=200012 | @AD_Reference_ID@=31 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_DATE('2020-10-24 13:31:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=54401
+;
+
+-- Oct 24, 2020, 1:31:49 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=19 | @AD_Reference_ID@=28 | @AD_Reference_ID@=30 | @AD_Reference_ID@=200012 | @AD_Reference_ID@=31 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_DATE('2020-10-24 13:31:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206129
+;
+
+-- Oct 24, 2020, 1:32:45 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=19 | @AD_Reference_ID@=28 | @AD_Reference_ID@=30 | @AD_Reference_ID@=200012 | @AD_Reference_ID@=31 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_DATE('2020-10-24 13:32:45','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=203266
+;
+
+-- Oct 24, 2020, 1:33:17 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=19 | @AD_Reference_ID@=28 | @AD_Reference_ID@=30 | @AD_Reference_ID@=200012 | @AD_Reference_ID@=31 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163 & @AttributeValueType@=''R''', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_DATE('2020-10-24 13:33:17','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206510
+;
+
+-- Oct 24, 2020, 1:33:41 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=19 | @AD_Reference_ID@=28 | @AD_Reference_ID@=30 | @AD_Reference_ID@=200012 | @AD_Reference_ID@=31 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_DATE('2020-10-24 13:33:41','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=201623
+;
+
+-- Oct 24, 2020, 1:38:25 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=19 | @AD_Reference_ID@=28 | @AD_Reference_ID@=30 | @AD_Reference_ID@=200012 | @AD_Reference_ID@=31 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_DATE('2020-10-24 13:38:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206130
+;
+
+SELECT register_migration_script('202010241339_IDEMPIERE-2902.sql') FROM dual
+;
+

--- a/migration/i7.1z/oracle/202010241339_IDEMPIERE-2902.sql
+++ b/migration/i7.1z/oracle/202010241339_IDEMPIERE-2902.sql
@@ -74,6 +74,10 @@ UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | 
 UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=19 | @AD_Reference_ID@=28 | @AD_Reference_ID@=30 | @AD_Reference_ID@=200012 | @AD_Reference_ID@=31 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_DATE('2020-10-24 13:38:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206130
 ;
 
+-- Oct 24, 2020, 1:42:01 PM CEST
+UPDATE AD_Column SET AD_Reference_ID=200152,Updated=TO_DATE('2020-10-24 13:42:01','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=211257
+;
+
 SELECT register_migration_script('202010241339_IDEMPIERE-2902.sql') FROM dual
 ;
 

--- a/migration/i7.1z/postgresql/201804111700_TicketAP2-19.sql
+++ b/migration/i7.1z/postgresql/201804111700_TicketAP2-19.sql
@@ -1,0 +1,24 @@
+-- Apr 10, 2018 7:56:35 PM GMT+08:00
+-- Radio Group List
+INSERT INTO AD_Reference (AD_Client_ID,AD_Org_ID,AD_Reference_ID,AD_Reference_UU,Created,CreatedBy,EntityType,IsActive,IsOrderByValue,Name,Updated,UpdatedBy,ValidationType) VALUES (0,0,200152,'bde88a42-3601-499e-a2ee-2185eb6fc785',TO_TIMESTAMP('2018-04-10 19:56:29','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','N','Radio Group List',TO_TIMESTAMP('2018-04-10 19:56:29','YYYY-MM-DD HH24:MI:SS'),100,'D')
+;
+
+-- Apr 10, 2018 7:57:56 PM GMT+08:00
+UPDATE AD_Val_Rule SET Code='AD_Reference.ValidationType=CASE WHEN  @AD_Reference_ID@ IN (17,28,200152) THEN ''L'' ELSE ''T'' END',Updated=TO_TIMESTAMP('2018-04-10 19:57:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Val_Rule_ID=115
+;
+
+-- Apr 10, 2018 8:00:03 PM GMT+08:00
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=30 | @AD_Reference_ID@=28 | @AD_Reference_ID@=200152', AD_Val_Rule_ID=NULL, AD_Reference_Value_ID=NULL, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2018-04-10 20:00:03','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=171
+;
+
+-- Apr 10, 2018 8:01:28 PM GMT+08:00
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=30 | @AD_Reference_ID@=28 | @AD_Reference_ID@=200152', AD_Val_Rule_ID=NULL, AD_Reference_Value_ID=NULL, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2018-04-10 20:01:28','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=54402
+;
+
+-- Apr 10, 2018 8:02:27 PM GMT+08:00
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=30 | @AD_Reference_ID@=28 | @AD_Reference_ID@=200152', AD_Val_Rule_ID=NULL, AD_Reference_Value_ID=NULL, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2018-04-10 20:02:27','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=200855
+;
+
+SELECT register_migration_script('201804111700_TicketAP2-19.sql') FROM dual
+;
+

--- a/migration/i7.1z/postgresql/202010241339_IDEMPIERE-2902.sql
+++ b/migration/i7.1z/postgresql/202010241339_IDEMPIERE-2902.sql
@@ -71,6 +71,10 @@ UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | 
 UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=19 | @AD_Reference_ID@=28 | @AD_Reference_ID@=30 | @AD_Reference_ID@=200012 | @AD_Reference_ID@=31 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2020-10-24 13:38:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206130
 ;
 
+-- Oct 24, 2020, 1:42:01 PM CEST
+UPDATE AD_Column SET AD_Reference_ID=200152,Updated=TO_TIMESTAMP('2020-10-24 13:42:01','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=211257
+;
+
 SELECT register_migration_script('202010241339_IDEMPIERE-2902.sql') FROM dual
 ;
 

--- a/migration/i7.1z/postgresql/202010241339_IDEMPIERE-2902.sql
+++ b/migration/i7.1z/postgresql/202010241339_IDEMPIERE-2902.sql
@@ -1,0 +1,76 @@
+-- IDEMPIERE-2902 UX: Implement Radio buttons
+-- Oct 24, 2020, 12:46:20 PM CEST
+UPDATE AD_Val_Rule SET Code='AD_Reference.ValidationType=CASE WHEN  @AD_Reference_ID@ IN (17,28,200152,200161) THEN ''L'' ELSE ''T'' END',Updated=TO_TIMESTAMP('2020-10-24 12:46:20','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Val_Rule_ID=115
+;
+
+-- Oct 24, 2020, 12:47:54 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=30 | @AD_Reference_ID@=28 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2020-10-24 12:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=171
+;
+
+-- Oct 24, 2020, 12:48:35 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=30 | @AD_Reference_ID@=28 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2020-10-24 12:48:35','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=54402
+;
+
+-- Oct 24, 2020, 12:49:14 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=30 | @AD_Reference_ID@=28 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2020-10-24 12:49:14','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=200855
+;
+
+-- Oct 24, 2020, 12:58:30 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=30 | @AD_Reference_ID@=28 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2020-10-24 12:58:30','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=10225
+;
+
+-- Oct 24, 2020, 12:59:32 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=30 | @AD_Reference_ID@=28 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2020-10-24 12:59:32','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=201622
+;
+
+-- Oct 24, 2020, 1:01:26 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=30 | @AD_Reference_ID@=28 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163 & @AttributeValueType@=''R''', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2020-10-24 13:01:26','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=204144
+;
+
+-- Oct 24, 2020, 1:01:51 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=30 | @AD_Reference_ID@=28 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2020-10-24 13:01:51','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=201895
+;
+
+-- Oct 24, 2020, 1:22:34 PM CEST
+UPDATE AD_Column SET AD_Reference_ID=200152,Updated=TO_TIMESTAMP('2020-10-24 13:22:34','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=53002
+;
+
+-- Oct 24, 2020, 1:26:26 PM CEST
+UPDATE AD_Column SET AD_Reference_ID=200152,Updated=TO_TIMESTAMP('2020-10-24 13:26:26','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=200989
+;
+
+-- Oct 24, 2020, 1:29:27 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=19 | @AD_Reference_ID@=28 | @AD_Reference_ID@=30 | @AD_Reference_ID@=200012 | @AD_Reference_ID@=31 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2020-10-24 13:29:27','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=172
+;
+
+-- Oct 24, 2020, 1:29:46 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=19 | @AD_Reference_ID@=28 | @AD_Reference_ID@=30 | @AD_Reference_ID@=200012 | @AD_Reference_ID@=31 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2020-10-24 13:29:45','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206091
+;
+
+-- Oct 24, 2020, 1:31:42 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=19 | @AD_Reference_ID@=28 | @AD_Reference_ID@=30 | @AD_Reference_ID@=200012 | @AD_Reference_ID@=31 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2020-10-24 13:31:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=54401
+;
+
+-- Oct 24, 2020, 1:31:49 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=19 | @AD_Reference_ID@=28 | @AD_Reference_ID@=30 | @AD_Reference_ID@=200012 | @AD_Reference_ID@=31 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2020-10-24 13:31:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206129
+;
+
+-- Oct 24, 2020, 1:32:45 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=19 | @AD_Reference_ID@=28 | @AD_Reference_ID@=30 | @AD_Reference_ID@=200012 | @AD_Reference_ID@=31 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2020-10-24 13:32:45','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=203266
+;
+
+-- Oct 24, 2020, 1:33:17 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=19 | @AD_Reference_ID@=28 | @AD_Reference_ID@=30 | @AD_Reference_ID@=200012 | @AD_Reference_ID@=31 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163 & @AttributeValueType@=''R''', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2020-10-24 13:33:17','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206510
+;
+
+-- Oct 24, 2020, 1:33:41 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=19 | @AD_Reference_ID@=28 | @AD_Reference_ID@=30 | @AD_Reference_ID@=200012 | @AD_Reference_ID@=31 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2020-10-24 13:33:41','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=201623
+;
+
+-- Oct 24, 2020, 1:38:25 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=17 | @AD_Reference_ID@=18 | @AD_Reference_ID@=19 | @AD_Reference_ID@=28 | @AD_Reference_ID@=30 | @AD_Reference_ID@=200012 | @AD_Reference_ID@=31 | @AD_Reference_ID@=200152 | @AD_Reference_ID@=200161 | @AD_Reference_ID@=200162 | @AD_Reference_ID@=200163', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2020-10-24 13:38:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206130
+;
+
+SELECT register_migration_script('202010241339_IDEMPIERE-2902.sql') FROM dual
+;
+

--- a/org.adempiere.base/src/org/compiere/model/MLookupFactory.java
+++ b/org.adempiere.base/src/org/compiere/model/MLookupFactory.java
@@ -188,7 +188,7 @@ public class MLookupFactory
 		MLookupInfo info = null;
 		boolean needToAddSecurity = true;
 		//	List
-		if (AD_Reference_ID == DisplayType.List || AD_Reference_ID == DisplayType.ChosenMultipleSelectionList)	//	17
+		if (AD_Reference_ID == DisplayType.List || AD_Reference_ID == DisplayType.ChosenMultipleSelectionList || AD_Reference_ID == DisplayType.RadiogroupList)	//	17
 		{
 			info = getLookup_List(language, AD_Reference_Value_ID);
 			needToAddSecurity = false;

--- a/org.adempiere.base/src/org/compiere/model/SystemIDs.java
+++ b/org.adempiere.base/src/org/compiere/model/SystemIDs.java
@@ -127,6 +127,7 @@ public class SystemIDs
 	public final static int REFERENCE_DATATYPE_PRINTNAME = 42;
 	public final static int REFERENCE_DATATYPE_PRODUCTATTRIBUTE = 35;
 	public final static int REFERENCE_DATATYPE_QUANTITY = 29;
+	public final static int REFERENCE_DATATYPE_RADIOGROUP_LIST= 200152;
 	public final static int REFERENCE_DATATYPE_ROWID = 26;
 	public final static int REFERENCE_DATATYPE_SEARCH = 30;
 	public final static int REFERENCE_DATATYPE_STRING = 10;

--- a/org.adempiere.base/src/org/compiere/util/DisplayType.java
+++ b/org.adempiere.base/src/org/compiere/util/DisplayType.java
@@ -287,6 +287,7 @@ public final class DisplayType
 			|| displayType == URL || displayType == PrinterName
 			|| displayType == SingleSelectionGrid || displayType == Color
 			|| displayType == MultipleSelectionGrid
+			|| displayType == RadiogroupList
 			|| displayType == ChosenMultipleSelectionList
 			|| displayType == ChosenMultipleSelectionTable
 			|| displayType == ChosenMultipleSelectionSearch)

--- a/org.adempiere.base/src/org/compiere/util/DisplayType.java
+++ b/org.adempiere.base/src/org/compiere/util/DisplayType.java
@@ -21,11 +21,13 @@ import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_AMOUNT;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_ASSIGNMENT;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_BINARY;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_BUTTON;
+import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_CHART;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_CHOSEN_MULTIPLE_SELECTION_LIST;
-import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_CHOSEN_MULTIPLE_SELECTION_TABLE;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_CHOSEN_MULTIPLE_SELECTION_SEARCH;
+import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_CHOSEN_MULTIPLE_SELECTION_TABLE;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_COLOR;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_COSTPRICE;
+import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_DASHBOARD_CONTENT;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_DATE;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_DATETIME;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_FILENAME;
@@ -37,13 +39,16 @@ import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_LIST;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_LOCATION;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_LOCATOR;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_MEMO;
+import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_MULTIPLE_SELECTION_GRID;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_NUMBER;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_PAYMENT;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_PRINTNAME;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_PRODUCTATTRIBUTE;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_QUANTITY;
+import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_RADIOGROUP_LIST;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_ROWID;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_SEARCH;
+import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_SINGLE_SELECTION_GRID;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_STRING;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_TABLE;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_TABLEDIR;
@@ -52,10 +57,6 @@ import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_TEXTLONG;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_TIME;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_URL;
 import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_YES_NO;
-import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_CHART;
-import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_DASHBOARD_CONTENT;
-import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_SINGLE_SELECTION_GRID;
-import static org.compiere.model.SystemIDs.REFERENCE_DATATYPE_MULTIPLE_SELECTION_GRID;
 
 import java.text.DateFormat;
 import java.text.DecimalFormat;
@@ -160,6 +161,8 @@ public final class DisplayType
 	public static final int SingleSelectionGrid = REFERENCE_DATATYPE_SINGLE_SELECTION_GRID;
 	
 	public static final int MultipleSelectionGrid = REFERENCE_DATATYPE_MULTIPLE_SELECTION_GRID;
+
+	public static final int RadiogroupList = REFERENCE_DATATYPE_RADIOGROUP_LIST;
 
 	public static final int ChosenMultipleSelectionList = REFERENCE_DATATYPE_CHOSEN_MULTIPLE_SELECTION_LIST;
 	
@@ -327,6 +330,7 @@ public final class DisplayType
 	{
 		if (displayType == List || displayType == Table
 			|| displayType == TableDir || displayType == Search
+			|| displayType == RadiogroupList
 			|| displayType == ChosenMultipleSelectionTable
 			|| displayType == ChosenMultipleSelectionSearch
 			|| displayType == ChosenMultipleSelectionList)
@@ -577,7 +581,7 @@ public final class DisplayType
 	 */
 	public static Class<?> getClass (int displayType, boolean yesNoAsBoolean)
 	{
-		if (isText(displayType) || displayType == List || displayType == Payment)
+		if (isText(displayType) || displayType == List || displayType == Payment || displayType == RadiogroupList)
 			return String.class;
 		else if (isID(displayType) || displayType == Integer)    //  note that Integer is stored as BD
 			return Integer.class;
@@ -656,7 +660,7 @@ public final class DisplayType
 			return getDatabase().getClobDataType();
 		if (displayType == DisplayType.YesNo)
 			return getDatabase().getCharacterDataType()+"(1)";
-		if (displayType == DisplayType.List || displayType == DisplayType.Payment) {
+		if (displayType == DisplayType.List || displayType == DisplayType.Payment || displayType == DisplayType.RadiogroupList) {
 			if (fieldLength == 1)
 				return getDatabase().getCharacterDataType()+"(" + fieldLength + ")";
 			else
@@ -711,6 +715,8 @@ public final class DisplayType
 			return "DateTime";
 		if (displayType == List)
 			return "List";
+		if (displayType == RadiogroupList)
+			return "RadiogroupList";
 		if (displayType == Table)
 			return "Table";
 		if (displayType == TableDir)

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WRadioGroupEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WRadioGroupEditor.java
@@ -1,0 +1,461 @@
+/******************************************************************************
+ * Project: Trek Global ERP                                                   *                       
+ * Copyright (C) 2009-2018 Trek Global Corporation                            *
+ *                                                                            *
+ * Product: Posterita Ajax UI 												  *
+ * Copyright (C) 2007 Posterita Ltd.  All Rights Reserved.                    *
+ * This program is free software; you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program; if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * Posterita Ltd., 3, Draper Avenue, Quatre Bornes, Mauritius                 *
+ * or via info@posterita.org or http://www.posterita.org/                     *
+ *****************************************************************************/
+
+package org.adempiere.webui.editor;
+
+import java.beans.PropertyChangeEvent;
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.List;
+
+import org.adempiere.webui.ValuePreference;
+import org.adempiere.webui.event.ContextMenuEvent;
+import org.adempiere.webui.event.ContextMenuListener;
+import org.adempiere.webui.event.ValueChangeEvent;
+import org.adempiere.webui.window.WFieldRecordInfo;
+import org.compiere.model.GridField;
+import org.compiere.model.Lookup;
+import org.compiere.util.CLogger;
+import org.compiere.util.DisplayType;
+import org.compiere.util.KeyNamePair;
+import org.compiere.util.NamePair;
+import org.compiere.util.Util;
+import org.compiere.util.ValueNamePair;
+import org.zkoss.zk.ui.event.Event;
+import org.zkoss.zk.ui.event.EventListener;
+import org.zkoss.zk.ui.event.Events;
+import org.zkoss.zul.Hlayout;
+import org.zkoss.zul.Radio;
+import org.zkoss.zul.Radiogroup;
+
+/**
+ * 
+ * @author hengsin
+ *
+ */
+public class WRadioGroupEditor extends WEditor implements ContextMenuListener
+{
+    public final static String[] LISTENER_EVENTS = {Events.ON_CHECK};
+    
+    @SuppressWarnings("unused")
+	private static final CLogger logger;
+    
+    static
+    {
+        logger = CLogger.getCLogger(WRadioGroupEditor.class);
+    }
+    
+    private Lookup  lookup;
+    private Object oldValue;
+
+	private boolean onselecting = false;
+
+    public WRadioGroupEditor(GridField gridField)
+    {
+        super(new RadioGroupEditor(), gridField);
+        lookup = gridField.getLookup();
+        init();
+    }
+	
+	/** 
+	 * Constructor for use if a grid field is unavailable
+	 * 
+	 * @param lookup		Store of selectable data
+	 * @param label			column name (not displayed)
+	 * @param description	description of component
+	 * @param mandatory		whether a selection must be made
+	 * @param readonly		whether or not the editor is read only
+	 * @param updateable	whether the editor contents can be changed
+	 */   
+    public WRadioGroupEditor(Lookup lookup, String label, String description, boolean mandatory, boolean readonly, boolean updateable)
+	{
+		super(new RadioGroupEditor(), label, description, mandatory, readonly, updateable);
+		if (lookup == null)
+		{
+			throw new IllegalArgumentException("Lookup cannot be null");
+		}
+		
+		this.lookup = lookup;
+		super.setColumnName(lookup.getColumnName());
+		init();
+	}
+    
+    /**
+     * For ease of porting swing form
+     * @param columnName
+     * @param mandatory
+     * @param isReadOnly
+     * @param isUpdateable
+     * @param lookup
+     */
+    public WRadioGroupEditor(String columnName, boolean mandatory, boolean isReadOnly, boolean isUpdateable,
+    		Lookup lookup)
+    {
+    	super(new RadioGroupEditor(), columnName, null, null, mandatory, isReadOnly, isUpdateable);
+    	if (lookup == null)
+		{
+			throw new IllegalArgumentException("Lookup cannot be null");
+		}
+    	this.lookup = lookup;
+    	init();
+    }
+    
+    private void init()
+    {
+        if (lookup != null)
+        {
+            lookup.setMandatory(isMandatory());
+            
+            refreshList();            
+        }        
+    }
+
+    @Override
+    public String getDisplay()
+    {
+
+        String display = null;
+        Radio selItem = getComponent().getSelectedItem();
+        if (selItem != null)
+        {
+        	display = selItem.getLabel();
+        }
+        return display;
+    }
+
+    @Override
+    public Object getValue()
+    {
+        Object retVal = null;
+        Radio selItem = getComponent().getSelectedItem();
+        if (selItem != null)
+        {
+            retVal = selItem.getValue();
+            if ((retVal instanceof Integer) && (Integer)retVal == -1)
+            	retVal = null;
+            else if ((retVal instanceof String) && "".equals(retVal))
+            	retVal = null;
+        }
+        return retVal;
+    }
+
+    public void setValue(Object value)
+    {
+    	if (onselecting) {
+    		return;
+    	}
+    	
+    	if (value != null && (value instanceof Integer || value instanceof String || value instanceof Timestamp || value instanceof BigDecimal))
+        {
+
+            getComponent().setValue(value);            
+            if (!getComponent().isSelected(value))
+            {
+            	Object curValue = oldValue;
+                oldValue = value;
+                
+            	if (value instanceof Integer && gridField != null && gridField.getDisplayType() != DisplayType.ID && 
+            			(gridTab==null || !gridTab.getTableModel().isImporting())) // for IDs is ok to be out of the list
+            	{
+            		getComponent().setValue(null);
+            		if (curValue == null)
+            			curValue = value;
+            		ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), curValue, null);
+        	        super.fireValueChange(changeEvent);
+            		oldValue = null;
+            	}
+            }
+            else
+            {
+            	oldValue = value;
+            }
+        }
+        else
+        {
+            getComponent().setValue(null);
+            oldValue = value;
+        }                                
+    }
+    
+    @Override
+	public RadioGroupEditor getComponent() {
+		return (RadioGroupEditor) component;
+	}
+
+	@Override
+	public boolean isReadWrite() {
+		return getComponent().isEnabled();
+	}
+
+	@Override
+	public void setReadWrite(boolean readWrite) {
+		getComponent().setEnabled(readWrite);
+	}
+
+	private void refreshList()
+    {
+    	if (getComponent().getItemCount() > 0)
+    		getComponent().removeAllItems();
+
+        if (lookup != null)
+        {
+        	lookup.refresh();
+            int size = lookup.getSize();
+            
+            boolean found = false;
+            for (int i = 0; i < size; i++)
+            {
+                Object obj = lookup.getElementAt(i);
+                if (obj instanceof KeyNamePair)
+                {
+                    KeyNamePair lookupKNPair = (KeyNamePair) obj;
+                    getComponent().appendItem(lookupKNPair.getName(), lookupKNPair.getKey());
+                    if (!found && oldValue != null && oldValue instanceof Integer &&
+                    	lookupKNPair.getKey() == (Integer)oldValue)
+                    {
+                    	found = true;
+                	}
+                }
+                else if (obj instanceof ValueNamePair)
+                {
+                    ValueNamePair lookupKNPair = (ValueNamePair) obj;
+                    getComponent().appendItem(lookupKNPair.getName(), lookupKNPair.getValue());
+                    if (!found && oldValue != null && lookupKNPair.getValue().equals(oldValue.toString()))
+	                {
+                    	found = true;
+                	}
+            	}
+        	}	        	        
+            if (!found && oldValue != null)
+            {
+            	NamePair pair = lookup.getDirect(oldValue, false, true);
+            	if (pair != null) {
+	    			if (pair instanceof KeyNamePair) {
+	    				int key = ((KeyNamePair)pair).getKey();
+	    				getComponent().appendItem(pair.getName(), key);
+	    			} else if (pair instanceof ValueNamePair) {
+	    				ValueNamePair valueNamePair = (ValueNamePair) pair;
+	                    getComponent().appendItem(valueNamePair.getName(), valueNamePair.getValue());
+	    			}
+            	}
+            }
+        }
+    	getComponent().setValue(oldValue);
+    }
+    
+    public void onEvent(Event event)
+    {
+    	if (Events.ON_CHECK.equalsIgnoreCase(event.getName()))
+    	{
+    		try {
+    			onselecting = true;
+		        Object newValue = getValue();
+		        if (isValueChange(newValue)) {
+		        	try {
+		        		if (gridField != null) 
+		        			gridField.setLookupEditorSettingValue(true);
+				        ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), oldValue, newValue);
+				        super.fireValueChange(changeEvent);
+				        oldValue = newValue;
+		    			getComponent().setValue(newValue);
+		        	} finally {
+		        		if (gridField != null) 
+		        			gridField.setLookupEditorSettingValue(false);
+		        	}
+		        }
+    		} finally {
+    			onselecting = false;
+    		}
+    	}
+    }
+
+	private boolean isValueChange(Object newValue) {
+		return (oldValue == null && newValue != null) || (oldValue != null && newValue == null) 
+			|| ((oldValue != null && newValue != null) && !oldValue.equals(newValue));
+	}
+    
+    public String[] getEvents()
+    {
+        return LISTENER_EVENTS;
+    }
+
+    public void actionRefresh()
+    {    	
+		if (lookup != null)
+        {
+			Object curValue = getValue();
+			
+			refreshList();
+            if (curValue != null)
+            {
+            	setValue(curValue);
+            }
+        }
+    }
+    
+    public Lookup getLookup()
+    {
+    	return lookup;
+    }
+    
+	public void onMenu(ContextMenuEvent evt) 
+	{
+		if (WEditorPopupMenu.REQUERY_EVENT.equals(evt.getContextEvent()))
+		{
+			actionRefresh();
+		}
+		else if (WEditorPopupMenu.PREFERENCE_EVENT.equals(evt.getContextEvent()))
+		{
+			if (isShowPreference())
+				ValuePreference.start (getComponent(), this.getGridField(), getValue());
+			return;
+		}
+		else if (WEditorPopupMenu.CHANGE_LOG_EVENT.equals(evt.getContextEvent()))
+		{
+			WFieldRecordInfo.start(gridField);
+		}
+	}
+	
+	public  void propertyChange(PropertyChangeEvent evt)
+	{
+		if ("FieldValue".equals(evt.getPropertyName()))
+		{
+			setValue(evt.getNewValue());
+		}
+	}
+	
+	@Override
+	public void dynamicDisplay()
+    {    	
+		super.dynamicDisplay();
+    }
+	
+	private static class RadioGroupEditor extends Hlayout {
+		/**
+		 * generated serial id
+		 */
+		private static final long serialVersionUID = -8814498538711459900L;
+		private Radiogroup radioGroup;
+		private boolean enabled;
+		
+		private RadioGroupEditor() {
+			radioGroup = new Radiogroup();
+			appendChild(radioGroup);
+			enabled = true;
+			setSpacing("0");
+			setStyle("white-space: normal");
+		}
+		
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(boolean readWrite) {
+			enabled = readWrite;
+			List<Radio> items = radioGroup.getItems();
+			for (Radio radio : items) {
+				radio.setDisabled(!readWrite);
+			}
+		}
+
+		public boolean isSelected(Object value) {
+			List<Radio> items = radioGroup.getItems();
+			for (Radio radio : items) {
+				if (radio.getValue() != null && radio.getValue().equals(value)) {
+					return true;
+				}
+			}
+			return false;
+		}
+
+		public Radio getSelectedItem() {
+			return radioGroup.getSelectedItem();
+		}
+
+		public void removeAllItems() {
+			List<Radio> items = radioGroup.getItems();
+			for (Radio radio : items) {
+				radio.detach();
+			}
+		}
+
+		public void setValue(Object newValue) {
+			List<Radio> items = radioGroup.getItems();
+			radioGroup.setSelectedItem(null);
+			for (Radio radio : items) {
+				if (radio.getValue() != null && radio.getValue().equals(newValue)) {
+					radioGroup.setSelectedItem(radio);
+					break;
+				}
+			}
+		}
+
+		public int getItemCount() {
+			return radioGroup.getItemCount();
+		}
+
+		public void appendItem(String name, String value) {
+			if (Util.isEmpty(name))
+				return;
+			Radio radio = new Radio(name);
+			radio.setValue(value);
+			radio.setRadiogroup(radioGroup);
+			radio.setDisabled(!enabled);
+			radio.setStyle("padding-right:1em");
+			appendChild(radio);
+		}
+
+		public void appendItem(String name, int key) {
+			if (Util.isEmpty(name))
+				return;
+			Radio radio = new Radio(name);
+			radio.setValue(key);
+			radio.setRadiogroup(radioGroup);
+			radio.setDisabled(!enabled);
+			appendChild(radio);
+		}
+
+		@Override
+		public boolean addEventListener(String evtnm, EventListener<? extends Event> listener) {
+			if (Events.ON_CHECK.equals(evtnm))
+				return radioGroup.addEventListener(evtnm, listener);
+			else
+				return super.addEventListener(evtnm, listener);
+		}
+
+		@Override
+		public boolean addEventListener(int priority, String evtnm, EventListener<? extends Event> listener) {
+			if (Events.ON_CHECK.equals(evtnm))
+				return radioGroup.addEventListener(priority, evtnm, listener);
+			else
+				return super.addEventListener(priority, evtnm, listener);
+		}
+
+		@Override
+		public boolean removeEventListener(String evtnm, EventListener<? extends Event> listener) {
+			if (Events.ON_CHECK.equals(evtnm))
+				return radioGroup.removeEventListener(evtnm, listener);
+			else
+				return super.removeEventListener(evtnm, listener);
+		}
+		
+		
+	}	
+}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/DefaultEditorFactory.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/DefaultEditorFactory.java
@@ -34,6 +34,7 @@ import org.adempiere.webui.editor.WNumberEditor;
 import org.adempiere.webui.editor.WPAttributeEditor;
 import org.adempiere.webui.editor.WPasswordEditor;
 import org.adempiere.webui.editor.WPaymentEditor;
+import org.adempiere.webui.editor.WRadioGroupEditor;
 import org.adempiere.webui.editor.WSearchEditor;
 import org.adempiere.webui.editor.WStringEditor;
 import org.adempiere.webui.editor.WTableDirEditor;
@@ -218,6 +219,10 @@ public class DefaultEditorFactory implements IEditorFactory {
         else if (displayType == DisplayType.ChosenMultipleSelectionSearch)
         {
         	editor = new WChosenboxSearchEditor(gridField);
+        }
+        else if (displayType == DisplayType.RadiogroupList)
+        {
+        	editor = new WRadioGroupEditor(gridField);
         }
         else
         {


### PR DESCRIPTION
Hi @hengsin - I integrated this code from TrekGlobal into [IDEMPIERE-2902](https://idempiere.atlassian.net/browse/IDEMPIERE-2902).

The [commit 8263265](https://github.com/CarlosRuiz-globalqss/idempiere/commit/8263265) fixes one issue in DisplayType that was making the ColumnSync process to fail when there was a default value without quotes.

Also, I fixed the validation rule and 15 display logics to include other references that were missing.

For testing and UX purposes I configured as Radio Group the fields:
Broadcast Message > Broadcast Message > Target
Field Group > Field group > Field Group Type
Info Window > Process > LayoutType

Now, visually the component looks good and is working fine, but I found some issues, if you can please take a look if is easily solvable:

* The context menu options _Zoom_, _Value Pref_, _Change Log_ are not being set
* Not sure if is worthy and possible to implement the context menu _Requery_
* The context menu _Field Suggestions_ appears twice

I also found a big issue when the component is rendered on a grid first, this is the case:

Broadcast Message > Broadcast Message > Target
Field Group > Field group > Field Group Type
* These two are in the first tab of the window and it's working perfect

Info Window > Process > LayoutType
* This field is in a detail tab and it has some problems depending on how you navigate on the window:
  * When you open the window _Info Window_, then navigate to _Column_ tab (detail), and from there you change to the _Process_ tab, the field works perfect
  * But when you open the window _Info Window_, then double click on the tab _Process_, navigating to the tab, the field behaves badly:
    * The options are Read-Only, cannot be edited
    * If you save, the default on the database will save a _B_, but if you reopen the window and try to edit that field, it cannot be saved as it's setting always the value to null, and the red color of the label never goes away

I tested setting a breakpoint in WRadioGroupEditor.setEnabled:371 and noticed that in the first case (not detail navigation) is creating one read-write editor, but when navigating as the second case, it seems to create several editors, and one of them is read-only.  I suspect maybe this is not related to this specific Editor, but maybe something bigger happening when navigating to a detail that way.

Can you please take a look?

Regards,

Carlos Ruiz
