### PR TITLE
IDEMPIERE-4770 - fix advanced find and/or where clause

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/FindWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/FindWindow.java
@@ -1043,7 +1043,6 @@ public class FindWindow extends Window implements EventListener<Event>, ValueCha
 
         // And / Or / And Not / Or Not
     	ValueNamePair[]	andOr = new ValueNamePair[] {
-    		new ValueNamePair ("",			""),	
     		new ValueNamePair ("AND",		Msg.getMsg(Env.getCtx(),"AND")),
     		new ValueNamePair ("OR",		Msg.getMsg(Env.getCtx(),"OR")),
     		new ValueNamePair ("AND NOT",	Msg.getMsg(Env.getCtx(),"ANDNOT")),
@@ -1052,11 +1051,10 @@ public class FindWindow extends Window implements EventListener<Event>, ValueCha
         
     	for (ValueNamePair item: andOr)
             listAndOr.appendItem(item.getName(), item.getValue());
+    	listAndOr.setSelectedIndex(0); //And - default
     	if (row<=0){ // don't show item on the first row.
-        	listAndOr.setSelectedIndex(0);
     		listAndOr.setVisible(false);
     	} else {
-    		listAndOr.setSelectedIndex(1); //And - default
     		listAndOr.setVisible(true);
     	}
 


### PR DESCRIPTION
when trying to use the advanced find, the first condition is always returning an error :

![image](https://user-images.githubusercontent.com/5605206/137597336-508f40f5-828d-4759-922a-5a15467c00d2.png)

