### PR TITLE
IDEMPIERE-4468 Pass the current value of numberbox to the textfield o…

### DIFF
--- a/org.adempiere.ui.zk/js/calc.js
+++ b/org.adempiere.ui.zk/js/calc.js
@@ -6,6 +6,7 @@ function Calc()
 	this.clearAll = clearAll;
 	this.evaluate = evaluate;
 	this.append = append;
+	this.appendOnCursor = appendOnCursor;
 
 	function validateDown(displayTextId, calcTextId, integral, separatorKey, e, processDotKeypad)
 	{
@@ -21,7 +22,7 @@ function Calc()
 	     }
 	     else if (processDotKeypad && (key == 108 || key == 110 || key == 188 || key == 190 || key == 194))
 	     {
-	     	append(calcTextId, String.fromCharCode(separatorKey));
+	    	appendOnCursor(calcTextId, String.fromCharCode(separatorKey));
 	     	e.stop;
 	     }
 	}
@@ -104,6 +105,17 @@ function Calc()
 		var id = "$".concat(calcTextId);
 		var calcText = jq(id)[0];
 		calcText.value += val;
+		calcText.focus();
+	}
+
+	function appendOnCursor(calcTextId, val)
+	{
+		var id = "$".concat(calcTextId);
+		var calcText = jq(id)[0];
+		var position = calcText.selectionStart;
+		var newValue = calcText.value.substring(0, position) + val + calcText.value.substring(position);
+		calcText.value = newValue;
+		calcText.setSelectionRange(position+1, position+1);
 	}
 }
 


### PR DESCRIPTION
…f calculator

[IDEMPIERE-2003](https://idempiere.atlassian.net/browse/IDEMPIERE-2003) Capturing wrong numbers with numeric keypad when decimal separator is not dot

- Simplify the code for [IDEMPIERE-4468](https://idempiere.atlassian.net/browse/IDEMPIERE-4468) using Clients.evalJavaScript
- Fix IDEMPIERE-4468 to work in sync with IDEMPIERE-2003
- Improve IDEMPIERE-4468 to set the cursor at the end of the passed value
- Improve IDEMPIERE-2003 to insert the comma separator where the cursor is
- Simplify the code for IDEMPIERE-2003, there was a code calling setWidgetListener onKeyDown and doKeyPress_
  Probably required for old browsers, tested without that code with actual chromium and firefox and both worked perfect