### PR TITLE
IDEMPIERE-4482 Mobile Improvements - Font

### DIFF
--- a/org.adempiere.ui.zk/theme/default/css/theme.css.dsp
+++ b/org.adempiere.ui.zk/theme/default/css/theme.css.dsp
@@ -26,7 +26,7 @@ html,body {
 .tablet-scrolling {
 	-webkit-overflow-scrolling: touch;
 }
-.mobile [class*="z-"]:not([class*="z-icon-"]) {
+.mobile [class*="z-"] {
     font-size: 16px;
 }
 


### PR DESCRIPTION
For mobile, a uniform default font-size of 16 for everything (including
z-icon and z-group-icon) seems to work better.