### PR TITLE
IDEMPIERE-4268 Web Services : Read miss cross-tenant check

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MUserDefWin.java
+++ b/org.adempiere.base/src/org/compiere/model/MUserDefWin.java
@@ -104,7 +104,20 @@ public class MUserDefWin extends X_AD_UserDef_Win implements ImmutablePOSupport
 	private static MUserDefWin[] getAll (Properties ctx, int window_ID )
 	{
 		if (m_fullList == null) {
-			m_fullList = new Query(ctx, MUserDefWin.Table_Name, "IsActive='Y'", null).list();
+			int cid = Env.getAD_Client_ID(Env.getCtx());
+			try {
+				if (cid > 0) {
+					// forced potential cross tenant read - requires System client in context
+					Env.setContext(Env.getCtx(), Env.AD_CLIENT_ID, 0);
+				}
+				m_fullList = new Query(ctx, MUserDefWin.Table_Name, null, null)
+						.setOnlyActiveRecords(true)
+						.list();
+			} finally {
+				if (cid > 0) {
+					Env.setContext(Env.getCtx(), Env.AD_CLIENT_ID, cid);
+				}
+			}
 		}
 		
 		if (m_fullList.size() == 0) {


### PR DESCRIPTION
Fixes:
org.adempiere.exceptions.AdempiereException: Cross tenant PO reading request detected from session 1009629 for table AD_UserDef_Win Record_ID=1000002
	at org.compiere.model.PO.checkValidClient(PO.java:5000)
	at org.compiere.model.PO.<init>(PO.java:212)
	at org.adempiere.model.GenericPO.<init>(GenericPO.java:81)
	at org.compiere.model.MTable.getPO(MTable.java:598)
	at org.compiere.model.Query.list(Query.java:286)
	at org.compiere.model.MUserDefWin.getAll(MUserDefWin.java:107)
	at org.compiere.model.MUserDefWin.getBestMatch(MUserDefWin.java:160)

https://idempiere.atlassian.net/browse/IDEMPIERE-4268