### PR TITLE
IDEMPIERE-4620 Improvements for Setup programs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ External Plug-in Libraries
 /org.idempiere.javadoc/API
 /.sonarlint/
 **/org.sonarlint.eclipse.core.prefs
+/runtime-*.app/

--- a/org.adempiere.install/install.silent.app.launch
+++ b/org.adempiere.install/install.silent.app.launch
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.pde.ui.RuntimeWorkbench">
+    <booleanAttribute key="append.args" value="true"/>
+    <stringAttribute key="application" value="org.adempiere.install.silent-application"/>
+    <booleanAttribute key="askclear" value="true"/>
+    <booleanAttribute key="automaticAdd" value="false"/>
+    <booleanAttribute key="automaticValidate" value="true"/>
+    <stringAttribute key="bootstrap" value=""/>
+    <stringAttribute key="checked" value="[NONE]"/>
+    <booleanAttribute key="clearConfig" value="true"/>
+    <booleanAttribute key="clearws" value="false"/>
+    <booleanAttribute key="clearwslog" value="false"/>
+    <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/install.silent.app"/>
+    <booleanAttribute key="default" value="false"/>
+    <setAttribute key="deselected_workspace_bundles"/>
+    <booleanAttribute key="includeOptional" value="false"/>
+    <stringAttribute key="location" value="${workspace_loc}/runtime-install.silent.app"/>
+    <listAttribute key="org.eclipse.debug.ui.favoriteGroups">
+        <listEntry value="org.eclipse.debug.ui.launchGroup.debug"/>
+    </listAttribute>
+    <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+    <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dosgi.compatibility.bootdelegation=true"/>
+    <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc}"/>
+    <stringAttribute key="pde.version" value="3.3"/>
+    <stringAttribute key="product" value="org.adempiere.server.server_product"/>
+    <setAttribute key="selected_target_bundles">
+        <setEntry value="bcpkix@default:default"/>
+        <setEntry value="bcprov@default:default"/>
+        <setEntry value="com.google.zxing.core@default:default"/>
+        <setEntry value="com.itextpdf@default:default"/>
+        <setEntry value="com.jaspersoft.studio.bundles.barbecue@default:default"/>
+        <setEntry value="com.sun.activation.jakarta.activation@default:default"/>
+        <setEntry value="com.sun.mail.gimap@default:default"/>
+        <setEntry value="com.sun.mail.imap@default:default"/>
+        <setEntry value="com.sun.mail.jakarta.mail@default:default"/>
+        <setEntry value="com.sun.mail.smtp@default:default"/>
+        <setEntry value="groovy@default:default"/>
+        <setEntry value="jakarta.annotation-api@default:default"/>
+        <setEntry value="jakarta.mail.api@default:default"/>
+        <setEntry value="jakarta.xml.bind-api@default:default"/>
+        <setEntry value="javax.jms@default:default"/>
+        <setEntry value="net.sf.supercsv.super-csv@default:default"/>
+        <setEntry value="org.apache.activemq.activemq-core@default:default"/>
+        <setEntry value="org.apache.activemq.kahadb@default:default"/>
+        <setEntry value="org.apache.ant@default:default"/>
+        <setEntry value="org.apache.commons.codec@default:default"/>
+        <setEntry value="org.apache.commons.collections@default:default"/>
+        <setEntry value="org.apache.commons.commons-collections4@default:default"/>
+        <setEntry value="org.apache.commons.compress@default:default"/>
+        <setEntry value="org.apache.commons.logging@default:default"/>
+        <setEntry value="org.apache.commons.net@default:default"/>
+        <setEntry value="org.apache.felix.scr@1:true"/>
+        <setEntry value="org.apache.geronimo.specs.geronimo-j2ee-management_1.1_spec@default:default"/>
+        <setEntry value="org.apache.poi.poi-ooxml-schemas@default:default"/>
+        <setEntry value="org.apache.poi.poi-ooxml@default:default"/>
+        <setEntry value="org.apache.poi.poi@default:default"/>
+        <setEntry value="org.apache.servicemix.bundles.cglib@default:default"/>
+        <setEntry value="org.apache.xmlbeans@default:default"/>
+        <setEntry value="org.cryptacular@default:default"/>
+        <setEntry value="org.eclipse.ant.core@default:default"/>
+        <setEntry value="org.eclipse.core.contenttype@default:default"/>
+        <setEntry value="org.eclipse.core.jobs@default:default"/>
+        <setEntry value="org.eclipse.core.runtime@default:true"/>
+        <setEntry value="org.eclipse.core.variables@default:default"/>
+        <setEntry value="org.eclipse.equinox.app@default:default"/>
+        <setEntry value="org.eclipse.equinox.common@2:true"/>
+        <setEntry value="org.eclipse.equinox.ds@1:true"/>
+        <setEntry value="org.eclipse.equinox.event@default:default"/>
+        <setEntry value="org.eclipse.equinox.preferences@default:default"/>
+        <setEntry value="org.eclipse.equinox.registry@default:default"/>
+        <setEntry value="org.eclipse.jetty.osgi-servlet-api@default:default"/>
+        <setEntry value="org.eclipse.osgi.compatibility.state@default:false"/>
+        <setEntry value="org.eclipse.osgi.services@default:default"/>
+        <setEntry value="org.eclipse.osgi.util@default:default"/>
+        <setEntry value="org.eclipse.osgi@-1:true"/>
+        <setEntry value="org.hamcrest.core@default:default"/>
+        <setEntry value="org.jfree.chart@default:default"/>
+        <setEntry value="org.jfree.jcommon@default:default"/>
+        <setEntry value="org.junit@default:default"/>
+        <setEntry value="org.krysalis.barcode4j@default:default"/>
+        <setEntry value="org.passay@default:default"/>
+        <setEntry value="slf4j.api@default:default"/>
+        <setEntry value="slf4j.jcl@default:false"/>
+    </setAttribute>
+    <setAttribute key="selected_workspace_bundles">
+        <setEntry value="org.adempiere.base@default:default"/>
+        <setEntry value="org.adempiere.install@default:default"/>
+        <setEntry value="org.apache.ecs@default:default"/>
+        <setEntry value="org.compiere.db.oracle.provider@default:default"/>
+        <setEntry value="org.compiere.db.postgresql.provider@default:default"/>
+    </setAttribute>
+    <booleanAttribute key="show_selected_only" value="true"/>
+    <stringAttribute key="templateConfig" value="${target_home}/configuration/config.ini"/>
+    <booleanAttribute key="tracing" value="false"/>
+    <booleanAttribute key="useCustomFeatures" value="false"/>
+    <booleanAttribute key="useDefaultConfig" value="true"/>
+    <booleanAttribute key="useDefaultConfigArea" value="true"/>
+    <booleanAttribute key="useProduct" value="false"/>
+</launchConfiguration>

