### PR TITLE
IDEMPIERE-4917:Inject Context Variables from Menu to Info Window

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/desktop/TabbedDesktop.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/desktop/TabbedDesktop.java
@@ -111,10 +111,9 @@ public abstract class TabbedDesktop extends AbstractDesktop {
 	 */
 	@Override
 	public void openInfo(int infoId) {
-		InfoPanel infoPanel = InfoManager.create(infoId);
+		InfoPanel infoPanel = InfoManager.create(infoId, getPredefinedContextVariables());
 		
 		if (infoPanel != null) {
-			Env.setPredefinedVariables(Env.getCtx(), infoPanel.getWindowNo(), getPredefinedContextVariables());
 			DesktopTabpanel tabPanel = new DesktopTabpanel();
 			infoPanel.setParent(tabPanel);
 			String title = infoPanel.getTitle();

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/DefaultInfoFactory.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/DefaultInfoFactory.java
@@ -50,6 +50,13 @@ public class DefaultInfoFactory implements IInfoFactory {
 	@Override
 	public InfoPanel create(int WindowNo, String tableName, String keyColumn,
 			String value, boolean multiSelection, String whereClause, int AD_InfoWindow_ID, boolean lookup) {
+	
+		return create(WindowNo, tableName, keyColumn,
+				value, multiSelection, whereClause, AD_InfoWindow_ID, lookup, null);
+	}
+	
+	public InfoPanel create(int WindowNo, String tableName, String keyColumn,
+				String value, boolean multiSelection, String whereClause, int AD_InfoWindow_ID, boolean lookup, String predefinedContextVariables) {
 		InfoPanel info = null;
 		setSOTrxBasedOnDocType(WindowNo);
 
@@ -106,7 +113,7 @@ public class DefaultInfoFactory implements IInfoFactory {
 	                    multiSelection, whereClause, lookup);
 	    	}
         } else {
-        	info = new InfoWindow(WindowNo, tableName, keyColumn, value, multiSelection, whereClause, AD_InfoWindow_ID, lookup);
+        	info = new InfoWindow(WindowNo, tableName, keyColumn, value, multiSelection, whereClause, AD_InfoWindow_ID, lookup, null, predefinedContextVariables);
         	if (!info.loadedOK()) {
 	            info = new InfoGeneralPanel (value, WindowNo,
 	                tableName, keyColumn,
@@ -176,10 +183,17 @@ public class DefaultInfoFactory implements IInfoFactory {
 
 	@Override
 	public InfoWindow create(int AD_InfoWindow_ID) {
+		
+		return create(AD_InfoWindow_ID, null);
+	}
+	
+	@Override
+	public InfoWindow create(int AD_InfoWindow_ID, String predefinedContextVariables) {
+		
 		MInfoWindow infoWindow = new MInfoWindow(Env.getCtx(), AD_InfoWindow_ID, (String)null);
 		String tableName = infoWindow.getAD_Table().getTableName();
 		String keyColumn = tableName + "_ID";
-		InfoPanel info = create(-1, tableName, keyColumn, null, false, null, AD_InfoWindow_ID, false);
+		InfoPanel info = create(-1, tableName, keyColumn, null, false, null, AD_InfoWindow_ID, false, predefinedContextVariables);
 		if (info instanceof InfoWindow)
 			return (InfoWindow) info;
 		else

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/IInfoFactory.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/IInfoFactory.java
@@ -34,4 +34,6 @@ public interface IInfoFactory {
             boolean multiSelection, String whereClause, int AD_InfoWindow_ID);
 	
 	public InfoWindow create (int AD_InfoWindow_ID); 
+	
+	public InfoWindow create (int AD_InfoWindow_ID, String predefinedContextVariables); 
 }

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/InfoManager.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/InfoManager.java
@@ -156,6 +156,18 @@ public class InfoManager
 	 */
 	public static InfoWindow create (int AD_InfoWindow_ID)
     {
+		return create (AD_InfoWindow_ID, null);
+    }
+	
+	
+	/**
+	 * 
+	 * @param AD_InfoWindow_ID
+	 * @param predefinedContextVariables
+	 * @return {@link InfoWindow}
+	 */
+	public static InfoWindow create (int AD_InfoWindow_ID, String predefinedContextVariables)
+    {
         InfoWindow info = null;
 
         List<Long> visitedIds = new ArrayList<Long>();
@@ -167,7 +179,7 @@ public class InfoManager
 					IInfoFactory service = serviceReference.getService();
 					if (service != null) {
 						visitedIds.add(key);
-						info = service.create(AD_InfoWindow_ID);
+						info = service.create(AD_InfoWindow_ID, predefinedContextVariables);
 						if (info != null)
 							return info;
 					} else {
@@ -187,7 +199,7 @@ public class InfoManager
 			if (service != null)
 			{
 				s_infoFactoryCache.put(serviceId, serviceReference);
-				info = service.create(AD_InfoWindow_ID);
+				info = service.create(AD_InfoWindow_ID, predefinedContextVariables);
 				if (info != null)
 					break;
 			}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
@@ -215,6 +215,21 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 	 */
 	public InfoWindow(int WindowNo, String tableName, String keyColumn, String queryValue, 
 			boolean multipleSelection, String whereClause, int AD_InfoWindow_ID, boolean lookup, GridField field) {
+		this(WindowNo, tableName, keyColumn, queryValue, multipleSelection, whereClause, AD_InfoWindow_ID, lookup, field, null);		
+	}
+
+	/**
+	 * @param WindowNo
+	 * @param tableName
+	 * @param keyColumn
+	 * @param multipleSelection
+	 * @param whereClause
+	 * @param lookup
+	 * @param gridfield
+	 * @param predefinedContextVariables
+	 */
+	public InfoWindow(int WindowNo, String tableName, String keyColumn, String queryValue, 
+			boolean multipleSelection, String whereClause, int AD_InfoWindow_ID, boolean lookup, GridField field, String predefinedContextVariables) {
 		super(WindowNo, tableName, keyColumn, multipleSelection, whereClause,
 				lookup, AD_InfoWindow_ID, queryValue);		
 		this.m_gridfield = field;
@@ -240,6 +255,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
    			}
    		}); //xolali --end-
 
+   		Env.setPredefinedVariables(Env.getCtx(), getWindowNo(), predefinedContextVariables);
 		infoContext = new Properties(Env.getCtx());
 		p_loadedOK = loadInfoDefinition(); 
 		


### PR DESCRIPTION
IDEMPIERE-4917

I added Info window to menu and tested below case.
I could perse Predefined Context Variables at Info Window.
*Sql WHERE field of info window.
*Display Logic field of info window column.
*Default Logic field of info window column.
*Dynamic Validation of info window column.
*Fields of process parameter that assigned info window.

I added a new method to IInfoFactory,so someone who developed a plugin of info window needs to implement the method.
And I confirmed to impact of source code change.
*I could open info window and use at field of window.
*I could open info window and use at field of find window.
*I could open info window and use at field of process parameter.
*I could open info window and use at Views of gadget.

This change is normal InfoWindow class only, 
Below special Infowindow classes can not perse Predefined Context Variables yet.
*InfoBPartnerWindow
*InfoProductWindow
*InfoInvoiceWindow
*InfoOrderWindow
*InfoAssetWindow
*InfoInOutWindow
*InfoPaymentWindow
*InfoCashLinePanel
*InfoAssignmentWindow

Because I think that these special Info windows does not open from menu usually.
I can't judgement if I should change up to these classes.

best regards.