### PR TITLE
IDEMPIERE-5050 Service startup freeze

### DIFF
--- a/org.adempiere.base.callout/src/org/adempiere/base/callout/factory/AnnotationBasedColumnCalloutFactoryImpl.java
+++ b/org.adempiere.base.callout/src/org/adempiere/base/callout/factory/AnnotationBasedColumnCalloutFactoryImpl.java
@@ -33,7 +33,7 @@ import org.osgi.service.component.annotations.Component;
  * @author hengsin
  *
  */
-@Component(immediate = true, service = IColumnCalloutFactory.class)
+@Component(immediate = false, service = IColumnCalloutFactory.class)
 public class AnnotationBasedColumnCalloutFactoryImpl extends AnnotationBasedColumnCalloutFactory {
 
 	public AnnotationBasedColumnCalloutFactoryImpl() {

--- a/org.adempiere.base.process/src/org/adempiere/base/process/factory/BaseProcessFactoryImpl.java
+++ b/org.adempiere.base.process/src/org/adempiere/base/process/factory/BaseProcessFactoryImpl.java
@@ -33,7 +33,7 @@ import org.osgi.service.component.annotations.Component;
  * @author hengsin
  *
  */
-@Component(immediate = true, service = IProcessFactory.class, property = {"service.ranking:Integer=0"})
+@Component(immediate = false, service = IProcessFactory.class, property = {"service.ranking:Integer=0"})
 public class BaseProcessFactoryImpl extends AnnotationBasedProcessFactory {
 
 	public BaseProcessFactoryImpl() {

--- a/org.adempiere.base/OSGI-INF/org.adempiere.base.AnnotationBasedModelFactory.xml
+++ b/org.adempiere.base/OSGI-INF/org.adempiere.base.AnnotationBasedModelFactory.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" immediate="true" name="org.adempiere.base.AnnotationBasedModelFactory">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" immediate="false" name="org.adempiere.base.AnnotationBasedModelFactory">
    <property name="service.ranking" type="Integer" value="0"/>
    <service>
       <provide interface="org.adempiere.base.IModelFactory"/>

--- a/org.adempiere.base/OSGI-INF/org.adempiere.base.DefaultAnnotationBasedColumnCalloutFactory.xml
+++ b/org.adempiere.base/OSGI-INF/org.adempiere.base.DefaultAnnotationBasedColumnCalloutFactory.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.adempiere.base.DefaultAnnotationBasedColumnCalloutFactory">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="false" name="org.adempiere.base.DefaultAnnotationBasedColumnCalloutFactory">
    <service>
       <provide interface="org.adempiere.base.IColumnCalloutFactory"/>
    </service>

--- a/org.adempiere.base/OSGI-INF/org.adempiere.base.DefaultAnnotationBasedEventManager.xml
+++ b/org.adempiere.base/OSGI-INF/org.adempiere.base.DefaultAnnotationBasedEventManager.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.adempiere.base.DefaultAnnotationBasedEventManager">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.adempiere.base.DefaultAnnotationBasedEventManager">
    <implementation class="org.adempiere.base.DefaultAnnotationBasedEventManager"/>
 </scr:component>

--- a/org.adempiere.base/OSGI-INF/org.adempiere.base.DefaultAnnotationBasedProcessFactory.xml
+++ b/org.adempiere.base/OSGI-INF/org.adempiere.base.DefaultAnnotationBasedProcessFactory.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.adempiere.base.DefaultAnnotationBasedProcessFactory">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="false" name="org.adempiere.base.DefaultAnnotationBasedProcessFactory">
    <property name="service.ranking" type="Integer" value="-1"/>
    <service>
       <provide interface="org.adempiere.base.IProcessFactory"/>

--- a/org.adempiere.base/src/org/adempiere/base/AnnotationBasedModelFactory.java
+++ b/org.adempiere.base/src/org/adempiere/base/AnnotationBasedModelFactory.java
@@ -14,8 +14,6 @@ package org.adempiere.base;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Level;
-
 import org.compiere.util.CLogger;
 import org.osgi.framework.wiring.BundleWiring;
 import org.osgi.service.component.ComponentContext;
@@ -36,7 +34,7 @@ import io.github.classgraph.ScanResult;
  * @author Saulo Gil
  * @author Heng Sin
  */
-@Component(immediate = true, service = IModelFactory.class, property = {"service.ranking:Integer=0"})
+@Component(immediate = false, service = IModelFactory.class, property = {"service.ranking:Integer=0"})
 public class AnnotationBasedModelFactory extends AbstractModelFactory implements IModelFactory
 {
 	/**
@@ -140,9 +138,8 @@ public class AnnotationBasedModelFactory extends AbstractModelFactory implements
 		    }
 		}
 		long end = System.currentTimeMillis();
-		if (s_log.isLoggable(Level.INFO))
-			s_log.info(this.getClass().getSimpleName() + " loaded "+classCache.size() +" classes in "
-					+((end-start)/1000f) + "s");
+		s_log.info(() -> this.getClass().getSimpleName() + " loaded " + classCache.size() + " classes in "
+					+ ((end-start)/1000f) + "s");
 	}
 
 	/**

--- a/org.adempiere.base/src/org/adempiere/base/AnnotationBasedProcessFactory.java
+++ b/org.adempiere.base/src/org/adempiere/base/AnnotationBasedProcessFactory.java
@@ -105,9 +105,8 @@ public abstract class AnnotationBasedProcessFactory implements IProcessFactory
 		    }
 		}
 		long end = System.currentTimeMillis();
-		if (s_log.isLoggable(Level.INFO))
-			s_log.info(this.getClass().getSimpleName() + " loaded "+classCache.size() +" classes in "
-					+((end-start)/1000f) + "s");
+		s_log.info(() -> this.getClass().getSimpleName() + " loaded " + classCache.size() + " classes in "
+					+ ((end-start)/1000f) + "s");
 	}
 
 	@SuppressWarnings("unchecked")

--- a/org.adempiere.base/src/org/adempiere/base/DefaultAnnotationBasedColumnCalloutFactory.java
+++ b/org.adempiere.base/src/org/adempiere/base/DefaultAnnotationBasedColumnCalloutFactory.java
@@ -31,7 +31,7 @@ import org.osgi.service.component.annotations.Component;
  * @author hengsin
  *
  */
-@Component(immediate = true, service = IColumnCalloutFactory.class)
+@Component(immediate = false, service = IColumnCalloutFactory.class)
 public class DefaultAnnotationBasedColumnCalloutFactory extends AnnotationBasedColumnCalloutFactory {
 
 	public DefaultAnnotationBasedColumnCalloutFactory() {

--- a/org.adempiere.base/src/org/adempiere/base/DefaultAnnotationBasedEventManager.java
+++ b/org.adempiere.base/src/org/adempiere/base/DefaultAnnotationBasedEventManager.java
@@ -26,7 +26,7 @@ package org.adempiere.base;
 
 import org.osgi.service.component.annotations.Component;
 
-@Component(immediate = true, service = {})
+@Component
 public class DefaultAnnotationBasedEventManager extends AnnotationBasedEventManager {
 
 	/**

--- a/org.adempiere.base/src/org/adempiere/base/DefaultAnnotationBasedProcessFactory.java
+++ b/org.adempiere.base/src/org/adempiere/base/DefaultAnnotationBasedProcessFactory.java
@@ -31,7 +31,7 @@ import org.osgi.service.component.annotations.Component;
  * @author hengsin
  *
  */
-@Component(immediate = true, service = IProcessFactory.class, property = {"service.ranking:Integer=-1"})
+@Component(immediate = false, service = IProcessFactory.class, property = {"service.ranking:Integer=-1"})
 public final class DefaultAnnotationBasedProcessFactory extends AnnotationBasedProcessFactory {
 
 	public DefaultAnnotationBasedProcessFactory() {

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/AnnotationBasedFormFactory.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/AnnotationBasedFormFactory.java
@@ -155,8 +155,7 @@ public abstract class AnnotationBasedFormFactory implements IFormFactory {
 		    }
 		}
 		long end = System.currentTimeMillis();
-		if (s_log.isLoggable(Level.INFO))
-			s_log.info(this.getClass().getSimpleName() + " loaded "+classCache.size() +" classes in "
+		s_log.info(() -> this.getClass().getSimpleName() + " loaded " + classCache.size() + " classes in "
 					+((end-start)/1000f) + "s");
 	}
 }

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/DefaultAnnotationBasedFormFactory.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/DefaultAnnotationBasedFormFactory.java
@@ -31,7 +31,7 @@ import org.osgi.service.component.annotations.Component;
  * @author hengsin
  *
  */
-@Component(immediate = true, service = IFormFactory.class, property = {"service.ranking:Integer=0"})
+@Component(immediate = false, service = IFormFactory.class, property = {"service.ranking:Integer=0"})
 public final class DefaultAnnotationBasedFormFactory extends AnnotationBasedFormFactory {
 
 	public DefaultAnnotationBasedFormFactory() {

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/util/ProcessFactoryImpl.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/util/ProcessFactoryImpl.java
@@ -21,7 +21,7 @@ import org.osgi.service.component.annotations.Component;
  * @author hengsin
  *
  */
-@Component(immediate = true, service = IProcessFactory.class, property = {"service.ranking:Integer=1"})
+@Component(immediate = false, service = IProcessFactory.class, property = {"service.ranking:Integer=1"})
 public class ProcessFactoryImpl extends AnnotationBasedProcessFactory {
 
 	/**

--- a/org.idempiere.webservices/WEB-INF/src/org/compiere/model/WS_ModelFactory.java
+++ b/org.idempiere.webservices/WEB-INF/src/org/compiere/model/WS_ModelFactory.java
@@ -35,7 +35,7 @@ import org.osgi.service.component.annotations.Component;
  * @author hengsin
  *
  */
-@Component(immediate = true, service = IModelFactory.class, property = "service.ranking:Integer=1")
+@Component(immediate = false, service = IModelFactory.class, property = "service.ranking:Integer=1")
 public class WS_ModelFactory extends AnnotationBasedModelFactory {
 
 	@Override


### PR DESCRIPTION
### Delayed service registration

Most annotation-based factories were switched to delayed OSGi component activation, in order to minimize the amount of threads simultaneously allocated to annotation scanning during service startup. This change doesn't seem to have any side effects. These factories are activated whenever needed, then the class scanning is performed synchronously upon the factory/component activation.

Classes such as `DefaultAnnotationBasedEventManager` were also switched to delayed initialization, since the `service` attribute of their `@Component` annotation shouldn't have effect as they don't implement any interface _directly_. More info on this at https://docs.osgi.org/javadoc/r4v43/cmpn/org/osgi/service/component/annotations/Component.html#service()

### Deferred class scanning

`DefaultAnnotationBasedEventManager` was modified to perform class scanning using background threads. This shouldn't pose any problems unless event processing is required very early upon service startup. A cached thread pool executor (see `java.util.concurrent.Executors.newCachedThreadPool()`) was used for this since the standard executor (i.e.: `org.compiere.Adempiere.getThreadPoolExecutor()` ) didn't solve the problem.


