### PR TITLE
IDEMPIERE-4917:Inject Context Variables from Menu to Info Window

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/desktop/TabbedDesktop.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/desktop/TabbedDesktop.java
@@ -111,10 +111,9 @@ public abstract class TabbedDesktop extends AbstractDesktop {
 	 */
 	@Override
 	public void openInfo(int infoId) {
-		InfoPanel infoPanel = InfoManager.create(infoId);
+		InfoPanel infoPanel = InfoManager.create(infoId, getPredefinedContextVariables());
 		
 		if (infoPanel != null) {
-			Env.setPredefinedVariables(Env.getCtx(), infoPanel.getWindowNo(), getPredefinedContextVariables());
 			DesktopTabpanel tabPanel = new DesktopTabpanel();
 			infoPanel.setParent(tabPanel);
 			String title = infoPanel.getTitle();

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/DefaultInfoFactory.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/DefaultInfoFactory.java
@@ -50,17 +50,24 @@ public class DefaultInfoFactory implements IInfoFactory {
 	@Override
 	public InfoPanel create(int WindowNo, String tableName, String keyColumn,
 			String value, boolean multiSelection, String whereClause, int AD_InfoWindow_ID, boolean lookup) {
+	
+		return create(WindowNo, tableName, keyColumn,
+				value, multiSelection, whereClause, AD_InfoWindow_ID, lookup, null);
+	}
+
+	public InfoPanel create(int WindowNo, String tableName, String keyColumn,
+				String value, boolean multiSelection, String whereClause, int AD_InfoWindow_ID, boolean lookup, String predefinedContextVariables) {
 		InfoPanel info = null;
 		setSOTrxBasedOnDocType(WindowNo);
 
         if (tableName.equals("C_BPartner")) {
-        	info = new InfoBPartnerWindow(WindowNo, tableName, keyColumn, value, multiSelection, whereClause, AD_InfoWindow_ID, lookup);
+        	info = new InfoBPartnerWindow(WindowNo, tableName, keyColumn, value, multiSelection, whereClause, AD_InfoWindow_ID, lookup, predefinedContextVariables);
         	if (!info.loadedOK()) {
         		info = new InfoBPartnerPanel (value,WindowNo, !Env.getContext(Env.getCtx(), WindowNo, "IsSOTrx").equals("N"),
         				multiSelection, whereClause, lookup);
         	}
         } else if (tableName.equals("M_Product")) {
-        	info = new InfoProductWindow(WindowNo, tableName, keyColumn, value, multiSelection, whereClause, AD_InfoWindow_ID, lookup);
+        	info = new InfoProductWindow(WindowNo, tableName, keyColumn, value, multiSelection, whereClause, AD_InfoWindow_ID, lookup, predefinedContextVariables);
     		if (!info.loadedOK()) {
 	            info = new InfoProductPanel ( WindowNo,
 	            		Env.getContextAsInt(Env.getCtx(), WindowNo, "M_Warehouse_ID"),
@@ -68,31 +75,31 @@ public class DefaultInfoFactory implements IInfoFactory {
 	                    multiSelection, value,whereClause, lookup);
     		}
         } else if (tableName.equals("C_Invoice")) {
-        	info = new InfoInvoiceWindow(WindowNo, tableName, keyColumn, value, multiSelection, whereClause, AD_InfoWindow_ID, lookup);
+        	info = new InfoInvoiceWindow(WindowNo, tableName, keyColumn, value, multiSelection, whereClause, AD_InfoWindow_ID, lookup, predefinedContextVariables);
     		if (!info.loadedOK()) {
     			info = new InfoInvoicePanel ( WindowNo, value,
                     multiSelection, whereClause, lookup);
     		}
         } else if (tableName.equals("A_Asset")) {
-        	info = new InfoAssetWindow(WindowNo, tableName, keyColumn, value, multiSelection, whereClause, AD_InfoWindow_ID, lookup);
+        	info = new InfoAssetWindow(WindowNo, tableName, keyColumn, value, multiSelection, whereClause, AD_InfoWindow_ID, lookup, predefinedContextVariables);
     		if (!info.loadedOK()) {
     			info = new InfoAssetPanel (WindowNo, 0, value,
     					multiSelection, whereClause, lookup);
     		}
         } else if (tableName.equals("C_Order")) {
-        	info = new InfoOrderWindow(WindowNo, tableName, keyColumn, value, multiSelection, whereClause, AD_InfoWindow_ID, lookup);
+        	info = new InfoOrderWindow(WindowNo, tableName, keyColumn, value, multiSelection, whereClause, AD_InfoWindow_ID, lookup, predefinedContextVariables);
     		if (!info.loadedOK()) {
 	            info = new InfoOrderPanel ( WindowNo, value,
 	                    multiSelection, whereClause, lookup);
     		}
         } else if (tableName.equals("M_InOut")) {
-        	info = new InfoInOutWindow(WindowNo, tableName, keyColumn, value, multiSelection, whereClause, AD_InfoWindow_ID, lookup);
+        	info = new InfoInOutWindow(WindowNo, tableName, keyColumn, value, multiSelection, whereClause, AD_InfoWindow_ID, lookup, predefinedContextVariables);
 	    	if (!info.loadedOK()) {
 	            info = new InfoInOutPanel (WindowNo, value,
 	                    multiSelection, whereClause, lookup);
 	    	}
         } else if (tableName.equals("C_Payment")) {
-        	info = new InfoPaymentWindow(WindowNo, tableName, keyColumn, value, multiSelection, whereClause, AD_InfoWindow_ID, lookup);
+        	info = new InfoPaymentWindow(WindowNo, tableName, keyColumn, value, multiSelection, whereClause, AD_InfoWindow_ID, lookup, predefinedContextVariables);
 	    	if (!info.loadedOK()) {
 	            info = new InfoPaymentPanel (WindowNo, value, multiSelection, whereClause, lookup);
 	    	}
@@ -100,13 +107,13 @@ public class DefaultInfoFactory implements IInfoFactory {
         	info = new InfoCashLinePanel (WindowNo, value,
                     multiSelection, whereClause, lookup);
         } else if (tableName.equals("S_ResourceAssignment")) {
-        	info = new InfoAssignmentWindow(WindowNo, tableName, keyColumn, value, multiSelection, whereClause, AD_InfoWindow_ID, lookup);
+        	info = new InfoAssignmentWindow(WindowNo, tableName, keyColumn, value, multiSelection, whereClause, AD_InfoWindow_ID, lookup, predefinedContextVariables);
 	    	if (!info.loadedOK()) {
 	            info = new InfoAssignmentPanel (WindowNo, value,
 	                    multiSelection, whereClause, lookup);
 	    	}
         } else {
-        	info = new InfoWindow(WindowNo, tableName, keyColumn, value, multiSelection, whereClause, AD_InfoWindow_ID, lookup);
+        	info = new InfoWindow(WindowNo, tableName, keyColumn, value, multiSelection, whereClause, AD_InfoWindow_ID, lookup, null, predefinedContextVariables);
         	if (!info.loadedOK()) {
 	            info = new InfoGeneralPanel (value, WindowNo,
 	                tableName, keyColumn,
@@ -176,10 +183,16 @@ public class DefaultInfoFactory implements IInfoFactory {
 
 	@Override
 	public InfoWindow create(int AD_InfoWindow_ID) {
+
+		return create(AD_InfoWindow_ID, null);
+	}
+
+	@Override
+	public InfoWindow create(int AD_InfoWindow_ID, String predefinedContextVariables) {
 		MInfoWindow infoWindow = new MInfoWindow(Env.getCtx(), AD_InfoWindow_ID, (String)null);
 		String tableName = infoWindow.getAD_Table().getTableName();
 		String keyColumn = tableName + "_ID";
-		InfoPanel info = create(-1, tableName, keyColumn, null, false, null, AD_InfoWindow_ID, false);
+		InfoPanel info = create(-1, tableName, keyColumn, null, false, null, AD_InfoWindow_ID, false, predefinedContextVariables);
 		if (info instanceof InfoWindow)
 			return (InfoWindow) info;
 		else

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/IInfoFactory.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/IInfoFactory.java
@@ -34,4 +34,8 @@ public interface IInfoFactory {
             boolean multiSelection, String whereClause, int AD_InfoWindow_ID);
 	
 	public InfoWindow create (int AD_InfoWindow_ID); 
+	
+	public default InfoWindow create (int AD_InfoWindow_ID, String predefinedContextVariables) {
+		return create (AD_InfoWindow_ID);
+	}
 }

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/InfoManager.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/InfoManager.java
@@ -155,6 +155,18 @@ public class InfoManager
 	 * @return {@link InfoWindow}
 	 */
 	public static InfoWindow create (int AD_InfoWindow_ID)
+	{
+		return create (AD_InfoWindow_ID, null);
+	}
+
+
+	/**
+	 * 
+	 * @param AD_InfoWindow_ID
+	 * @param predefinedContextVariables
+	 * @return {@link InfoWindow}
+	 */
+	public static InfoWindow create (int AD_InfoWindow_ID, String predefinedContextVariables)
     {
         InfoWindow info = null;
 
@@ -167,7 +179,7 @@ public class InfoManager
 					IInfoFactory service = serviceReference.getService();
 					if (service != null) {
 						visitedIds.add(key);
-						info = service.create(AD_InfoWindow_ID);
+						info = service.create(AD_InfoWindow_ID ,predefinedContextVariables);
 						if (info != null)
 							return info;
 					} else {
@@ -187,7 +199,7 @@ public class InfoManager
 			if (service != null)
 			{
 				s_infoFactoryCache.put(serviceId, serviceReference);
-				info = service.create(AD_InfoWindow_ID);
+				info = service.create(AD_InfoWindow_ID, predefinedContextVariables);
 				if (info != null)
 					break;
 			}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoAssetWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoAssetWindow.java
@@ -50,6 +50,24 @@ public class InfoAssetWindow extends InfoWindow {
 		// TODO Auto-generated constructor stub
 	}
 
+	/**
+	 * @param WindowNo
+	 * @param tableName
+	 * @param keyColumn
+	 * @param queryValue
+	 * @param multipleSelection
+	 * @param whereClause
+	 * @param AD_InfoWindow_ID
+	 * @param lookup
+	 * @param predefinedContextVariables
+	 */
+	public InfoAssetWindow(int WindowNo, String tableName, String keyColumn,
+			String queryValue, boolean multipleSelection, String whereClause,
+			int AD_InfoWindow_ID, boolean lookup, String predefinedContextVariables) {
+		super(WindowNo, tableName, keyColumn, queryValue, multipleSelection,
+				whereClause, AD_InfoWindow_ID, lookup, null, predefinedContextVariables);
+	}
+	
 	@Override
 	protected void saveSelectionDetail() {
         int row = contentPanel.getSelectedRow();

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoAssignmentWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoAssignmentWindow.java
@@ -47,4 +47,21 @@ public class InfoAssignmentWindow extends InfoWindow {
 				whereClause, AD_InfoWindow_ID, lookup);
 	}
 
+	/**
+	 * @param WindowNo
+	 * @param tableName
+	 * @param keyColumn
+	 * @param queryValue
+	 * @param multipleSelection
+	 * @param whereClause
+	 * @param AD_InfoWindow_ID
+	 * @param lookup
+	 * @param predefinedContextVariables
+	 */
+	public InfoAssignmentWindow(int WindowNo, String tableName,
+			String keyColumn, String queryValue, boolean multipleSelection,
+			String whereClause, int AD_InfoWindow_ID, boolean lookup, String predefinedContextVariables) {
+		super(WindowNo, tableName, keyColumn, queryValue, multipleSelection,
+				whereClause, AD_InfoWindow_ID, lookup, null, predefinedContextVariables);
+	}
 }

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoBPartnerWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoBPartnerWindow.java
@@ -48,6 +48,24 @@ public class InfoBPartnerWindow extends InfoWindow {
 		super(WindowNo, tableName, keyColumn, queryValue, multipleSelection,
 				whereClause, AD_InfoWindow_ID, lookup);
 	}
+	
+	/**
+	 * @param WindowNo
+	 * @param tableName
+	 * @param keyColumn
+	 * @param queryValue
+	 * @param multipleSelection
+	 * @param whereClause
+	 * @param AD_InfoWindow_ID
+	 * @param lookup
+	 * @param predefinedContextVariables
+	 */
+	public InfoBPartnerWindow(int WindowNo, String tableName, String keyColumn,
+			String queryValue, boolean multipleSelection, String whereClause,
+			int AD_InfoWindow_ID, boolean lookup, String predefinedContextVariables) {
+		super(WindowNo, tableName, keyColumn, queryValue, multipleSelection,
+				whereClause, AD_InfoWindow_ID, lookup, null, predefinedContextVariables);
+	}
 
 	/**
 	 *	Has History

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoInOutWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoInOutWindow.java
@@ -46,4 +46,21 @@ public class InfoInOutWindow extends InfoWindow {
 				whereClause, AD_InfoWindow_ID, lookup);
 	}
 
+	/**
+	 * @param WindowNo
+	 * @param tableName
+	 * @param keyColumn
+	 * @param queryValue
+	 * @param multipleSelection
+	 * @param whereClause
+	 * @param AD_InfoWindow_ID
+	 * @param lookup
+	 * @param predefinedContextVariables
+	 */
+	public InfoInOutWindow(int WindowNo, String tableName, String keyColumn,
+			String queryValue, boolean multipleSelection, String whereClause,
+			int AD_InfoWindow_ID, boolean lookup, String predefinedContextVariables) {
+		super(WindowNo, tableName, keyColumn, queryValue, multipleSelection,
+				whereClause, AD_InfoWindow_ID, lookup, null, predefinedContextVariables);
+	}
 }

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoInvoiceWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoInvoiceWindow.java
@@ -48,6 +48,24 @@ public class InfoInvoiceWindow extends InfoWindow {
 				whereClause, AD_InfoWindow_ID, lookup);
 	}
 
+	/**
+	 * @param WindowNo
+	 * @param tableName
+	 * @param keyColumn
+	 * @param queryValue
+	 * @param multipleSelection
+	 * @param whereClause
+	 * @param AD_InfoWindow_ID
+	 * @param lookup
+	 * @param predefinedContextVariables
+	 */
+	public InfoInvoiceWindow(int WindowNo, String tableName, String keyColumn,
+			String queryValue, boolean multipleSelection, String whereClause,
+			int AD_InfoWindow_ID, boolean lookup, String predefinedContextVariables) {
+		super(WindowNo, tableName, keyColumn, queryValue, multipleSelection,
+				whereClause, AD_InfoWindow_ID, lookup, null, predefinedContextVariables);
+	}
+	
 	@Override
 	protected void saveSelectionDetail() {
         int row = contentPanel.getSelectedRow();

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoOrderWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoOrderWindow.java
@@ -45,5 +45,23 @@ public class InfoOrderWindow extends InfoWindow {
 		super(WindowNo, tableName, keyColumn, queryValue, multipleSelection,
 				whereClause, AD_InfoWindow_ID, lookup);
 	}
+	
+	/**
+	 * @param WindowNo
+	 * @param tableName
+	 * @param keyColumn
+	 * @param queryValue
+	 * @param multipleSelection
+	 * @param whereClause
+	 * @param AD_InfoWindow_ID
+	 * @param lookup
+	 * @param predefinedContextVariables
+	 */
+	public InfoOrderWindow(int WindowNo, String tableName, String keyColumn,
+			String queryValue, boolean multipleSelection, String whereClause,
+			int AD_InfoWindow_ID, boolean lookup, String predefinedContextVariables) {
+		super(WindowNo, tableName, keyColumn, queryValue, multipleSelection,
+				whereClause, AD_InfoWindow_ID, lookup, null, predefinedContextVariables);
+	}
 
 }

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoPaymentWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoPaymentWindow.java
@@ -46,4 +46,22 @@ public class InfoPaymentWindow extends InfoWindow {
 				whereClause, AD_InfoWindow_ID, lookup);
 	}
 
+	/**
+	 * @param WindowNo
+	 * @param tableName
+	 * @param keyColumn
+	 * @param queryValue
+	 * @param multipleSelection
+	 * @param whereClause
+	 * @param AD_InfoWindow_ID
+	 * @param lookup
+	 * @param predefinedContextVariables
+	 */
+	public InfoPaymentWindow(int WindowNo, String tableName, String keyColumn,
+			String queryValue, boolean multipleSelection, String whereClause,
+			int AD_InfoWindow_ID, boolean lookup, String predefinedContextVariables) {
+		super(WindowNo, tableName, keyColumn, queryValue, multipleSelection,
+				whereClause, AD_InfoWindow_ID, lookup, null, predefinedContextVariables);
+	}
+
 }

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoProductWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoProductWindow.java
@@ -114,6 +114,24 @@ public class InfoProductWindow extends InfoWindow {
 		super(WindowNo, tableName, keyColumn, queryValue, multipleSelection,
 				whereClause, AD_InfoWindow_ID, lookup);
 	}
+	
+	/**
+	 * @param WindowNo
+	 * @param tableName
+	 * @param keyColumn
+	 * @param queryValue
+	 * @param multipleSelection
+	 * @param whereClause
+	 * @param AD_InfoWindow_ID
+	 * @param lookup
+	 * @param predefinedContextVariables
+	 */
+	public InfoProductWindow(int WindowNo, String tableName, String keyColumn,
+			String queryValue, boolean multipleSelection, String whereClause,
+			int AD_InfoWindow_ID, boolean lookup, String predefinedContextVariables) {
+		super(WindowNo, tableName, keyColumn, queryValue, multipleSelection,
+				whereClause, AD_InfoWindow_ID, lookup, null, predefinedContextVariables);
+	}
 
 	@Override
 	protected String getSQLWhere() {

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
@@ -215,6 +215,21 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 	 */
 	public InfoWindow(int WindowNo, String tableName, String keyColumn, String queryValue, 
 			boolean multipleSelection, String whereClause, int AD_InfoWindow_ID, boolean lookup, GridField field) {
+		this(WindowNo, tableName, keyColumn, queryValue, multipleSelection, whereClause, AD_InfoWindow_ID, lookup, field, null);		
+	}
+
+	/**
+	 * @param WindowNo
+	 * @param tableName
+	 * @param keyColumn
+	 * @param multipleSelection
+	 * @param whereClause
+	 * @param lookup
+	 * @param gridfield
+	 * @param predefinedContextVariables
+	 */
+	public InfoWindow(int WindowNo, String tableName, String keyColumn, String queryValue, 
+			boolean multipleSelection, String whereClause, int AD_InfoWindow_ID, boolean lookup, GridField field, String predefinedContextVariables) {
 		super(WindowNo, tableName, keyColumn, multipleSelection, whereClause,
 				lookup, AD_InfoWindow_ID, queryValue);		
 		this.m_gridfield = field;
@@ -240,6 +255,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
    			}
    		}); //xolali --end-
 
+   		Env.setPredefinedVariables(Env.getCtx(), getWindowNo(), predefinedContextVariables);
 		infoContext = new Properties(Env.getCtx());
 		p_loadedOK = loadInfoDefinition(); 
 		


### PR DESCRIPTION
This improvement is applied normal Info Window and special Info Windows below.
*InfoBPartnerWindow
*InfoProductWindow
*InfoInvoiceWindow
*InfoOrderWindow
*InfoAssetWindow
*InfoInOutWindow
*InfoPaymentWindow
*InfoAssignmentWindow


I added above Info Windows to menu and tested below case.
I could perse Predefined Context Variables at Info Windows.
*Sql WHERE field of info window.
*Display Logic field of info window column.
*Default Logic field of info window column.
*Dynamic Validation of info window column.
*Fields of process parameter that assigned info window.


I added a new method to IInfoFactory as Default.
And I confirmed there are not bad impact of source code change.
*I could open info window and use at search field of window.
*I could open info window and use at search field of find window.
*I could open info window and use at search & Multiple Selection Search of process parameter.
*I could open info window and use at Views of gadget.

I seem there are not bad impact of source code change.

best regards.