### PR TITLE
IDEMPIERE-4287 Cache API not thread safe and inconsistent with contex…

### DIFF
--- a/org.adempiere.base/src/org/compiere/wf/WorkflowValidate.java
+++ b/org.adempiere.base/src/org/compiere/wf/WorkflowValidate.java
@@ -48,7 +48,7 @@ public class WorkflowValidate extends SvrProcess
 	 */
 	protected String doIt () throws Exception
 	{
-		MWorkflow wf = MWorkflow.get (getCtx(), p_AD_Worlflow_ID);
+		MWorkflow wf = new MWorkflow(getCtx(), p_AD_Worlflow_ID, get_TrxName());
 		if (log.isLoggable(Level.INFO)) log.info("WF=" + wf);
 		
 		String msg = wf.validate();


### PR DESCRIPTION
…t parameter

- Fix PO immutable exception with Workflow Validate process.