### PR TITLE
IDEMPIERE-4911 Silent fail when translated column is shorter than original column (FHCA-2888)

### DIFF
--- a/migration/i8.2/oracle/202108182002_IDEMPIERE-4911.sql
+++ b/migration/i8.2/oracle/202108182002_IDEMPIERE-4911.sql
@@ -7,7 +7,7 @@ INSERT INTO AD_Message (MsgType,MsgText,AD_Client_ID,AD_Org_ID,IsActive,Created,
 ;
 
 -- Aug 18, 2021, 8:13:56 PM CEST
-UPDATE AD_Message SET MsgText='Error synchronizing translation, string too long', MsgTip='There is a mismatch on the size of a translated column, the translated column is shorter than the original column',Updated=TO_DATE('2021-08-18 20:13:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Message_ID=200714
+UPDATE AD_Message SET MsgText='Error synchronizing translation, string too long', MsgTip='There is a mismatch in the size of a translated column.  Please contact the system administrator to correct the problem.',Updated=TO_DATE('2021-08-18 20:13:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Message_ID=200714
 ;
 
 -- Aug 18, 2021, 9:24:16 PM CEST

--- a/migration/i8.2/oracle/202108182002_IDEMPIERE-4911.sql
+++ b/migration/i8.2/oracle/202108182002_IDEMPIERE-4911.sql
@@ -1,0 +1,27 @@
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- IDEMPIERE-4911 Silent fail when translated column is shorter than original column (FHCA-2888)
+-- Aug 18, 2021, 8:01:59 PM CEST
+INSERT INTO AD_Message (MsgType,MsgText,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Message_ID,Value,EntityType,AD_Message_UU) VALUES ('E','...',0,0,'Y',TO_DATE('2021-08-18 20:01:59','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2021-08-18 20:01:59','YYYY-MM-DD HH24:MI:SS'),100,200714,'MismatchTrlColumnSize','D','14ca00be-1dc1-4e27-b908-257704aae45d')
+;
+
+-- Aug 18, 2021, 8:13:56 PM CEST
+UPDATE AD_Message SET MsgText='Error synchronizing translation, string too long', MsgTip='There is a mismatch on the size of a translated column, the translated column is shorter than the original column',Updated=TO_DATE('2021-08-18 20:13:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Message_ID=200714
+;
+
+-- Aug 18, 2021, 9:24:16 PM CEST
+INSERT INTO AD_Message (MsgType,MsgText,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Message_ID,Value,EntityType,AD_Message_UU) VALUES ('I','Do not forget to create the corresponding translation table {0} with column {1}',0,0,'Y',TO_DATE('2021-08-18 21:24:15','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2021-08-18 21:24:15','YYYY-MM-DD HH24:MI:SS'),100,200715,'WarnCreateTrlTable','D','df97a71a-bb65-4ed5-b7dc-000610f807f5')
+;
+
+-- Aug 18, 2021, 9:24:27 PM CEST
+INSERT INTO AD_Message (MsgType,MsgText,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Message_ID,Value,EntityType,AD_Message_UU) VALUES ('I','Do not forget to create the translation column {0}.{1}',0,0,'Y',TO_DATE('2021-08-18 21:24:26','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2021-08-18 21:24:26','YYYY-MM-DD HH24:MI:SS'),100,200716,'WarnCreateTrlColumn','D','7bd54fc7-40cc-408d-b88e-ec25f9ae28fa')
+;
+
+-- Aug 18, 2021, 9:24:38 PM CEST
+INSERT INTO AD_Message (MsgType,MsgText,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Message_ID,Value,EntityType,AD_Message_UU) VALUES ('I','Do not forget to increase the size on translation column {0}.{1} to {2}',0,0,'Y',TO_DATE('2021-08-18 21:24:38','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2021-08-18 21:24:38','YYYY-MM-DD HH24:MI:SS'),100,200717,'WarnUpdateSizeTrlTable','D','d5951ecd-3d4f-4438-bc48-8d3fbace8693')
+;
+
+SELECT register_migration_script('202108182002_IDEMPIERE-4911.sql') FROM dual
+;
+

--- a/migration/i8.2/postgresql/202108182002_IDEMPIERE-4911.sql
+++ b/migration/i8.2/postgresql/202108182002_IDEMPIERE-4911.sql
@@ -1,0 +1,24 @@
+-- IDEMPIERE-4911 Silent fail when translated column is shorter than original column (FHCA-2888)
+-- Aug 18, 2021, 8:01:59 PM CEST
+INSERT INTO AD_Message (MsgType,MsgText,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Message_ID,Value,EntityType,AD_Message_UU) VALUES ('E','...',0,0,'Y',TO_TIMESTAMP('2021-08-18 20:01:59','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2021-08-18 20:01:59','YYYY-MM-DD HH24:MI:SS'),100,200714,'MismatchTrlColumnSize','D','14ca00be-1dc1-4e27-b908-257704aae45d')
+;
+
+-- Aug 18, 2021, 8:13:56 PM CEST
+UPDATE AD_Message SET MsgText='Error synchronizing translation, string too long', MsgTip='There is a mismatch on the size of a translated column, the translated column is shorter than the original column',Updated=TO_TIMESTAMP('2021-08-18 20:13:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Message_ID=200714
+;
+
+-- Aug 18, 2021, 9:24:16 PM CEST
+INSERT INTO AD_Message (MsgType,MsgText,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Message_ID,Value,EntityType,AD_Message_UU) VALUES ('I','Do not forget to create the corresponding translation table {0} with column {1}',0,0,'Y',TO_TIMESTAMP('2021-08-18 21:24:15','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2021-08-18 21:24:15','YYYY-MM-DD HH24:MI:SS'),100,200715,'WarnCreateTrlTable','D','df97a71a-bb65-4ed5-b7dc-000610f807f5')
+;
+
+-- Aug 18, 2021, 9:24:27 PM CEST
+INSERT INTO AD_Message (MsgType,MsgText,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Message_ID,Value,EntityType,AD_Message_UU) VALUES ('I','Do not forget to create the translation column {0}.{1}',0,0,'Y',TO_TIMESTAMP('2021-08-18 21:24:26','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2021-08-18 21:24:26','YYYY-MM-DD HH24:MI:SS'),100,200716,'WarnCreateTrlColumn','D','7bd54fc7-40cc-408d-b88e-ec25f9ae28fa')
+;
+
+-- Aug 18, 2021, 9:24:38 PM CEST
+INSERT INTO AD_Message (MsgType,MsgText,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Message_ID,Value,EntityType,AD_Message_UU) VALUES ('I','Do not forget to increase the size on translation column {0}.{1} to {2}',0,0,'Y',TO_TIMESTAMP('2021-08-18 21:24:38','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2021-08-18 21:24:38','YYYY-MM-DD HH24:MI:SS'),100,200717,'WarnUpdateSizeTrlTable','D','d5951ecd-3d4f-4438-bc48-8d3fbace8693')
+;
+
+SELECT register_migration_script('202108182002_IDEMPIERE-4911.sql') FROM dual
+;
+

--- a/migration/i8.2/postgresql/202108182002_IDEMPIERE-4911.sql
+++ b/migration/i8.2/postgresql/202108182002_IDEMPIERE-4911.sql
@@ -4,7 +4,7 @@ INSERT INTO AD_Message (MsgType,MsgText,AD_Client_ID,AD_Org_ID,IsActive,Created,
 ;
 
 -- Aug 18, 2021, 8:13:56 PM CEST
-UPDATE AD_Message SET MsgText='Error synchronizing translation, string too long', MsgTip='There is a mismatch on the size of a translated column, the translated column is shorter than the original column',Updated=TO_TIMESTAMP('2021-08-18 20:13:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Message_ID=200714
+UPDATE AD_Message SET MsgText='Error synchronizing translation, string too long', MsgTip='There is a mismatch in the size of a translated column.  Please contact the system administrator to correct the problem.',Updated=TO_TIMESTAMP('2021-08-18 20:13:56','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Message_ID=200714
 ;
 
 -- Aug 18, 2021, 9:24:16 PM CEST

--- a/org.adempiere.base/src/org/adempiere/exceptions/DBException.java
+++ b/org.adempiere.base/src/org/adempiere/exceptions/DBException.java
@@ -36,13 +36,14 @@ import org.compiere.util.DB;
  */
 public class DBException extends AdempiereException
 {
-	public static final String DATABASE_OPERATION_TIMEOUT_MSG = "DatabaseOperationTimeout";
-	public static final String DELETE_ERROR_DEPENDENT_MSG = "DeleteErrorDependent";
-	public static final String SAVE_ERROR_NOT_UNIQUE_MSG = "SaveErrorNotUnique";
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = 4264201718343118625L;
+	private static final long serialVersionUID = -1961265420169932726L;
+
+	public static final String DATABASE_OPERATION_TIMEOUT_MSG = "DatabaseOperationTimeout";
+	public static final String DELETE_ERROR_DEPENDENT_MSG = "DeleteErrorDependent";
+	public static final String SAVE_ERROR_NOT_UNIQUE_MSG = "SaveErrorNotUnique";
 	private String m_sql = null;
 
 	/**
@@ -212,7 +213,18 @@ public class DBException extends AdempiereException
     		return false;
     	}
     }
-    
+
+    /**
+     * Check if value too large for column exception (aka ORA-12899)
+     * @param e exception
+     */
+    public static boolean isValueTooLarge(Exception e) {
+    	if (DB.isPostgreSQL())
+    		return isSQLState(e, "22001");
+    	//
+    	return isErrorCode(e, 12899);
+    }
+
     /**
      * @param e
      */
@@ -227,4 +239,5 @@ public class DBException extends AdempiereException
     		return null;
     	}
     }
+
 }	//	DBException

--- a/org.adempiere.base/src/org/compiere/model/MColumn.java
+++ b/org.adempiere.base/src/org/compiere/model/MColumn.java
@@ -524,6 +524,21 @@ public class MColumn extends X_AD_Column implements ImmutablePOSupport
 				LogicEvaluator.validate(getReadOnlyLogic());
 			}
 		}
+
+		// IDEMPIERE-4911
+		MTable table = MTable.get(getAD_Table_ID());
+		String tableName = table.getTableName();
+		if (tableName.toLowerCase().endsWith("_trl")) {
+			String parentTable = tableName.substring(0, tableName.length()-4);
+			MColumn column = MColumn.get(getCtx(), parentTable, colname);
+			if (column != null && column.isTranslated()) {
+				if (getFieldLength() < column.getFieldLength()) {
+					log.saveWarning("Warning", "Size increased to " + column.getFieldLength() + " in translated column " + tableName + "." + colname);
+					setFieldLength(column.getFieldLength());
+				}
+			}
+		}
+
 		return true;
 	}	//	beforeSave
 	
@@ -543,7 +558,26 @@ public class MColumn extends X_AD_Column implements ImmutablePOSupport
 				|| "EntityType".equals(get_ValueOld(COLUMNNAME_ColumnName).toString()))) {
 			MChangeLog.resetLoggedList();
 		}
-		
+
+		// IDEMPIERE-4911
+		if (isTranslated()) {
+			MTable table = MTable.get(getAD_Table_ID());
+			String trlTableName = table.getTableName() + "_Trl";
+			MTable trlTable = MTable.get(getCtx(), trlTableName);
+			if (trlTable == null) {
+				log.saveWarning("Warning", Msg.getMsg(getCtx(), "WarnCreateTrlTable", new Object[] {trlTableName, getColumnName()}));
+			} else {
+				MColumn trlColumn = MColumn.get(getCtx(), trlTableName, getColumnName());
+				if (trlColumn == null) {
+					log.saveWarning("Warning", Msg.getMsg(getCtx(), "WarnCreateTrlColumn", new Object[] {trlTableName, getColumnName()}));
+				} else {
+					if (trlColumn.getFieldLength() < getFieldLength()) {
+						log.saveWarning("Warning", Msg.getMsg(getCtx(), "WarnUpdateSizeTrlTable", new Object[] {trlTableName, getColumnName(), getFieldLength()}));
+					}
+				}
+			}
+		}
+
 		return success;
 	}	//	afterSave
 	


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-4911

Changes:
* Saving a value that doesn't fit in the translation now fails with a proper user understandable message
* Synchronize Doc Translation now fails with a user understandable message in case it fails because a value doesn't fit
* When updating a column on a translation table, check for the size of the original column and update the size accordingly
* When updating a translated column, show warnings to user about creating the table, or creating the column, or updating the column size