### PR TITLE
IDEMPIERE-4644 Heading only Field is the cause of NullPointerException Error on Find Window

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/FindWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/FindWindow.java
@@ -1218,7 +1218,7 @@ public class FindWindow extends Window implements EventListener<Event>, ValueCha
         WEditor editor = null;
         //false will use hflex which is render 1 pixel too width on firefox
         editor = WebEditorFactory.getEditor(mField, true);
-        if (!editor.isSearchable()) {
+        if (editor == null || !editor.isSearchable()) {
         	return false;
         }
         editor.setMandatory(false);


### PR DESCRIPTION
This is pull request of IDEMPIERE-4644 : Heading only Field is the cause of NullPointerException Error on Find Window.
I added null check logic.
And test below.

・I confirmed that NullPointerException Error on Find Window Don't display when there is a Heading only Field. 
・In case of tick "Lookup Only Selection Columns" of tab setting,  it also seemed good .