### PR TITLE
IDEMPIERE-4488 Remove .classpath from repository

### DIFF
--- a/migration/.project
+++ b/migration/.project
@@ -5,13 +5,7 @@
 	<projects>
 	</projects>
 	<buildSpec>
-		<buildCommand>
-			<name>org.eclipse.jdt.core.javabuilder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
 </projectDescription>


### PR DESCRIPTION
Fix project definition for migration folder - is not java nature

Usually I import the projects db and migration into eclipse for tracking of changes, the migration definition is wrong.

https://idempiere.atlassian.net/browse/IDEMPIERE-4488