### PR TITLE
IDEMPIERE-4763 Add IsDefault to AD_StorageProvider and use it when creating a new tenant (FHCA-1165)

### DIFF
--- a/migration/i8.2/oracle/202104161730_IDEMPIERE-4763.sql
+++ b/migration/i8.2/oracle/202104161730_IDEMPIERE-4763.sql
@@ -1,0 +1,27 @@
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- IDEMPIERE-4763 Add IsDefault to AD_StorageProvider and use it when creating a new tenant (FHCA-1165)
+-- Apr 16, 2021, 5:27:17 PM CEST
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,IsHtml) VALUES (214419,0,'Default','Default value','The Default Checkbox indicates if this record will be used as a default value.',200037,'IsDefault','N',1,'N','N','Y','N','N',0,'N',20,0,0,'Y',TO_DATE('2021-04-16 17:27:16','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2021-04-16 17:27:16','YYYY-MM-DD HH24:MI:SS'),100,1103,'Y','N','D','N','N','N','Y','e07c06a3-aeda-45e2-9427-a147501cddb1','Y',0,'N','N','N')
+;
+
+-- Apr 16, 2021, 5:27:23 PM CEST
+ALTER TABLE AD_StorageProvider ADD IsDefault CHAR(1) DEFAULT 'N' CHECK (IsDefault IN ('Y','N')) NOT NULL
+;
+
+-- Apr 16, 2021, 5:27:48 PM CEST
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan) VALUES (206603,'Default','Default value','The Default Checkbox indicates if this record will be used as a default value.',200032,214419,'Y',1,100,'N','N','N','N',0,0,'Y',TO_DATE('2021-04-16 17:27:48','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2021-04-16 17:27:48','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','15879e5e-dc83-421a-a21b-bb54d96a0cad','Y',100,2,2)
+;
+
+-- Apr 16, 2021, 5:28:43 PM CEST
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=90, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, XPosition=2, IsToolbarButton=NULL,Updated=TO_DATE('2021-04-16 17:28:43','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206603
+;
+
+-- Apr 16, 2021, 5:28:43 PM CEST
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=100, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, XPosition=5, IsToolbarButton=NULL,Updated=TO_DATE('2021-04-16 17:28:43','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=200860
+;
+
+SELECT register_migration_script('202104161730_IDEMPIERE-4763.sql') FROM dual
+;
+

--- a/migration/i8.2/postgresql/202104161730_IDEMPIERE-4763.sql
+++ b/migration/i8.2/postgresql/202104161730_IDEMPIERE-4763.sql
@@ -1,0 +1,24 @@
+-- IDEMPIERE-4763 Add IsDefault to AD_StorageProvider and use it when creating a new tenant (FHCA-1165)
+-- Apr 16, 2021, 5:27:17 PM CEST
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,IsHtml) VALUES (214419,0,'Default','Default value','The Default Checkbox indicates if this record will be used as a default value.',200037,'IsDefault','N',1,'N','N','Y','N','N',0,'N',20,0,0,'Y',TO_TIMESTAMP('2021-04-16 17:27:16','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2021-04-16 17:27:16','YYYY-MM-DD HH24:MI:SS'),100,1103,'Y','N','D','N','N','N','Y','e07c06a3-aeda-45e2-9427-a147501cddb1','Y',0,'N','N','N')
+;
+
+-- Apr 16, 2021, 5:27:23 PM CEST
+ALTER TABLE AD_StorageProvider ADD COLUMN IsDefault CHAR(1) DEFAULT 'N' CHECK (IsDefault IN ('Y','N')) NOT NULL
+;
+
+-- Apr 16, 2021, 5:27:48 PM CEST
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan) VALUES (206603,'Default','Default value','The Default Checkbox indicates if this record will be used as a default value.',200032,214419,'Y',1,100,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2021-04-16 17:27:48','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2021-04-16 17:27:48','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','15879e5e-dc83-421a-a21b-bb54d96a0cad','Y',100,2,2)
+;
+
+-- Apr 16, 2021, 5:28:43 PM CEST
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=90, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, XPosition=2, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2021-04-16 17:28:43','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206603
+;
+
+-- Apr 16, 2021, 5:28:43 PM CEST
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=100, AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, XPosition=5, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2021-04-16 17:28:43','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=200860
+;
+
+SELECT register_migration_script('202104161730_IDEMPIERE-4763.sql') FROM dual
+;
+

--- a/org.adempiere.base/src/org/compiere/model/MClient.java
+++ b/org.adempiere.base/src/org/compiere/model/MClient.java
@@ -457,6 +457,13 @@ public class MClient extends X_AD_Client implements ImmutablePOSupport
 			AD_Tree_Org_ID, AD_Tree_BPartner_ID, AD_Tree_Project_ID,
 			AD_Tree_SalesRegion_ID, AD_Tree_Product_ID,
 			AD_Tree_Campaign_ID, AD_Tree_Activity_ID, get_TrxName());
+		int defaultStorageProvider = MStorageProvider.getDefaultStorageProviderID();
+		if (defaultStorageProvider > 0)
+		{
+			clientInfo.setAD_StorageProvider_ID(defaultStorageProvider);
+			clientInfo.setStorageImage_ID(defaultStorageProvider);
+			clientInfo.setStorageArchive_ID(defaultStorageProvider);
+		}
 		success = clientInfo.save();
 		return success;
 	}	//	createTrees

