### PR TITLE
IDEMPIERE-3508 2pack: support export from text column to string column

### DIFF
--- a/org.adempiere.pipo/src/org/adempiere/pipo2/PackOut.java
+++ b/org.adempiere.pipo/src/org/adempiere/pipo2/PackOut.java
@@ -85,6 +85,8 @@ public class PackOut
 
 	public static final int MAX_OFFICIAL_ID = MTable.MAX_OFFICIAL_ID;
 
+	public static final String PACKOUT_BLOB_FILE_EXTENSION = ".dat";
+
 	public static void addTextElement(TransformerHandler handler, String qName, String text, AttributesImpl atts) throws SAXException {
 		handler.startElement("", "", qName, atts);
 		append(handler, text);
@@ -381,7 +383,7 @@ public class PackOut
 	 */
 	public String writeBlob(byte[] data) throws IOException {
 		blobCount++;
-		String fileName = blobCount + ".dat";
+		String fileName = blobCount + PACKOUT_BLOB_FILE_EXTENSION;
 		File path = new File(packageDirectory+File.separator+"blobs"+File.separator);
 		path.mkdirs();
 		File file = new File(path, fileName);

--- a/org.adempiere.pipo/src/org/adempiere/pipo2/PoExporter.java
+++ b/org.adempiere.pipo/src/org/adempiere/pipo2/PoExporter.java
@@ -39,6 +39,9 @@ public class PoExporter {
 
 	private TransformerHandler transformerHandler;
 
+	public static final String POEXPORTER_BLOB_TYPE_STRING = "string";
+	public static final String POEXPORTER_BLOB_TYPE_BYTEARRAY = "byte[]";
+
 	private void addTextElement(String qName, String text, AttributesImpl atts) {
 		try {
 			transformerHandler.startElement("", "", qName, atts);
@@ -337,15 +340,15 @@ public class PoExporter {
 		
 		PackOut packOut = ctx.packOut;
 		byte[] data = null;
-		String dataType = null;
+		String dataType = null; // see PoFiller.isBlobOnPackinFile
 		String fileName = null;
 		try {
 			if (value instanceof String) {
 				data = ((String)value).getBytes("UTF-8");
-				dataType = "string";
+				dataType = POEXPORTER_BLOB_TYPE_STRING;
 			} else {
 				data = (byte[]) value;
-				dataType = "byte[]";
+				dataType = POEXPORTER_BLOB_TYPE_BYTEARRAY;
 			}
 
 			fileName = packOut.writeBlob(data);

--- a/org.adempiere.pipo/src/org/adempiere/pipo2/PoFiller.java
+++ b/org.adempiere.pipo/src/org/adempiere/pipo2/PoFiller.java
@@ -57,10 +57,12 @@ public class PoFiller{
 		String value = getStringValue(columnName);
 		if(value == null)
 			return false;
-		
-		String strParts [] = value.split("[|]");
-		return strParts.length == 2;
 
+		String strParts [] = value.split("[|]");
+		return (   strParts.length == 2
+				&& strParts[0].endsWith(PackOut.PACKOUT_BLOB_FILE_EXTENSION)
+				&& (   PoExporter.POEXPORTER_BLOB_TYPE_STRING.equals(strParts[1]) // see PoExporter.addBlob
+					|| PoExporter.POEXPORTER_BLOB_TYPE_BYTEARRAY.equals(strParts[1])));
 	}
 	
 	/**
@@ -358,7 +360,11 @@ public class PoFiller{
 				} else if (DisplayType.isLOB(info.getColumnDisplayType(index))) {
 					setBlob(qName);
 				} else {
-					setString(qName);
+					if (isBlobOnPackinFile(qName)) {
+						setBlob(qName);
+					} else {
+						setString(qName);
+					}
 				}
 			}
 		}
@@ -410,7 +416,7 @@ public class PoFiller{
 					PackIn packIn = ctx.packIn;
 					try {
 						bytes = packIn.readBlob(fileName);
-						if ("byte[]".equals(dataType)) {
+						if (PoExporter.POEXPORTER_BLOB_TYPE_BYTEARRAY.equals(dataType)) {
 							data = bytes;
 						} else {
 							data = new String(bytes, "UTF-8");


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-3508

Implement the fix for the case mentioned in the last comment at
https://idempiere.atlassian.net/browse/IDEMPIERE-3508?focusedCommentId=42780

"in case a 2pack is generated on a system with a blob column, and then imported in a system where that column is string, the import leaves wrong data"

For testing purposes, the following 2pack can be used:
[202105041141_GardenWorld_KanbanRequestsGardenWorld.zip](https://github.com/idempiere/idempiere/files/6420227/202105041141_GardenWorld_KanbanRequestsGardenWorld.zip)

The value of the _Kanban Card Content_ is left incorrectly as "1.dat|string" - with the fix the value is correctly assigned.