### PR TITLE
IDEMPIERE-4485 Info Window Columns has no Value preference

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
@@ -981,7 +981,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 					builder.append(whereClause);
 				}
 			} else if (editor.getGridField() != null && editor.getValue() != null && editor.getValue().toString().trim().length() > 0) {
-				InfoColumnVO InfoColumnVO = findInfoColumn(editor.getGridField());
+				InfoColumnVO InfoColumnVO = findInfoColumnParameter(editor.getGridField());
 				if (InfoColumnVO == null || InfoColumnVO.getSelectClause().equals("0")) {
 					continue;
 				}
@@ -1085,6 +1085,18 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 		return null;
 	}
 
+	protected InfoColumnVO findInfoColumnParameter(GridField gridField) {
+		for (Integer i : parameterTree.keySet()) {
+			List<Object[]> list = parameterTree.get(i);
+			for(Object[] value : list) {
+				if (gridField == value[1]) {
+					return (InfoColumnVO) value[0];
+				}
+			}
+		}
+		return null;
+	}
+
 	/**
 	 * Check has new parameter is change or new input
 	 * in case first time search, return true
@@ -1110,7 +1122,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 				continue;
 			
 			if (editor.getGridField() != null && editor.getValue() != null && editor.getValue().toString().trim().length() > 0) {
-				InfoColumnVO InfoColumnVO = findInfoColumn(editor.getGridField());
+				InfoColumnVO InfoColumnVO = findInfoColumnParameter(editor.getGridField());
 				if (InfoColumnVO == null || InfoColumnVO.getSelectClause().equals("0")) {
 					continue;
 				}
@@ -1152,7 +1164,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 				continue;
 			
 			if (editor.getGridField() != null && editor.getValue() != null && editor.getValue().toString().trim().length() > 0) {
-				InfoColumnVO InfoColumnVO = findInfoColumn(editor.getGridField());
+				InfoColumnVO InfoColumnVO = findInfoColumnParameter(editor.getGridField());
 				if (InfoColumnVO == null || InfoColumnVO.getSelectClause().equals("0")) {
 					continue;
 				}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
@@ -627,30 +627,9 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 				GridField gridField = new GridField(vo);
 				gridFields.add(gridField);
 
-				//IDEMPIERE-4485 Store new Gridfields with IsReadOnly = false
+				//IDEMPIERE-4485 Clone new Gridfields with IsReadOnly = false
 				if(infoColumn.isQueryCriteria()) {
-					vo = GridFieldVO.createParameter(infoContext, p_WindowNo, AEnv.getADWindowID(p_WindowNo), infoWindow.getAD_InfoWindow_ID(), 0,
-							columnName, infoColumn.getNameTrl(), infoColumn.getAD_Reference_ID(), 
-							infoColumn.getAD_Reference_Value_ID(), isMandatory, false, infoColumn.getPlaceHolderTrl());
-					
-					if (infoColumn.getAD_Val_Rule_ID() > 0) {
-						vo.ValidationCode = infoColumn.getValidationCode();
-						if (vo.lookupInfo != null) {
-							vo.lookupInfo.ValidationCode = vo.ValidationCode;
-							vo.lookupInfo.IsValidated = false;
-						}
-					}
-					if (infoColumn.getDisplayLogic() != null)					
-						vo.DisplayLogic =  infoColumn.getDisplayLogic();
-					if (infoColumn.isQueryCriteria() && infoColumn.getDefaultValue() != null)
-						vo.DefaultValue = infoColumn.getDefaultValue();
-					desc = infoColumn.getDescriptionTrl();
-					vo.Description = desc != null ? desc : "";
-					help = infoColumn.getHelpTrl();
-					vo.Help = help != null ? help : "";
-					vo.AD_FieldStyle_ID = infoColumn.getAD_FieldStyle_ID();
-					vo.IsAutocomplete = infoColumn.isAutocomplete();
-					vo.IsReadOnly = false;
+					vo = vo.clone(infoContext, p_WindowNo, 0, vo.AD_Window_ID, 0, false);
 					gridField = new GridField(vo);
 					List<Object[]> list = parameterTree.get(infoColumn.getSeqNoSelection());
 					if (list == null) {


### PR DESCRIPTION
Problem is that Info Column has ReadOnly parameter which have 2 uses. So if we set Parameter as ReadOnly, this parameter is in table set as read only. But if this parameter is set as Query Parameter it will interfere with menu popup which checks ReadOnly Parameter.
So i created parameterTree to store new Gridfield copy which have forced read only false in Query Parameter.

https://idempiere.atlassian.net/browse/IDEMPIERE-4485