### PR TITLE
IDEMPIERE-4653 Improve timeout handling of window tab

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/GridTab.java
+++ b/org.adempiere.base/src/org/compiere/model/GridTab.java
@@ -3437,7 +3437,7 @@ public class GridTab implements DataStatusListener, Evaluatee, Serializable
 		// minimum between AD_Tab.MaxQueryRecords and AD_Role.MaxQueryRecords
 		int roleMaxQueryRecords = MRole.getDefault().getMaxQueryRecords();
 		int tabMaxQueryRecords = m_vo.MaxQueryRecords;
-		if (roleMaxQueryRecords > 0 && roleMaxQueryRecords < tabMaxQueryRecords)
+		if (roleMaxQueryRecords > 0 && (roleMaxQueryRecords < tabMaxQueryRecords || tabMaxQueryRecords == 0))
 			tabMaxQueryRecords = roleMaxQueryRecords;
 		return tabMaxQueryRecords;
 	}

--- a/org.adempiere.base/src/org/compiere/model/GridTable.java
+++ b/org.adempiere.base/src/org/compiere/model/GridTable.java
@@ -785,21 +785,22 @@ public class GridTable extends AbstractTableModel
 		if (m_buffer != null)
 		{
 			m_buffer.clear();
-			m_buffer = null;
 		}
 		if (m_sort != null)
 		{
 			m_sort.clear();
-			m_sort = null;
 		}
 		if (m_virtualBuffer != null)
 		{
 			m_virtualBuffer.clear();
-			m_virtualBuffer = null;
 		}
 
-		if (finalCall)
+		if (finalCall) {
 			dispose();
+			m_buffer = null;
+			m_sort = null;
+			m_virtualBuffer = null;
+		}
 
 		//  Fields are disposed from MTab
 		log.fine("");
@@ -3698,7 +3699,7 @@ public class GridTable extends AbstractTableModel
 					}
 				}	//	while(rs.next())
 			}
-			catch (SQLException e)
+			catch (Exception e)
 			{
 				log.log(Level.SEVERE, "run", e);
 			}

--- a/org.adempiere.base/src/org/compiere/model/MRole.java
+++ b/org.adempiere.base/src/org/compiere/model/MRole.java
@@ -124,7 +124,7 @@ public final class MRole extends X_AD_Role implements ImmutablePOSupport
 	 */
 	public synchronized static MRole get (Properties ctx, int AD_Role_ID, int AD_User_ID, boolean reload)
 	{
-		if (s_log.isLoggable(Level.INFO)) s_log.info("AD_Role_ID=" + AD_Role_ID + ", AD_User_ID=" + AD_User_ID + ", reload=" + reload);
+		if (s_log.isLoggable(Level.CONFIG)) s_log.info("AD_Role_ID=" + AD_Role_ID + ", AD_User_ID=" + AD_User_ID + ", reload=" + reload);
 		String key = AD_Role_ID + "_" + AD_User_ID;
 		MRole role = (MRole)s_roles.get (key, e -> new MRole(ctx, e));
 		if (role == null || reload)

--- a/org.adempiere.base/src/org/compiere/model/MRole.java
+++ b/org.adempiere.base/src/org/compiere/model/MRole.java
@@ -124,7 +124,7 @@ public final class MRole extends X_AD_Role implements ImmutablePOSupport
 	 */
 	public synchronized static MRole get (Properties ctx, int AD_Role_ID, int AD_User_ID, boolean reload)
 	{
-		if (s_log.isLoggable(Level.CONFIG)) s_log.info("AD_Role_ID=" + AD_Role_ID + ", AD_User_ID=" + AD_User_ID + ", reload=" + reload);
+		if (s_log.isLoggable(Level.CONFIG)) s_log.config("AD_Role_ID=" + AD_Role_ID + ", AD_User_ID=" + AD_User_ID + ", reload=" + reload);
 		String key = AD_Role_ID + "_" + AD_User_ID;
 		MRole role = (MRole)s_roles.get (key, e -> new MRole(ctx, e));
 		if (role == null || reload)

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/ADTabpanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/ADTabpanel.java
@@ -1172,7 +1172,7 @@ DataStatusListener, IADTabpanel, IdSpace, IFieldEditorContainer
     	{
     		if (DBException.isTimeout(e)) 
     		{
-    			FDialog.error(windowNo, GridTable.LOAD_TIMEOUT_ERROR_MESSAGE);
+    			throw e;
     		}
     		else
     		{


### PR DESCRIPTION
* Fixed a problem with IDEMPIERE-4130 that was not using role max query records
* GridTable was throwing NPEs because the arrays were disposed before closing
* Lowered log level on MRole to avoid clogging the console (I was testing with INFO level)
* Added more points of control for the timeout exception to give meaningful errors to the user and allow refining the query without closing the Find dialog
* Implemented a control to avoid repeating a slow initial query every time the dialog is open
* Added dialog when the find criteria doesn't return rows and allows the user to refine the query
* When the initial number of records is unknown, show a question mark instead of the count

https://idempiere.atlassian.net/browse/IDEMPIERE-4653