### PR TITLE
IDEMPIERE-4695 Add document factory base class backed by Map and Lamb…

### DIFF
--- a/org.adempiere.base/src/org/compiere/acct/DocManager.java
+++ b/org.adempiere.base/src/org/compiere/acct/DocManager.java
@@ -47,6 +47,8 @@ import org.compiere.util.ValueNamePair;
  */
 public class DocManager {
 
+	public static final String IDOC_FACTORY_CACHE_TABLE_NAME = "_IDocFactory_Cache";
+
 	private final static CLogger s_log = CLogger.getCLogger(DocManager.class);
 
 	/** AD_Table_ID's of documents          */
@@ -110,7 +112,7 @@ public class DocManager {
 		}
 	}
 
-	private static final CCache<String, IServiceReferenceHolder<IDocFactory>> s_DocFactoryCache = new CCache<>(null, "IDocFactory", 100, false);
+	private static final CCache<String, IServiceReferenceHolder<IDocFactory>> s_DocFactoryCache = new CCache<>(IDOC_FACTORY_CACHE_TABLE_NAME, "IDocFactory", 100, false);
 	
 	/**
 	 *  Create Posting document

--- a/org.idempiere.test/src/org/idempiere/test/model/MappedDocumentFactoryTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/MappedDocumentFactoryTest.java
@@ -36,6 +36,7 @@ import org.compiere.acct.Doc_InOut;
 import org.compiere.model.MAcctSchema;
 import org.compiere.model.MClientInfo;
 import org.compiere.model.MInOut;
+import org.compiere.util.CacheMgt;
 import org.compiere.util.Env;
 import org.idempiere.test.AbstractTestCase;
 import org.junit.jupiter.api.Test;
@@ -54,6 +55,9 @@ public class MappedDocumentFactoryTest extends AbstractTestCase {
 	public void testDefaultMappedDocumentFactory() {
 		IMappedDocumentFactory factory = Core.getMappedDocumentFactory();
 		factory.addMapping(null, MInOut.Table_Name, (p) -> new MyDocInOut(p.as, p.rs, p.trxName));
+		
+		//need to reset cache if you are replacing doc classes from core
+		CacheMgt.get().reset(DocManager.IDOC_FACTORY_CACHE_TABLE_NAME);
 		
 		int C_AcctSchema_ID = MClientInfo.get().getC_AcctSchema1_ID();
 		MAcctSchema as = new MAcctSchema(Env.getCtx(), C_AcctSchema_ID, getTrxName());

--- a/org.idempiere.test/src/org/idempiere/test/performance/CacheTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/performance/CacheTest.java
@@ -687,7 +687,7 @@ public class CacheTest extends AbstractTestCase {
 			if (ci instanceof CCache<?, ?>) {				
 				@SuppressWarnings("rawtypes")
 				CCache ccache = (CCache) ci;
-				if (ccache.getTableName() == null && ccache.getName().equals(name)) {
+				if (ccache.getName().equals(name)) {
 					if (key != null) {
 						if (ccache.containsKey(key)) {
 							return ccache;


### PR DESCRIPTION
…da functional object

MappedDocumentFactoryTest fail when running idempiere.unit.test due to
document factory cache.