### PR TITLE
IDEMPIERE-4842 Easier model registration

### DIFF
--- a/org.adempiere.base/src/org/adempiere/base/AnnotationBasedModelFactory.java
+++ b/org.adempiere.base/src/org/adempiere/base/AnnotationBasedModelFactory.java
@@ -84,7 +84,6 @@ public class AnnotationBasedModelFactory extends AbstractModelFactory implements
 				.enableAnnotationInfo()
 				.overrideClassLoaders(classLoader)
 				.disableNestedJarScanning()
-				.rejectJars(getRejectJars())
 				.disableModuleScanning();
 
 		// narrow search to a list of packages
@@ -92,11 +91,7 @@ public class AnnotationBasedModelFactory extends AbstractModelFactory implements
 		if(isAtCore())
 			packages = CORE_PACKAGES;
 		else
-		{
 			packages = getPackages();
-			if(packages==null || packages.length==0)
-				s_log.warning(this.getClass().getSimpleName() + " should override the getPackages method");				
-		}
 
 		//acceptClasses has no effect when acceptPackagesNonRecursive is use
 		if (packages != null && packages.length > 0)
@@ -148,29 +143,6 @@ public class AnnotationBasedModelFactory extends AbstractModelFactory implements
 		if (s_log.isLoggable(Level.INFO))
 			s_log.info(this.getClass().getSimpleName() + " loaded "+classCache.size() +" classes in "
 					+((end-start)/1000f) + "s");
-	}
-
-	/**
-	 * Skip scanning some well known jars
-	 * @return list of jar names
-	 */
-	protected String[] getRejectJars() {
-		return new String[] {
-				"ant-*.jar", "commons-*.jar",
-				"javax.*.jar", "jakarta.*.jar",
-				"com.microsoft.*.jar",
-				"com.sun.*.jar",
-				"com.google.*.jar", "google-*.jar",
-				"com.fasterxml.*.jar", "jackson-*.jar",
-				"groovy*.jar",
-				"org.apache.*.jar",
-				"org.eclipse.*.jar", "jetty.*.jar",
-				"org.glassfish.*.jar",
-				"org.junit.*.jar",
-				"org.w3c.*.jar",
-				"org.springframework.*.jar",
-				"wrapped.*.jar"				
-		};
 	}
 
 	/**


### PR DESCRIPTION
- Needs to enable jar scanning to support felix/console installation of plugin jar.
- add rejectJars call to reduce startup delay after enable of jar scanning. keep the list short to reduce future maintenance hazard.
- remove the not supported use of acceptPackagesNonRecursive and acceptClasses together.
- change getAcceptClassesPatterns() default to X_* and M*. Withouut acceptPackages, we need to scan both X and M classes.