### PR TITLE
IDEMPIERE-4268 Fix recursive call to PO

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/PO.java
+++ b/org.adempiere.base/src/org/compiere/model/PO.java
@@ -4986,7 +4986,7 @@ public abstract class PO
 			int poClientID = getAD_Client_ID();
 			if (poClientID != envClientID &&
 					(poClientID != 0 || writing)) {
-				log.severe("Table="+get_TableName()+" Record_ID="+get_ID()+" Env.AD_Client_ID="+envClientID+" PO.AD_Client_ID="+poClientID);
+				log.warning("Table="+get_TableName()+" Record_ID="+get_ID()+" Env.AD_Client_ID="+envClientID+" PO.AD_Client_ID="+poClientID);
 				String message = "Cross tenant PO request detected from session " 
 						+ Env.getContext(getCtx(), "#AD_Session_ID") + " for table " + get_TableName()
 						+ " Record_ID=" + get_ID();

--- a/org.adempiere.base/src/org/compiere/model/PO.java
+++ b/org.adempiere.base/src/org/compiere/model/PO.java
@@ -4986,8 +4986,13 @@ public abstract class PO
 			int poClientID = getAD_Client_ID();
 			if (poClientID != envClientID &&
 					(poClientID != 0 || writing)) {
-				log.warning("Table="+get_TableName()+" Record_ID="+get_ID()+" Env.AD_Client_ID="+envClientID+" PO.AD_Client_ID="+poClientID);
-				String message = "Cross tenant PO request detected from session " 
+				log.warning("Table="+get_TableName()
+					+" Record_ID="+get_ID()
+					+" Env.AD_Client_ID="+envClientID
+					+" PO.AD_Client_ID="+poClientID
+					+" writing="+writing
+					+" Session="+Env.getContext(getCtx(), "#AD_Session_ID"));
+				String message = "Cross tenant PO " + (writing ? "writing" : "reading") + " request detected from session " 
 						+ Env.getContext(getCtx(), "#AD_Session_ID") + " for table " + get_TableName()
 						+ " Record_ID=" + get_ID();
 				throw new AdempiereException(message);

--- a/org.adempiere.base/src/org/compiere/wf/MWorkflow.java
+++ b/org.adempiere.base/src/org/compiere/wf/MWorkflow.java
@@ -130,11 +130,23 @@ public class MWorkflow extends X_AD_Workflow implements ImmutablePOSupport
 		if (s_cacheDocValue.isReset())
 		{
 			final String whereClause = "WorkflowType=? AND IsValid=?";
-			List<MWorkflow> workflows = new Query(ctx, Table_Name, whereClause, trxName)
-				.setParameters(new Object[]{WORKFLOWTYPE_DocumentValue, true})
-				.setOnlyActiveRecords(true)
-				.setOrderBy("AD_Client_ID, AD_Table_ID")
-				.list();
+			List<MWorkflow> workflows;
+			int cid = Env.getAD_Client_ID(Env.getCtx());
+			try {
+				if (cid > 0) {
+					// forced potential cross tenant read - requires System client in context
+					Env.setContext(Env.getCtx(), Env.AD_CLIENT_ID, 0);
+				}
+				workflows = new Query(ctx, Table_Name, whereClause, trxName)
+						.setParameters(new Object[]{WORKFLOWTYPE_DocumentValue, true})
+						.setOnlyActiveRecords(true)
+						.setOrderBy("AD_Client_ID, AD_Table_ID")
+						.list();
+			} finally {
+				if (cid > 0) {
+					Env.setContext(Env.getCtx(), Env.AD_CLIENT_ID, cid);
+				}
+			}
 			ArrayList<MWorkflow> list = new ArrayList<MWorkflow>();
 			String oldKey = "";
 			String newKey = null;


### PR DESCRIPTION
Found a case where PO.checkValidClient fails, and then because of log.severe it tries to create a record with MIssue, and the PO.checkValidClient fails in MIssue, and is called recursively until it fails with a "Trx.run: Transaction timeout."

https://idempiere.atlassian.net/browse/IDEMPIERE-4268