### PR TITLE
IDEMPIERE-4933 Platform update for 9.x

### DIFF
--- a/org.idempiere.keikai/META-INF/MANIFEST.MF
+++ b/org.idempiere.keikai/META-INF/MANIFEST.MF
@@ -208,5 +208,5 @@ Automatic-Module-Name: org.idempiere.keikai
 Bundle-Vendor: iDempiere Community
 Bundle-ActivationPolicy: lazy
 Fragment-Host: org.adempiere.ui.zk;bundle-version="9.0.0"
-Jetty-WarPatchFragmentFolderPath: /
+Jetty-WarPrependFragmentResourcePath: /
 Service-Component: OSGI-INF/org.idempiere.keikai.view.KeikaiMediaViewProvider.xml


### PR DESCRIPTION
- Jetty 10: Jetty-WarPatchFragmentFolderPath have been drop and replace
by Jetty-WarPrependFragmentResourcePath