### PR TITLE
IDEMPIERE-4792 Bring back frozen column feature for desktop browser

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/metainfo/zk/lang-addon.xml
+++ b/org.adempiere.ui.zk/WEB-INF/src/metainfo/zk/lang-addon.xml
@@ -48,7 +48,7 @@ Copyright (C) 2007 Ashley G Ramdass (ADempiere WebUI).
 	<javascript-module name="jawwa.atmosphere" version="202102091500"/>
 	<javascript-module name="adempiere.local.storage" version="202011151100"/>
 	<javascript-moudle name="html2canvas" version="1.0.0.rc7"/>
-	<javascript-module name="org.idempiere.commons" version="202105072207"/>
+	<javascript-module name="org.idempiere.commons" version="202105200826"/>
 	<javascript-module name="jquery.maskedinput" version="1.4.1" />
 	<javascript-module name="photobooth"	version="0.7-rsd3" />
 	<javascript-module name="chosenbox" version="202012041500"/>

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/GridView.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/GridView.java
@@ -61,6 +61,7 @@ import org.zkoss.zul.Cell;
 import org.zkoss.zul.Center;
 import org.zkoss.zul.Column;
 import org.zkoss.zul.Div;
+import org.zkoss.zul.Frozen;
 import org.zkoss.zul.Paging;
 import org.zkoss.zul.Row;
 import org.zkoss.zul.Vlayout;
@@ -299,6 +300,10 @@ public class GridView extends Vlayout implements EventListener<Event>, IdSpace, 
 		setupColumns();
 		render();
 		
+		if (listbox.getFrozen() != null){
+			listbox.getFrozen().setWidgetOverride("syncScroll", "function (){idempiere.syncScrollFrozen(this);}");
+		}
+		
 		updateListIndex();
 
 		this.init = true;
@@ -528,9 +533,7 @@ public class GridView extends Vlayout implements EventListener<Event>, IdSpace, 
 		Columns columns = new Columns();
 		
 		//frozen not working well on tablet devices yet
-		//frozen is implemented poorly on zk ce, not working with scroll and white-space wrap
 		//unlikely to be fixed since the working 'smooth scrolling frozen' is a zk ee only feature
-		/*
 		if (!ClientInfo.isMobile())
 		{
 			Frozen frozen = new Frozen();
@@ -538,8 +541,7 @@ public class GridView extends Vlayout implements EventListener<Event>, IdSpace, 
 			frozen.setColumns(2);
 			listbox.appendChild(frozen);
 		}
-		*/
-		
+				
 		org.zkoss.zul.Column selection = new Column();
 		selection.setHeight("2em");
 		ZKUpdateUtil.setWidth(selection, "22px");

--- a/org.adempiere.ui.zk/WEB-INF/src/web/js/org/idempiere/commons/layout.js
+++ b/org.adempiere.ui.zk/WEB-INF/src/web/js/org/idempiere/commons/layout.js
@@ -13,3 +13,37 @@ window.idempiere.scrollToRow = function(uuid){
 	}
 };
 
+//overload for recalculate width of grid frozen scroll
+window.idempiere.syncScrollFrozen = function(wgt){
+	var parent = wgt.parent;
+	
+	if (parent.eheadtbl && parent._nativebar) {
+		var scroll = wgt.$n('scrollX');
+		var cells = parent._getFirstRowCells(parent.eheadrows);
+		var frozens = wgt._columns;
+		
+		var frozenWidth = 0; 
+		for (var i = 0; i < frozens; i++)
+			frozenWidth += cells[i].offsetWidth;
+		
+		var bodyWidth = parent.$n('body').offsetWidth;
+		var availableWidth = bodyWidth - frozenWidth;
+		var totalWidth = 0;
+		var toScroll = 0;
+		for (var i = frozens; i < cells.length; i++){
+			totalWidth += cells[i].offsetWidth;
+		}
+		for (var i = frozens; i < cells.length; i++){
+			totalWidth -= cells[i].offsetWidth;
+			toScroll++;
+			if (totalWidth <= availableWidth) {
+				break;
+			}
+		}
+		
+		if (toScroll > 0)
+			scroll.firstChild.style.width = jq.px0(availableWidth+(toScroll * 50));
+	}
+	
+	wgt.$syncScroll ()
+}

--- a/org.adempiere.ui.zk/index.zul
+++ b/org.adempiere.ui.zk/index.zul
@@ -13,6 +13,12 @@ Copyright (C) 2007 Ashley G Ramdass.
 <?link rel="stylesheet" type="text/css" href="${themeStyleSheetByBrowser}"?>
 <?link rel="stylesheet" type="text/css" href="css/PAPanel.css"?>
 <?link rel="manifest" href="manifest.json"?>
+<?style content="
+     .z-grid-header > table > tbody > tr.z-columns > th.z-column.hiddencol > .z-column-content {
+	     white-space: nowrap !important;     
+	     text-overflow: unset !important;
+     }
+"?>
 <zk>
 	<script><![CDATA[
 		zk.load("jawwa.atmosphere");
@@ -239,7 +245,31 @@ Copyright (C) 2007 Ashley G Ramdass.
 				}
 				this.$onSize.apply(this, arguments);
 			});
-		});			
+		});	
+		
+		zk.afterLoad("zul.mesh", function () {
+		    var _xFrozen = {};
+		    zk.override(zul.mesh.Frozen.prototype, _xFrozen, {
+		        _doScrollNow: function() {
+					var result = _xFrozen._doScrollNow.apply(this, arguments);
+					/*Patch: add class to non-visible columns*/
+					var mesh = this.parent;
+					if (mesh.head) {
+						var totalCols = mesh.head.nChildren,
+									hdcol = mesh.ehdfaker.firstChild;
+			
+						for (var faker, i = 0; hdcol && i < totalCols; hdcol = hdcol.nextSibling, i++) {
+							if (hdcol.style.width.indexOf('0.001px') != -1 || hdcol.style.width.indexOf('0px') != -1) {
+								jq(zk.$(hdcol).$n()).addClass("hiddencol");
+							} else {
+								jq(zk.$(hdcol).$n()).removeClass("hiddencol");
+							}
+						}
+					}
+					return result;
+		        }
+		    });
+		});						
 	]]>
 	</script>
     <include src="${themePreference}"/>


### PR DESCRIPTION
Incorporate workaround from zk tracker and re-eanble grid frozen columns
for dekstop browser.