### PR TITLE
IDEMPIERE-4676 Browser hangs after restarting iDempiere or refreshing…

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/metainfo/zk/lang-addon.xml
+++ b/org.adempiere.ui.zk/WEB-INF/src/metainfo/zk/lang-addon.xml
@@ -45,7 +45,7 @@ Copyright (C) 2007 Ashley G Ramdass (ADempiere WebUI).
 	</component>
 
 	<javascript-module name="org.idempiere.websocket" version="202011211500"/>	
-	<javascript-module name="jawwa.atmosphere" version="202101290100"/>
+	<javascript-module name="jawwa.atmosphere" version="202102091500"/>
 	<javascript-module name="adempiere.local.storage" version="202011151100"/>
 	<javascript-moudle name="html2canvas" version="1.0.0.rc7"/>
 	<javascript-module name="org.idempiere.commons" version="202012030330"/>

--- a/org.adempiere.ui.zk/WEB-INF/src/web/js/jawwa/atmosphere/serverpush.js
+++ b/org.adempiere.ui.zk/WEB-INF/src/web/js/jawwa/atmosphere/serverpush.js
@@ -44,7 +44,7 @@
     	  if (textStatus != "timeout" && textStatus != "abort" && errorThrown != "SessionNotFound") {
 	          console.error("error: " + textStatus + " errorThrown: " + errorThrown + " status: " + jqxhr.status);
 	          //stop immediately if server is not reachable
-	          if (jqxhr.status == 404 || jqxhr.status == 0) {
+	          if (jqxhr.status == 404) {
 	          	me.failures = 3;
 	          } else {
 	          	me.failures += 1;


### PR DESCRIPTION
… ui.zk, on macos sometimes during work

Immediately treat jqxhr.status=0 as server not available doesn't work
well on firefox. With Firefox both stop of server and navigate away to
another site provide same jqxhr.onerror event and jqxhr.status of 0.