### PR TITLE
IDEMPIERE-4811 Custom Toolbar Buttons Dynamic Validation Fix

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/DetailPane.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/DetailPane.java
@@ -477,8 +477,8 @@ public class DetailPane extends Panel implements EventListener<Event>, IdSpace {
 							btn.setLabel(label);
 						}
 
-						ToolbarCustomButton toolbarCustomBtn = new ToolbarCustomButton(toolbarButton, btn, actionId, tabPanel.getGridTab().getWindowNo());
-						tp.toolbarCustomButtons.add(toolbarCustomBtn);
+						ToolbarCustomButton toolbarCustomBtn = new ToolbarCustomButton(toolbarButton, btn, actionId, tabPanel.getGridTab().getWindowNo(), tabPanel.getGridTab().getTabNo());
+						tp.toolbarCustomButtons.put(btn, toolbarCustomBtn);
 
 						toolbar.appendChild(btn);
 					}
@@ -877,7 +877,10 @@ public class DetailPane extends Panel implements EventListener<Event>, IdSpace {
         			btn.setVisible(false);
         		} else if (tabRestrictList.contains(btn.getId())) {
         			btn.setVisible(false);
-        		} else {
+        		} else if (tabpanel.toolbarCustomButtons.containsKey(btn)) {
+        			ToolbarCustomButton customButton = tabpanel.toolbarCustomButtons.get(btn);
+        			customButton.dynamicDisplay();
+        		}else {
         			btn.setVisible(true);
         		}
         	}        	
@@ -1090,7 +1093,7 @@ public class DetailPane extends Panel implements EventListener<Event>, IdSpace {
 
 		private IADTabpanel adTabPanel;
 		
-		private List<ToolbarCustomButton> toolbarCustomButtons = new ArrayList<ToolbarCustomButton>();
+		private HashMap<ToolBarButton, ToolbarCustomButton> toolbarCustomButtons = new HashMap<ToolBarButton, ToolbarCustomButton>();
 
 		private A overflowButton;
 

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/ToolbarCustomButton.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/ToolbarCustomButton.java
@@ -34,12 +34,7 @@ public class ToolbarCustomButton implements EventListener<Event>, Evaluatee {
 	private MToolBarButton mToolbarButton;
 
 	public ToolbarCustomButton(MToolBarButton mToolbarButton, Toolbarbutton btn, String actionId, int windowNo) {
-		toolbarButton = btn;
-		this.actionId = actionId;
-		this.windowNo = windowNo;
-		this.mToolbarButton = mToolbarButton;
-		
-		toolbarButton.addEventListener(Events.ON_CLICK, this);
+		this(mToolbarButton, btn, actionId, windowNo, -1);
 	}
 	
 	public ToolbarCustomButton(MToolBarButton mToolbarButton, Toolbarbutton btn, String actionId, int windowNo, int tabNo) {

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/ToolbarCustomButton.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/ToolbarCustomButton.java
@@ -30,12 +30,23 @@ public class ToolbarCustomButton implements EventListener<Event>, Evaluatee {
 	private Toolbarbutton toolbarButton;
 	private String actionId;
 	private int windowNo;
+	private int tabNo = -1;
 	private MToolBarButton mToolbarButton;
 
 	public ToolbarCustomButton(MToolBarButton mToolbarButton, Toolbarbutton btn, String actionId, int windowNo) {
 		toolbarButton = btn;
 		this.actionId = actionId;
 		this.windowNo = windowNo;
+		this.mToolbarButton = mToolbarButton;
+		
+		toolbarButton.addEventListener(Events.ON_CLICK, this);
+	}
+	
+	public ToolbarCustomButton(MToolBarButton mToolbarButton, Toolbarbutton btn, String actionId, int windowNo, int tabNo) {
+		toolbarButton = btn;
+		this.actionId = actionId;
+		this.windowNo = windowNo;
+		this.tabNo = tabNo;
 		this.mToolbarButton = mToolbarButton;
 		
 		toolbarButton.addEventListener(Events.ON_CLICK, this);
@@ -62,7 +73,7 @@ public class ToolbarCustomButton implements EventListener<Event>, Evaluatee {
 		if (adTabpanel == null)
 			return "";
 		
-		int tabNo = adTabpanel.getTabNo();
+		int tabNo = this.tabNo >= 0 ? this.tabNo : adTabpanel.getTabNo();
 		if( tabNo == 0)
 	    	return adTabpanel.get_ValueAsString(variableName);
 	    else


### PR DESCRIPTION
Ticket: https://idempiere.atlassian.net/browse/IDEMPIERE-4811

Expanded ToolbarCustomButton class to set tabNo when rendered on Tab Detail Pane to have access to tab Context.
Expanded DetailPane on method updateToolbar to use ToolbarCustomButton.dynamicDisplay() when toolbarbutton is CustomToolbarButton. 