--- a/org.adempiere.base/src/org/compiere/model/MStorageProvider.java
+++ b/org.adempiere.base/src/org/compiere/model/MStorageProvider.java
@@ -24,12 +24,13 @@ import org.adempiere.base.Service;
 import org.adempiere.base.ServiceQuery;
 import org.adempiere.exceptions.AdempiereException;
 import org.compiere.util.CCache;
+import org.compiere.util.DB;
 
 public class MStorageProvider extends X_AD_StorageProvider {
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = -5889682671195395536L;
+	private static final long serialVersionUID = 6030898744999167572L;
 
 	public MStorageProvider(Properties ctx, int AD_StorageProvider_ID, String trxName) {
 		super(ctx, AD_StorageProvider_ID, trxName);
@@ -167,4 +168,10 @@ public class MStorageProvider extends X_AD_StorageProvider {
 		}
 		return store;
 	}
+
+	public static int getDefaultStorageProviderID() {
+		final String sql = "SELECT AD_StorageProvider_ID FROM AD_StorageProvider WHERE IsDefault='Y' AND IsActive='Y' ORDER BY AD_StorageProvider_ID";
+		return DB.getSQLValueEx(null, sql);
+	}
+
 }

--- a/org.adempiere.base/src/org/compiere/util/Login.java
+++ b/org.adempiere.base/src/org/compiere/util/Login.java
@@ -31,6 +31,7 @@ import java.util.logging.Level;
 
 import javax.swing.JOptionPane;
 
+import org.adempiere.exceptions.DBException;
 import org.compiere.Adempiere;
 import org.compiere.db.CConnection;
 import org.compiere.model.I_M_Warehouse;
@@ -1024,32 +1025,25 @@ public class Login
 		if (TableName.startsWith("AD_Window")
 			|| TableName.startsWith("AD_PrintFormat")
 			|| TableName.startsWith("AD_Workflow")
+			|| TableName.equals("AD_StorageProvider")
 			|| TableName.startsWith("M_Locator") )
 			return;
 		String value = null;
 		//
-		String sql = "SELECT " + ColumnName + " FROM " + TableName	//	most specific first
-			+ " WHERE IsDefault='Y' AND IsActive='Y' ORDER BY AD_Client_ID DESC, AD_Org_ID DESC";
-		sql = MRole.getDefault(m_ctx, false).addAccessSQL(sql, 
+		StringBuilder sqlb = new StringBuilder("SELECT ")
+			.append(ColumnName).append(" FROM ").append(TableName)	//	most specific first
+			.append(" WHERE IsDefault='Y' AND IsActive='Y' ORDER BY AD_Client_ID DESC, AD_Org_ID DESC, ")
+			.append(ColumnName);
+		String sql = MRole.getDefault(m_ctx, false).addAccessSQL(sqlb.toString(), 
 			TableName, MRole.SQL_NOTQUALIFIED, MRole.SQL_RO);
-		PreparedStatement pstmt = null;
-		ResultSet rs = null;
 		try
 		{
-			pstmt = DB.prepareStatement(sql, null);
-			rs = pstmt.executeQuery();
-			if (rs.next())
-				value = rs.getString(1);
+			value = DB.getSQLValueString(value, sql);
 		}
-		catch (SQLException e)
+		catch (DBException e)
 		{
 			log.log(Level.SEVERE, TableName + " (" + sql + ")", e);
 			return;
-		}
-		finally
-		{
-			DB.close(rs, pstmt);
-			rs = null; pstmt = null;
 		}
 		//	Set Context Value
 		if (value != null && value.length() != 0)


### PR DESCRIPTION


https://idempiere.atlassian.net/browse/IDEMPIERE-4763

* Add column/field AD_StorageProvider.IsDefault
* Includes a minor refactoring of Login.loadDefault to add the ID column to the order by, to make predictable the ID returned when there are more than one record marked as default
* Context variable #AD_StorageProvider_ID is not created