### PR TITLE
IDEMPIERE-4268 Web Services : Read miss cross-tenant check

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MUserDefWin.java
+++ b/org.adempiere.base/src/org/compiere/model/MUserDefWin.java
@@ -36,6 +36,7 @@ public class MUserDefWin extends X_AD_UserDef_Win implements ImmutablePOSupport
 	 */
 	private static final long serialVersionUID = -7542708120229671875L;
 	private volatile static List<MUserDefWin> m_fullList = null;
+	private static final Object m_fullListLock = new Object();
 
 	/**
 	 * 	Standard constructor.
@@ -103,14 +104,13 @@ public class MUserDefWin extends X_AD_UserDef_Win implements ImmutablePOSupport
 	 */
 	private static MUserDefWin[] getAll (Properties ctx, int window_ID )
 	{
-		if (m_fullList == null) {
-			try {
-				PO.setCrossTenantSafe();
-				m_fullList = new Query(ctx, MUserDefWin.Table_Name, null, null)
-						.setOnlyActiveRecords(true)
-						.list();
-			} finally {
-				PO.clearCrossTenantSafe();
+		synchronized (m_fullListLock) {
+			if (m_fullList == null) {
+				Env.runAsSystemTenant(() -> {
+					m_fullList = new Query(ctx, MUserDefWin.Table_Name, null, null)
+							.setOnlyActiveRecords(true)
+							.list();
+				});
 			}
 		}
 		

--- a/org.adempiere.base/src/org/compiere/model/PO.java
+++ b/org.adempiere.base/src/org/compiere/model/PO.java
@@ -209,7 +209,7 @@ public abstract class PO
 		else
 			load(ID, trxName);
 
-		checkValidClient(false);
+		checkCrossTenant(false);
 	}   //  PO
 
 	/**
@@ -2082,7 +2082,7 @@ public abstract class PO
 		checkImmutable();
 		
 		checkValidContext();
-		checkValidClient(true);
+		checkCrossTenant(true);
 		CLogger.resetLast();
 		boolean newRecord = is_new();	//	save locally as load resets
 		if (!newRecord && !is_Changed())
@@ -3270,7 +3270,7 @@ public abstract class PO
 		checkImmutable();
 		
 		checkValidContext();
-		checkValidClient(true);
+		checkCrossTenant(true);
 		CLogger.resetLast();
 		if (is_new())
 			return true;
@@ -4981,30 +4981,7 @@ public abstract class PO
 			throw new AdempiereException("Context lost");
 	}
 
-	/*
-	 * To force a cross tenant safe read/write the client program must write code like this:
-		try {
-			PO.setCrossTenantSafe();
-			// write here the Query.list or PO.saveEx that is cross tenant safe
-		} finally {
-			PO.clearCrossTenantSafe();
-		}
-	 */
-	private static ThreadLocal<Boolean> isSafeCrossTenant = new ThreadLocal<Boolean>() {
-		@Override protected Boolean initialValue() {
-			return Boolean.FALSE;
-		};
-	};
-	public static void setCrossTenantSafe() {
-		isSafeCrossTenant.set(Boolean.TRUE);
-	}
-	public static void clearCrossTenantSafe() {
-		isSafeCrossTenant.set(Boolean.FALSE);
-	}
-
-	private void checkValidClient(boolean writing) {
-		if (isSafeCrossTenant.get())
-			return;
+	private void checkCrossTenant(boolean writing) {
 		int envClientID = Env.getAD_Client_ID(getCtx());
 		// processes running from system client can read/write always
 		if (envClientID > 0) {

--- a/org.adempiere.base/src/org/compiere/util/Env.java
+++ b/org.adempiere.base/src/org/compiere/util/Env.java
@@ -2039,7 +2039,26 @@ public final class Env
 		return AD_Window_ID;
 	}
 	
-	
+	/**
+	 * Temporary switch to system tenant and invoke runnable.
+	 * This should only be use if absolutely necessary due to the security risk involve. 
+	 * @param runnable
+	 */
+	public static void runAsSystemTenant(Runnable runnable) {
+		Properties currentContext = ServerContext.getCurrentInstance();
+		if (Env.getAD_Client_ID(currentContext) != 0) {
+			try {
+				Properties temp = new Properties(currentContext);
+				Env.setContext(temp, AD_CLIENT_ID, 0);
+				ServerContext.setCurrentInstance(temp);
+				runnable.run();
+			} finally {
+				ServerContext.setCurrentInstance(currentContext);
+			}
+		} else {
+			runnable.run();
+		}
+	}
 	
 	/**************************************************************************
 	 *  Static Variables


### PR DESCRIPTION
- Use a different approach that doesn't add strange API to PO. The new
API reduce chance of mistake and give clearer picture of what's the
intention. Also, it sounds more correct to perform the cross tenant
operation with the active context's AD_Client_ID=0
- rename checkValidContext(boolean) to checkCrossTenant(boolean)