### PR TITLE
IDEMPIERE-4914 Wrong BankAccount when creating createCounterDoc for linked BPartner

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MPayment.java
+++ b/org.adempiere.base/src/org/compiere/model/MPayment.java
@@ -2220,9 +2220,9 @@ public class MPayment extends X_C_Payment
 		counter.setRef_Payment_ID(getC_Payment_ID());
 		//
 		String sql = "SELECT C_BankAccount_ID FROM C_BankAccount "
-			+ "WHERE C_Currency_ID=? AND AD_Org_ID IN (0,?) AND IsActive='Y' "
+			+ "WHERE C_Currency_ID=? AND AD_Org_ID IN (0,?) AND IsActive='Y' AND AD_Client_ID = ?"
 			+ "ORDER BY IsDefault DESC";
-		int C_BankAccount_ID = DB.getSQLValue(get_TrxName(), sql, getC_Currency_ID(), counterAD_Org_ID);
+		int C_BankAccount_ID = DB.getSQLValue(get_TrxName(), sql, getC_Currency_ID(), counterAD_Org_ID,getAD_Client_ID());
 		counter.setC_BankAccount_ID(C_BankAccount_ID);
 
 		//	References


### PR DESCRIPTION
Added a client check when retrieving the default bank account

[https://idempiere.atlassian.net/browse/IDEMPIERE-4914](url)