### PR TITLE
IDEMPIERE-4655 WTimeEditor display time picker button when read only.

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WTimeEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WTimeEditor.java
@@ -191,6 +191,7 @@ public class WTimeEditor extends WEditor implements ContextMenuListener
 	@Override
 	public void setReadWrite(boolean readWrite) {
 		getComponent().setReadonly(!readWrite);
+		getComponent().setButtonVisible(readWrite);
 	}
 
 	@Override


### PR DESCRIPTION
I tested below case.

* In case of processed = 'Y' at Window.
* In case of IsActive = 'Y' at Window.
* In case of Read only field at Window.
* In case of apply Read only Logic at Window. 
* In case of apply Read only Logic at Process. 

It's seems good.

best regards.