--- a/org.adempiere.install/plugin.xml
+++ b/org.adempiere.install/plugin.xml
@@ -21,4 +21,16 @@
          </run>
       </application>
    </extension>
+   <extension
+         id="org.adempiere.install.silent-application"
+         point="org.eclipse.core.runtime.applications">
+      <application
+            cardinality="singleton-global"
+            thread="main"
+            visible="true">
+         <run
+               class="org.compiere.install.console.SilentInstallApplication">
+         </run>
+      </application>
+   </extension>
 </plugin>

--- a/org.adempiere.install/src/org/compiere/install/InstallApplication.java
+++ b/org.adempiere.install/src/org/compiere/install/InstallApplication.java
@@ -29,7 +29,7 @@ import org.eclipse.equinox.app.IApplicationContext;
 public class InstallApplication implements IApplication {
 
 	public Object start(IApplicationContext context) throws Exception {
-		Setup.main(new String[]{});
+		Setup.main((String[]) context.getArguments().get(IApplicationContext.APPLICATION_ARGS));
 		Thread.sleep(10000);
 		while (Setup.instance.isDisplayable()) {
 			Thread.sleep(2000);

--- a/org.adempiere.install/src/org/compiere/install/InstallApplication.java
+++ b/org.adempiere.install/src/org/compiere/install/InstallApplication.java
@@ -36,7 +36,6 @@ public class InstallApplication implements IApplication {
 		}
 		String path = System.getProperty("user.dir") + "/org.adempiere.install/build.xml";
 		File file = new File(path);
-//		System.out.println("file="+path+" exists="+file.exists());
 		//only exists if it is running from development environment
 		if (file.exists()) {
 			AntRunner runner = new AntRunner();

--- a/org.adempiere.install/src/org/compiere/install/Setup.java
+++ b/org.adempiere.install/src/org/compiere/install/Setup.java
@@ -150,17 +150,17 @@ public class Setup extends JFrame implements ActionListener
 	public static void main(String[] args)
 	{
 		CLogMgt.initialize(false);
-		// Duplicate log file - not required
-		// Handler fileHandler = new CLogFile(System.getProperty("user.dir"), false, false);
-		// CLogMgt.addHandler(fileHandler);
+
 		//	Log Level
-		if (args.length > 0)
-			CLogMgt.setLevel(args[0]);
-		else
-			CLogMgt.setLevel(Level.INFO);
-		//	File Logger at least FINE
-		// if (fileHandler.getLevel().intValue() > Level.FINE.intValue())
-		//	fileHandler.setLevel(Level.FINE);
+		Level logLevel = Level.INFO;
+		if (args.length > 0) {
+			try {
+				logLevel = Level.parse(args[0]);
+			} catch (IllegalArgumentException e) {
+				CLogger.get().warning("Unrecognized log level: " + args[0] + " defaulting to: " + logLevel);
+			}
+		}
+		CLogMgt.setLevel(logLevel);
 
 		instance = new Setup();
 	}	//	main

--- a/org.adempiere.install/src/org/compiere/install/Setup.java
+++ b/org.adempiere.install/src/org/compiere/install/Setup.java
@@ -22,7 +22,6 @@ import java.awt.Cursor;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ResourceBundle;
-import java.util.logging.Handler;
 import java.util.logging.Level;
 
 import javax.swing.BorderFactory;
@@ -35,7 +34,6 @@ import javax.swing.JPanel;
 
 import org.compiere.Adempiere;
 import org.compiere.install.util.AEnv;
-import org.compiere.util.CLogFile;
 import org.compiere.util.CLogMgt;
 import org.compiere.util.CLogger;
 
@@ -151,17 +149,18 @@ public class Setup extends JFrame implements ActionListener
 	 */
 	public static void main(String[] args)
 	{
-		CLogMgt.initialize(true);
-		Handler fileHandler = new CLogFile(System.getProperty("user.dir"), false, false);
-		CLogMgt.addHandler(fileHandler);
+		CLogMgt.initialize(false);
+		// Duplicate log file - not required
+		// Handler fileHandler = new CLogFile(System.getProperty("user.dir"), false, false);
+		// CLogMgt.addHandler(fileHandler);
 		//	Log Level
 		if (args.length > 0)
 			CLogMgt.setLevel(args[0]);
 		else
 			CLogMgt.setLevel(Level.INFO);
 		//	File Logger at least FINE
-		if (fileHandler.getLevel().intValue() > Level.FINE.intValue())
-			fileHandler.setLevel(Level.FINE);
+		// if (fileHandler.getLevel().intValue() > Level.FINE.intValue())
+		//	fileHandler.setLevel(Level.FINE);
 
 		instance = new Setup();
 	}	//	main

--- a/org.adempiere.install/src/org/compiere/install/SilentSetup.java
+++ b/org.adempiere.install/src/org/compiere/install/SilentSetup.java
@@ -1,15 +1,14 @@
 package org.compiere.install;
 
 import java.io.File;
-import java.util.logging.Handler;
 import java.util.logging.Level;
 
 import org.apache.tools.ant.Main;
-import org.compiere.util.CLogFile;
 import org.compiere.util.CLogMgt;
 import org.compiere.util.CLogger;
 import org.compiere.util.Ini;
 
+@Deprecated
 public class SilentSetup {
 
 	public SilentSetup()
@@ -61,17 +60,18 @@ public class SilentSetup {
 	 */
 	public static void main(String[] args)
 	{
-		CLogMgt.initialize(true);
-		Handler fileHandler = new CLogFile(System.getProperty("user.dir"), false, false);
-		CLogMgt.addHandler(fileHandler);
+		CLogMgt.initialize(false);
+		// Duplicate log file - not required
+		// Handler fileHandler = new CLogFile(System.getProperty("user.dir"), false, false);
+		// CLogMgt.addHandler(fileHandler);
 		//	Log Level
 		if (args.length > 0)
 			CLogMgt.setLevel(args[0]);
 		else
 			CLogMgt.setLevel(Level.INFO);
 		//	File Logger at least FINE
-		if (fileHandler.getLevel().intValue() > Level.FINE.intValue())
-			fileHandler.setLevel(Level.FINE);
+		// if (fileHandler.getLevel().intValue() > Level.FINE.intValue())
+		//	fileHandler.setLevel(Level.FINE);
 
 		new SilentSetup();
 	}

--- a/org.adempiere.install/src/org/compiere/install/SilentSetup.java
+++ b/org.adempiere.install/src/org/compiere/install/SilentSetup.java
@@ -1,14 +1,37 @@
+/***********************************************************************
+ * This file is part of iDempiere ERP Open Source                      *
+ * http://www.idempiere.org                                            *
+ *                                                                     *
+ * Copyright (C) Contributors                                          *
+ *                                                                     *
+ * This program is free software; you can redistribute it and/or       *
+ * modify it under the terms of the GNU General Public License         *
+ * as published by the Free Software Foundation; either version 2      *
+ * of the License, or (at your option) any later version.              *
+ *                                                                     *
+ * This program is distributed in the hope that it will be useful,     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of      *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the        *
+ * GNU General Public License for more details.                        *
+ *                                                                     *
+ * You should have received a copy of the GNU General Public License   *
+ * along with this program; if not, write to the Free Software         *
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,          *
+ * MA 02110-1301, USA.                                                 *
+ **********************************************************************/
+
 package org.compiere.install;
 
 import java.io.File;
 import java.util.logging.Level;
 
-import org.apache.tools.ant.Main;
+import org.apache.tools.ant.DefaultLogger;
+import org.apache.tools.ant.Project;
 import org.compiere.util.CLogMgt;
 import org.compiere.util.CLogger;
 import org.compiere.util.Ini;
+import org.eclipse.ant.core.AntRunner;
 
-@Deprecated
 public class SilentSetup {
 
 	public SilentSetup()
@@ -18,35 +41,43 @@ public class SilentSetup {
 		if (adempiereHome == null || adempiereHome.length() == 0)
 			adempiereHome = System.getProperty("user.dir");
 
-//		boolean envLoaded = false;
 		String fileName = adempiereHome + File.separator + ConfigurationData.IDEMPIERE_ENV_FILE;
 		File env = new File(fileName);
 		if (!env.exists())
 		{
-			System.err.println("Usage: Please edit idempiereEnvTemplate.properties and save as idempiereEnv.properties");
+			CLogger.get().severe("Usage: Please edit idempiereEnvTemplate.properties and save as idempiereEnv.properties");
 			return;
 		}
 
 		Ini.setShowLicenseDialog(false);
 		ConfigurationData data = new ConfigurationData(null);
-		if (!data.load()) return;
+		if (!data.load())
+			return;
 		if (!data.test(null))
 		{
-			System.err.println("");
-			System.err.println("Warning: One or more of the configuration test failed.");
-			System.err.println("");
+			CLogger.get().severe("");
+			CLogger.get().severe("ERROR: One or more of the configuration test failed.");
+			CLogger.get().severe("");
+			return;
 		}
-		if (!data.save()) return;
+		if (!data.save())
+			return;
 
 		/**	Run Ant	**/
 		try
 		{
-			CLogger.get().info("Starting Ant ... ");
-			System.setProperty("ant.home", ".");
-			String[] 	args = new String[] {"setup"};
-		//	Launcher.main (args);	//	calls System.exit
-			Main antMain = new Main();
-			antMain.startAnt(args, null, null);
+			String path = System.getProperty("user.dir") + "/org.adempiere.install/build.xml";
+			File file = new File(path);
+			System.out.println("file="+path+" exists="+file.exists());
+			//only exists if it is running from development environment
+			if (file.exists()) {
+				AntRunner runner = new AntRunner();
+				runner.setBuildFileLocation(path);
+				runner.setMessageOutputLevel(Project.MSG_VERBOSE);
+				runner.addBuildLogger(DefaultLogger.class.getName());
+				runner.run();
+				runner.stop();
+			}
 		}
 		catch (Exception e)
 		{
@@ -61,17 +92,17 @@ public class SilentSetup {
 	public static void main(String[] args)
 	{
 		CLogMgt.initialize(false);
-		// Duplicate log file - not required
-		// Handler fileHandler = new CLogFile(System.getProperty("user.dir"), false, false);
-		// CLogMgt.addHandler(fileHandler);
+
 		//	Log Level
-		if (args.length > 0)
-			CLogMgt.setLevel(args[0]);
-		else
-			CLogMgt.setLevel(Level.INFO);
-		//	File Logger at least FINE
-		// if (fileHandler.getLevel().intValue() > Level.FINE.intValue())
-		//	fileHandler.setLevel(Level.FINE);
+		Level logLevel = Level.INFO;
+		if (args.length > 0) {
+			try {
+				logLevel = Level.parse(args[0]);
+			} catch (IllegalArgumentException e) {
+				CLogger.get().warning("Unrecognized log level: " + args[0] + " defaulting to: " + logLevel);
+			}
+		}
+		CLogMgt.setLevel(logLevel);
 
 		new SilentSetup();
 	}

--- a/org.adempiere.install/src/org/compiere/install/console/ConsoleInstallApplication.java
+++ b/org.adempiere.install/src/org/compiere/install/console/ConsoleInstallApplication.java
@@ -14,9 +14,11 @@
 package org.compiere.install.console;
 
 import java.io.File;
+import java.util.logging.Level;
 
 import org.apache.tools.ant.DefaultLogger;
 import org.apache.tools.ant.Project;
+import org.compiere.util.CLogMgt;
 import org.eclipse.ant.core.AntRunner;
 import org.eclipse.equinox.app.IApplication;
 import org.eclipse.equinox.app.IApplicationContext;
@@ -32,6 +34,12 @@ public class ConsoleInstallApplication implements IApplication {
 	 */
 	@Override
 	public Object start(IApplicationContext context) throws Exception {
+		CLogMgt.initialize(false);
+		String[] args = (String[]) context.getArguments().get(IApplicationContext.APPLICATION_ARGS);
+		if (args.length > 0)
+			CLogMgt.setLevel(args[0]);
+		else
+			CLogMgt.setLevel(Level.INFO);
 		ConfigurationConsole console = new ConfigurationConsole();
 		console.doSetup();
 		String path = System.getProperty("user.dir") + "/org.adempiere.install/build.xml";

--- a/org.adempiere.install/src/org/compiere/install/console/ConsoleInstallApplication.java
+++ b/org.adempiere.install/src/org/compiere/install/console/ConsoleInstallApplication.java
@@ -19,6 +19,7 @@ import java.util.logging.Level;
 import org.apache.tools.ant.DefaultLogger;
 import org.apache.tools.ant.Project;
 import org.compiere.util.CLogMgt;
+import org.compiere.util.CLogger;
 import org.eclipse.ant.core.AntRunner;
 import org.eclipse.equinox.app.IApplication;
 import org.eclipse.equinox.app.IApplicationContext;
@@ -36,10 +37,18 @@ public class ConsoleInstallApplication implements IApplication {
 	public Object start(IApplicationContext context) throws Exception {
 		CLogMgt.initialize(false);
 		String[] args = (String[]) context.getArguments().get(IApplicationContext.APPLICATION_ARGS);
-		if (args.length > 0)
-			CLogMgt.setLevel(args[0]);
-		else
-			CLogMgt.setLevel(Level.INFO);
+
+		//	Log Level
+		Level logLevel = Level.INFO;
+		if (args.length > 0) {
+			try {
+				logLevel = Level.parse(args[0]);
+			} catch (IllegalArgumentException e) {
+				CLogger.get().warning("Unrecognized log level: " + args[0] + " defaulting to: " + logLevel);
+			}
+		}
+		CLogMgt.setLevel(logLevel);
+
 		ConfigurationConsole console = new ConfigurationConsole();
 		console.doSetup();
 		String path = System.getProperty("user.dir") + "/org.adempiere.install/build.xml";

--- a/org.adempiere.install/src/org/compiere/install/console/SilentInstallApplication.java
+++ b/org.adempiere.install/src/org/compiere/install/console/SilentInstallApplication.java
@@ -1,0 +1,47 @@
+/***********************************************************************
+ * This file is part of iDempiere ERP Open Source                      *
+ * http://www.idempiere.org                                            *
+ *                                                                     *
+ * Copyright (C) Contributors                                          *
+ *                                                                     *
+ * This program is free software; you can redistribute it and/or       *
+ * modify it under the terms of the GNU General Public License         *
+ * as published by the Free Software Foundation; either version 2      *
+ * of the License, or (at your option) any later version.              *
+ *                                                                     *
+ * This program is distributed in the hope that it will be useful,     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of      *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the        *
+ * GNU General Public License for more details.                        *
+ *                                                                     *
+ * You should have received a copy of the GNU General Public License   *
+ * along with this program; if not, write to the Free Software         *
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,          *
+ * MA 02110-1301, USA.                                                 *
+ *                                                                     *
+ * Contributors:                                                       *
+ * - Carlos Ruiz - globalqss - bxservice                               *
+ **********************************************************************/
+
+package org.compiere.install.console;
+
+import org.compiere.install.SilentSetup;
+import org.eclipse.equinox.app.IApplication;
+import org.eclipse.equinox.app.IApplicationContext;
+
+/**
+ * Silent setup
+ * @author Carlos Ruiz - globalqss - bxservice
+ *
+ */
+public class SilentInstallApplication implements IApplication {
+
+	public Object start(IApplicationContext context) throws Exception {
+		SilentSetup.main((String[]) context.getArguments().get(IApplicationContext.APPLICATION_ARGS));
+		return EXIT_OK;
+	}
+
+	public void stop() {
+	}
+
+}

--- a/org.adempiere.server-feature/build.properties
+++ b/org.adempiere.server-feature/build.properties
@@ -6,28 +6,28 @@ root.folder.jettyhome=jettyhome
 root.folder.migration=../migration
 
 #linux 64 bits
-root.linux.gtk.x86_64=file:setup.sh,file:console-setup.sh,file:idempiere-server.sh,file:setup-alt.sh,file:console-setup-alt.sh,file:sign-database-build.sh,file:sign-database-build-alt.sh,file:idempiereEnvTemplate.properties,file:../Credits.html
+root.linux.gtk.x86_64=file:setup.sh,file:console-setup.sh,file:silent-setup.sh,file:idempiere-server.sh,file:setup-alt.sh,file:console-setup-alt.sh,file:silent-setup-alt.sh,file:sign-database-build.sh,file:sign-database-build-alt.sh,file:idempiereEnvTemplate.properties,file:../Credits.html
 root.linux.gtk.x86_64.folder.utils=utils.unix
 root.linux.gtk.x86_64.permissions.755=*.sh,**/*.sh
 #linux
-root.linux.gtk.x86=file:setup.sh,file:console-setup.sh,file:idempiere-server.sh,file:setup-alt.sh,file:console-setup-alt.sh,file:sign-database-build.sh,file:sign-database-build-alt.sh,file:idempiereEnvTemplate.properties,file:../Credits.html
+root.linux.gtk.x86=file:setup.sh,file:console-setup.sh,file:silent-setup.sh,file:idempiere-server.sh,file:setup-alt.sh,file:console-setup-alt.sh,file:silent-setup-alt.sh,file:sign-database-build.sh,file:sign-database-build-alt.sh,file:idempiereEnvTemplate.properties,file:../Credits.html
 root.linux.gtk.x86.folder.utils=utils.unix
 root.linux.gtk.x86.permissions.755=*.sh,**/*.sh
 #mac
-root.macosx.cocoa.x86=file:setup.sh,file:console-setup.sh,file:idempiere-server.sh,file:setup-alt.sh,file:console-setup-alt.sh,file:sign-database-build.sh,file:sign-database-build-alt.sh,file:idempiereEnvTemplate.properties,file:../Credits.html
+root.macosx.cocoa.x86=file:setup.sh,file:console-setup.sh,file:silent-setup.sh,file:idempiere-server.sh,file:setup-alt.sh,file:console-setup-alt.sh,file:silent-setup-alt.sh,file:sign-database-build.sh,file:sign-database-build-alt.sh,file:idempiereEnvTemplate.properties,file:../Credits.html
 root.macosx.cocoa.x86.folder.utils=utils.unix
 root.macosx.cocoa.x86.permissions.755=*.sh,**/*.sh
 #mac 64
-root.macosx.cocoa.x86_64=file:setup.sh,file:console-setup.sh,file:idempiere-server.sh,file:setup-alt.sh,file:console-setup-alt.sh,file:sign-database-build.sh,file:sign-database-build-alt.sh,file:idempiereEnvTemplate.properties,file:../Credits.html
+root.macosx.cocoa.x86_64=file:setup.sh,file:console-setup.sh,file:silent-setup.sh,file:idempiere-server.sh,file:setup-alt.sh,file:console-setup-alt.sh,file:silent-setup-alt.sh,file:sign-database-build.sh,file:sign-database-build-alt.sh,file:idempiereEnvTemplate.properties,file:../Credits.html
 root.macosx.cocoa.x86_64.folder.utils=utils.unix
 root.macosx.cocoa.x86_64.permissions.755=*.sh,**/*.sh
 #windows
-root.win32.win32.x86=file:setup.bat,file:console-setup.bat,file:idempiere-server.bat,file:setup-alt.bat,file:console-setup-alt.bat,file:sign-database-build.bat,file:sign-database-build-alt.bat,file:idempiereEnvTemplate.properties,file:../Credits.html
+root.win32.win32.x86=file:setup.bat,file:console-setup.bat,file:silent-setup.bat,file:idempiere-server.bat,file:setup-alt.bat,file:console-setup-alt.bat,file:silent-setup-alt.bat,file:sign-database-build.bat,file:sign-database-build-alt.bat,file:idempiereEnvTemplate.properties,file:../Credits.html
 root.win32.win32.x86.folder.utils=utils.windows
 #windows 64
-root.win32.win32.x86_64=file:setup.bat,file:console-setup.bat,file:idempiere-server.bat,file:setup-alt.bat,file:console-setup-alt.bat,file:sign-database-build.bat,file:sign-database-build-alt.bat,file:idempiereEnvTemplate.properties,file:../Credits.html
+root.win32.win32.x86_64=file:setup.bat,file:console-setup.bat,file:silent-setup.bat,file:idempiere-server.bat,file:setup-alt.bat,file:console-setup-alt.bat,file:silent-setup-alt.bat,file:sign-database-build.bat,file:sign-database-build-alt.bat,file:idempiereEnvTemplate.properties,file:../Credits.html
 root.win32.win32.x86_64.folder.utils=utils.windows
 #solaris
-root.solaris.gtk.x86=file:setup.sh,file:console-setup.sh,file:idempiere-server.sh,file:setup-alt.sh,file:console-setup-alt.sh,file:sign-database-build.sh,file:sign-database-build-alt.sh,file:idempiereEnvTemplate.properties,file:../Credits.html
+root.solaris.gtk.x86=file:setup.sh,file:console-setup.sh,file:silent-setup.sh,file:idempiere-server.sh,file:setup-alt.sh,file:console-setup-alt.sh,file:silent-setup-alt.sh,file:sign-database-build.sh,file:sign-database-build-alt.sh,file:idempiereEnvTemplate.properties,file:../Credits.html
 root.solaris.gtk.x86.folder.utils=utils.unix
 root.solaris.gtk.x86.permissions.755=*.sh,**/*.sh

--- a/org.adempiere.server-feature/silent-setup-alt.bat
+++ b/org.adempiere.server-feature/silent-setup-alt.bat
@@ -1,0 +1,36 @@
+@Title Install idempiere Server Silently
+@Echo off
+
+
+@if not "%JAVA_HOME%" == "" goto JAVA_HOME_OK
+@Set JAVA=java
+@Echo JAVA_HOME is not set.
+@Echo You may not be able to start the required Setup window !!
+@Echo Set JAVA_HOME to the directory of your local 1.5 JDK.
+@Echo If you experience problems, run utils/WinEnv.js
+@Echo Example: cscript utils\WinEnv.js C:\Adempiere "C:\Program Files\Java\jdk1.5.0_04"
+goto START
+
+:JAVA_HOME_OK
+@Set JAVA=%JAVA_HOME%\bin\java
+
+
+:START
+@REM Setup idempiere.properties and idempiereEnv.properties
+FOR %%c in (plugins\org.eclipse.equinox.launcher_1.*.jar) DO set JARFILE=%%c
+@"%JAVA%" -jar %JARFILE% -install setup -configuration setup/configuration -application org.adempiere.install.silent-application
+
+@Echo ErrorLevel = %ERRORLEVEL%
+@IF NOT ERRORLEVEL = 1 GOTO NEXT
+@Echo ***************************************
+@Echo Check the error message above.
+@Echo ***************************************
+@Pause
+@Exit
+
+:NEXT
+@REM setup jetty
+@"%JAVA%" -jar %JARFILE% -install setup -configuration setup/configuration -application org.eclipse.ant.core.antRunner -buildfile build.xml
+
+@Echo .
+@Echo For problems, check log file in base directory

--- a/org.adempiere.server-feature/silent-setup-alt.sh
+++ b/org.adempiere.server-feature/silent-setup-alt.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+#
+echo Setup iDempiere Server
+# $Header: /cvsroot/adempiere/install/Adempiere/RUN_setup.sh,v 1.19 2005/09/08 21:54:12 jjanke Exp $
+
+if [ "$JAVA_HOME" ]; then
+  JAVA=$JAVA_HOME/bin/java
+else
+  JAVA=java
+  echo JAVA_HOME is not set.
+  echo You may not be able to start the Setup
+  echo Set JAVA_HOME to the directory of your local JDK.
+fi
+
+
+# Setup idempiere.properties and idempiereEnv.properties
+$JAVA -jar plugins/org.eclipse.equinox.launcher_1.*.jar -install setup -configuration setup/configuration -application org.adempiere.install.silent-application
+
+if [ -s idempiere.properties ]
+then
+    # Setup Jetty
+    $JAVA -jar plugins/org.eclipse.equinox.launcher_1.*.jar -install setup -configuration setup/configuration -application org.eclipse.ant.core.antRunner -buildfile build.xml
+fi
+
+echo .
+echo For problems, check log file in base directory

--- a/org.adempiere.server-feature/silent-setup.bat
+++ b/org.adempiere.server-feature/silent-setup.bat
@@ -1,0 +1,21 @@
+@Title Install idempiere Server Silently
+@Echo off
+
+
+@REM Setup idempiere.properties and idempiereEnv.properties
+idempiere --launcher.ini setup.ini -application org.adempiere.install.silent-application
+
+@Echo ErrorLevel = %ERRORLEVEL%
+@IF NOT ERRORLEVEL = 1 GOTO NEXT
+@Echo ***************************************
+@Echo Check the error message above.
+@Echo ***************************************
+@Pause
+@Exit
+
+:NEXT
+@REM Setup Jetty
+idempiere --launcher.ini setup.ini -application org.eclipse.ant.core.antRunner -buildfile build.xml
+
+@Echo .
+@Echo For problems, check log file in base directory

--- a/org.adempiere.server-feature/silent-setup.sh
+++ b/org.adempiere.server-feature/silent-setup.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+#
+echo Setup idempiere Server
+
+# Setup idempiere.properties and idempiereEnv.properties
+./idempiere --launcher.ini setup.ini -application org.adempiere.install.silent-application
+
+# Setup Jetty
+if [ -s idempiere.properties ]
+then
+    ./idempiere --launcher.ini setup.ini -application org.eclipse.ant.core.antRunner -buildfile build.xml
+fi
+
+echo .
+echo For problems, check log file in base directory

--- a/org.adempiere.server-feature/utils.unix/unix/DebianInstaller/etc/init.d/idempiere
+++ b/org.adempiere.server-feature/utils.unix/unix/DebianInstaller/etc/init.d/idempiere
@@ -41,7 +41,7 @@ IDEMPIERE_USER=idempiere
 IDEMPIERE_HOME=/opt/idempiere-server
 # in case you manual install java by use zip or your linux distros, or your java provider have difference pattern of path, please update here
 JAVA_HOME=$(ls -r /usr/lib/jvm/java-1[1234]-openjdk*/bin/javac | head -1)
-JAVA_HOME=$(dirname "$JAVA_HOME")
+JAVA_HOME=$(dirname $( dirname "$JAVA_HOME") )
 SU=su
 export IDEMPIERE_HOME
 export TELNET_PORT=12612
@@ -212,36 +212,10 @@ configure_perform()
     sed -i "s/:8080/:${ADEMPIERE_WEB_PORT}/g" /usr/share/applications/idempiere-homepage.desktop
     sed -i "s/:8443/:${ADEMPIERE_SSL_PORT}/g" /usr/share/applications/idempiere-webclient.desktop
 
-    if [ -f ${IDEMPIERE_HOME}/console-setup.sh ]
+    if [ -f ${IDEMPIERE_HOME}/silent-setup.sh ]
     then
      	echo -n "Deploying iDempiere ERP server..."
-       	$SU ${IDEMPIERE_USER} -c "cd ${IDEMPIERE_HOME}; ./console-setup.sh" <<!
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-!
+       	$SU ${IDEMPIERE_USER} -c "cd ${IDEMPIERE_HOME}; ./silent-setup.sh"
 	echo "Done"
     fi
     grep "${ADEMPIERE_WEB_PORT}" ${IDEMPIERE_HOME}/jettyhome/etc/jetty-http.xml > /dev/null 2>&1
@@ -263,6 +237,12 @@ configure_perform()
     then
         echo -n "Importing seed database..."
        	$SU ${IDEMPIERE_USER} -c "cd ${IDEMPIERE_HOME}/utils; ( echo "" | ./RUN_ImportIdempiere.sh )" # > /dev/null 2>&1
+	echo "Done"
+        echo -n "Applying latest migration scripts ..."
+       	$SU ${IDEMPIERE_USER} -c "cd ${IDEMPIERE_HOME}/utils; ./RUN_SyncDB.sh" # > /dev/null 2>&1
+	echo "Done"
+        echo -n "Signing DB ..."
+       	$SU ${IDEMPIERE_USER} -c "cd ${IDEMPIERE_HOME}; ./sign-database-build.sh" # > /dev/null 2>&1
 	echo "Done"
     fi
     $SU ${IDEMPIERE_USER} -c "cd; export PGPASSWORD=${ADEMPIERE_DB_PASSWORD}; psql -d idempiere -U adempiere -h localhost -p 5432 -c ''" > /dev/null 2>&1

--- a/org.adempiere.server-feature/utils.unix/unix/createDEBpackage.sh
+++ b/org.adempiere.server-feature/utils.unix/unix/createDEBpackage.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
+
+## before running this command you must move and rename the folder as:
+# mkdir -p ../../../idempiere.gtk.linux.x86_64
+# mv ../../../linux/gtk/x86_64  ../../../idempiere.gtk.linux.x86_64/idempiere-server
+# cd ../../../idempiere.gtk.linux.x86_64/idempiere-server/utils/unix
+# bash createDEBpackage.sh
+
 TMP=/tmp
 cd "$(dirname "$0")"/../../.. || exit
 IDEMPIERE_HOME=$(pwd)


### PR DESCRIPTION
* Allow receiving log level as parameter for setup and console-setup
* Avoid duplication of log file - just leave it in /log
* Implement logging for console-setup too
* mark SilentSetup as deprecated
* add runtime-*.app to .gitignore (sometimes files appear in these folders and can be wrongly committed)

https://idempiere.atlassian.net/browse/IDEMPIERE-4620