### PR TITLE
IDEMPIERE-2377: Add "Prepare" Document Action to all document type

### DIFF
--- a/org.adempiere.base/src/org/compiere/process/DocumentEngine.java
+++ b/org.adempiere.base/src/org/compiere/process/DocumentEngine.java
@@ -970,7 +970,7 @@ public class DocumentEngine implements DocAction
 			|| docStatus.equals(DocumentEngine.STATUS_Invalid))
 		{
 			options[index++] = DocumentEngine.ACTION_Complete;
-		//	options[index++] = DocumentEngine.ACTION_Prepare;
+			options[index++] = DocumentEngine.ACTION_Prepare;
 			options[index++] = DocumentEngine.ACTION_Void;
 		}
 		//	In Process                  ..  IP


### PR DESCRIPTION

As per requested by Chuck, Enabling Prepare action for all document type. If needs to disable, this can be controlled by document action access per role.