### PR TITLE
IDEMPIERE-4945 Selected row is changed after table sort in Swing UI

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/GridTable.java
+++ b/org.adempiere.base/src/org/compiere/model/GridTable.java
@@ -1013,10 +1013,10 @@ public class GridTable extends AbstractTableModel
 		
 		if (!isSameSortEntries)
 		{
-			//	update UI
-			fireTableDataChanged();
 			//  Info detected by MTab.dataStatusChanged and current row set to 0
 			fireDataStatusIEvent(SORTED_DSE_EVENT, "#" + m_sort.size());
+			//	update UI
+			fireTableDataChanged();
 		}
 	}	//	sort
 


### PR DESCRIPTION
At the end of table sorting, trigger data status change event before UI
event, so that GridTab data is changed before UI refresh, which is
needed for Swing UI.

I have tested the patch in Swing and ZK.

Not sure why ZK UI do not have this same issue.