### PR TITLE
Fix for the safari browser tile image positioning problem.

### DIFF
--- a/org.adempiere.server/resources/templates/black/styles/template.css
+++ b/org.adempiere.server/resources/templates/black/styles/template.css
@@ -110,8 +110,7 @@ div.body{
 }
 #main-docuBtns ul li > a > img {
 	position: relative;
-	top: 50%;
-  	transform: translate(0%,-45%);
+  	transform: translate(0%,5%);
 }
 .main-txt-btn {
 	padding-top:2px;

--- a/org.adempiere.server/resources/templates/white/styles/template.css
+++ b/org.adempiere.server/resources/templates/white/styles/template.css
@@ -100,8 +100,7 @@ div.body{
 }
 #main-docuBtns ul li > a > img {
 	position: relative;
-	top: 50%;
-  	transform: translate(0%,-45%);
+  	transform: translate(0%,5%);
 }
 .main-txt-btn {
 	padding-top:2px;


### PR DESCRIPTION
This is a fix for the safari tile image positioning issue:

![Bildschirmfoto 2021-01-09 um 11 59 32](https://user-images.githubusercontent.com/2970124/104093745-d5c09800-528c-11eb-81b6-7d0f843e2827.png)

Discussion here: https://groups.google.com/g/idempiere/c/soHxAlytJMs

 