### PR TITLE
IDEMPIERE-5049 Zk Session and Desktop object not destroy immediately …

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/fi/jawsy/jawwa/zk/atmosphere/AtmosphereServerPush.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/fi/jawsy/jawwa/zk/atmosphere/AtmosphereServerPush.java
@@ -22,6 +22,7 @@ package fi.jawsy.jawwa.zk.atmosphere;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.atmosphere.cpr.AtmosphereResource;
@@ -267,7 +268,8 @@ public class AtmosphereServerPush implements ServerPush {
         }
 
 	  	if (!resource.isSuspended()) {
-	  		resource.suspend(); 
+	  		//browser default timeout is 2 minutes
+	  		resource.suspend(5, TimeUnit.MINUTES); 
 	  	}
 	  	AtmosphereResource oldResource = this.resource.getAndSet(resource);
 	  	if (oldResource != null) {


### PR DESCRIPTION
…after logout

added 5 minute timeout (browser default is 2) to comet resource