### PR TITLE
IDEMPIERE-4658 The operator Dropdown entries for a foreign ID column is corrupted when a search preset is loaded in any window's Advanced Search tab.

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/FindWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/FindWindow.java
@@ -1238,6 +1238,9 @@ public class FindWindow extends Window implements EventListener<Event>, ValueCha
             }
             if(!selected) listColumn.setSelectedIndex(0);
 
+            if (liCol != null)
+            	addOperators(liCol, listOperator);
+
             selected = false;
             for (int i = 0; i < op.length; i++)
             {
@@ -1250,9 +1253,6 @@ public class FindWindow extends Window implements EventListener<Event>, ValueCha
             	}
             }
             if(!selected) listOperator.setSelectedIndex(0);
-
-            if (liCol != null)
-            	addOperators(liCol, listOperator);
         }
     }   // setValues
 


### PR DESCRIPTION


Fix issue discovered:
* Saving a query with LIKE operator, when restored it changes to = operator

https://idempiere.atlassian.net/browse/IDEMPIERE-4658