### PR TITLE
IDEMPIERE-4842 Easier model registration

### DIFF
--- a/org.adempiere.base/OSGI-INF/org.adempiere.base.AnnotationBasedModelFactory.xml
+++ b/org.adempiere.base/OSGI-INF/org.adempiere.base.AnnotationBasedModelFactory.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" immediate="true" name="org.adempiere.base.AnnotationBasedModelFactory">
-   <property name="service.ranking" type="Integer" value="1"/>
+   <property name="service.ranking" type="Integer" value="-1"/>
    <service>
       <provide interface="org.adempiere.base.IModelFactory"/>
    </service>

--- a/org.adempiere.base/build.properties
+++ b/org.adempiere.base/build.properties
@@ -9,5 +9,6 @@ bin.includes = plugin.xml,\
                lib/cron4j.jar,\
                lib/classindex.jar
 src.includes = schema/
-source.. = src/
+source.. = src/,\
+           .apt_generated/
 output.. = target/classes/

--- a/org.adempiere.base/src/org/adempiere/base/AnnotationBasedModelFactory.java
+++ b/org.adempiere.base/src/org/adempiere/base/AnnotationBasedModelFactory.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Component;
  * discovery using SPI is preferred over reflection-based methods.
  * @author Saulo Gil
  */
-@Component(immediate = true, service = IModelFactory.class, property = {"service.ranking:Integer=1"})
+@Component(immediate = true, service = IModelFactory.class, property = {"service.ranking:Integer=-1"})
 public class AnnotationBasedModelFactory extends AbstractModelFactory implements IModelFactory
 {
 


### PR DESCRIPTION
- Temporary disable AnnotationBasedModelFactory until getSubclasses()
doesn't work for subclass from different package is resolve.