### PR TITLE
IDEMPIERE-2490 java.lang.IllegalStateException: Form too large

### DIFF
--- a/org.adempiere.server-feature/jettyhome/etc/jetty-template.xml
+++ b/org.adempiere.server-feature/jettyhome/etc/jetty-template.xml
@@ -111,12 +111,6 @@
     <Set name="dumpAfterStart"><Property name="jetty.server.dumpAfterStart" deprecated="jetty.dump.start" default="false"/></Set>
     <Set name="dumpBeforeStop"><Property name="jetty.server.dumpBeforeStop" deprecated="jetty.dump.stop" default="false"/></Set>
 	
-	<!-- IDEMPIERE-2490 -->
-	<Call name="setAttribute">
-      <Arg>org.eclipse.jetty.server.Request.maxFormContentSize</Arg>
-      <Arg>1048576</Arg>
-    </Call>
-    
     <!-- IDEMPIERE-2761 -->
     <Set class="org.eclipse.jetty.util.resource.Resource" name="defaultUseCaches">false</Set>
     

--- a/org.adempiere.ui.zk/WEB-INF/jetty-web.xml
+++ b/org.adempiere.ui.zk/WEB-INF/jetty-web.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+	<!-- IDEMPIERE-2490 -->
+	<Set name="maxFormContentSize">1048576</Set>
+</Configure>


### PR DESCRIPTION
replace the now defunc setting at jetty.xml with jetty-web.xml