### PR TITLE
IDEMPIERE-4602 Encrypt passwords on properties files (FHCA-1982)

### DIFF
--- a/org.adempiere.server-feature/build.xml
+++ b/org.adempiere.server-feature/build.xml
@@ -49,6 +49,7 @@
 			tofile="jettyhome/etc/jetty-http.xml" filtering="yes" overwrite="yes"/>
 		<copy file="hazelcast-template.xml"
 			tofile="hazelcast.xml" filtering="yes" overwrite="yes"/>
+		<chmod file="jettyhome/etc/jetty-ssl-context.xml" perm="0600"/>
 
 		<mkdir dir="jettyhome/work"/>
 		<mkdir dir="log"/>
@@ -98,6 +99,9 @@
 		<!--	Fix OS stuff	-->
 		<fixcrlf srcdir="." eol="lf" eof="remove" includes="**/*.sh" />
 		<chmod dir="." perm="ugo+x" includes="**/*.sh" />
+		<chmod file="idempiereEnv.properties" perm="0600"/>
+		<chmod file="idempiere.properties" perm="0600"/>
+		<chmod file="utils/myEnvironment.sh" perm="0700"/>
 
 		<delete>
 			<fileset dir="." includes="*.bat" />

--- a/org.adempiere.server-feature/console-setup-alt.sh
+++ b/org.adempiere.server-feature/console-setup-alt.sh
@@ -19,11 +19,5 @@ $JAVA -jar plugins/org.eclipse.equinox.launcher_1.*.jar -install setup -configur
 # Setup Jetty
 $JAVA -jar plugins/org.eclipse.equinox.launcher_1.*.jar -install setup -configuration setup/configuration -application org.eclipse.ant.core.antRunner -buildfile build.xml
 
-echo ===================================
-echo Make .sh executable & set Env
-echo ===================================
-chmod -R a+x -- *.sh
-find . -name '*.sh' -exec chmod a+x '{}' \;
-
 echo .
 echo For problems, check log file in base directory

--- a/org.adempiere.server-feature/hazelcast-template.xml
+++ b/org.adempiere.server-feature/hazelcast-template.xml
@@ -32,7 +32,7 @@
            http://www.hazelcast.com/schema/config/hazelcast-config-3.11.xsd">
 
     <group>
-        <name>@ADEMPIERE_DB_USER@.@ADEMPIERE_DB_NAME@/@ADEMPIERE_DB_SERVER@</name>
+        <name>@ADEMPIERE_DB_USER@.@ADEMPIERE_DB_NAME@/@ADEMPIERE_DB_SERVER@:@ADEMPIERE_DB_PORT@</name>
         <!-- https://github.com/hazelcast/hazelcast/issues/11667 -->
     </group>
     <management-center enabled="false">http://localhost:8080/hazelcast-mancenter</management-center>

--- a/org.adempiere.server-feature/setup-alt.sh
+++ b/org.adempiere.server-feature/setup-alt.sh
@@ -19,9 +19,5 @@ echo ... Setup Jetty
 #setup jetty
 $JAVA -jar plugins/org.eclipse.equinox.launcher_1.*.jar -install setup -configuration setup/configuration -application org.eclipse.ant.core.antRunner -buildfile build.xml
 
-echo ... Make .sh executable
-chmod -R a+x -- *.sh
-find . -name '*.sh' -exec chmod a+x '{}' \;
-
 echo ...
 echo For problems, check log file in base directory


### PR DESCRIPTION
* Secure sensitive files containing passwords at the end of build.xml for linux
  * jettyhome/etc/jetty-ssl-context.xml - contains keystore password
  * idempiereEnv.properties, idempiere.properties, utils/myEnvironment.sh - contain database and other passwords
* setup-alt.sh and console-setup-alt.sh don't need to chmod as the ant task already did it
* add port to hazelcast-template.xml (useful in case there are same databases in different ports on the server)

https://idempiere.atlassian.net/browse/IDEMPIERE-4602