### PR TITLE
IDEMPIERE-4665 SearchQuery should behave the same as the toolbar butt…

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/ADWindowToolbar.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/ADWindowToolbar.java
@@ -898,6 +898,11 @@ public class ADWindowToolbar extends FToolbar implements EventListener<Event>
 								break;
 							}					
 						}					
+					} else if (p instanceof Combobox) {
+						if (advancedName.equals(((Combobox) p).getId())) {
+							this.removeChild(p);
+							break;
+						}
 					}
 				}
 
@@ -946,6 +951,8 @@ public class ADWindowToolbar extends FToolbar implements EventListener<Event>
 				if (p instanceof ToolBarButton) {
 					if (!customButtons.contains(p) && !p.isVisible())
 						p.setVisible(true);
+				} else if (p instanceof Combobox && !p.isVisible()) {
+					p.setVisible(true);
 				}
 			}
 			
@@ -964,6 +971,11 @@ public class ADWindowToolbar extends FToolbar implements EventListener<Event>
 								break;
 							}					
 						}					
+					}  else if (p instanceof Combobox) {
+						if (restrictName.equals(((Combobox) p).getId())) {
+							p.setVisible(false);
+							break;
+						}
 					}
 				}
 


### PR DESCRIPTION
…ons - role access,advanced button,dynamic display

https://idempiere.atlassian.net/browse/IDEMPIERE-4665

Test case scenarios:

**Advanced Button**
1. Log in as System
2. Navigate to the WIndow - SearchQuery record
3. Check the advanced Button flag

Expected Result
When logged in as SuperUser or GardenAdmin the select query Combobox should be displayed normally.
When logged in as GardenUser the Select Query Combobox should not be present on any window.

**Tab access restriction**
1. Log in as System
2. Create a new record in Role Toolbar Button Access with Action: Window, Window: Payment, Tab: Allocate, ToolbarButton: Window - SearchQuery

Expected Result
Log in as GardenAdmin. Open the Payment window

The Select Query should be displayed in the master tab. 
Navigate to allocate -> The select query combobox should be hidden for this tab.
Navigate back to Payment -> The select query should be visible again.




