### PR TITLE
IDEMPIERE-5078 - M_inout movementtype add to before save

### DIFF
--- a/org.adempiere.base.callout/src/org/compiere/model/CalloutInOut.java
+++ b/org.adempiere.base.callout/src/org/compiere/model/CalloutInOut.java
@@ -196,6 +196,7 @@ public class CalloutInOut extends CalloutEngine
 				String trxFlag = rs.getString("IsSOTrx");
 				Object isSOTrxValue = mTab.getValue("IsSOTrx");
 				String isSOTrxValueStr = null;
+				boolean IsSOTrx = "Y".equals(trxFlag);
 				if (isSOTrxValue != null)
 				{
 					if (isSOTrxValue instanceof Boolean)
@@ -206,28 +207,9 @@ public class CalloutInOut extends CalloutEngine
 				
 				if (!(trxFlag.equals(isSOTrxValueStr)))
 					mTab.setValue("IsSOTrx", trxFlag);
-				if (DocBaseType.equals("MMS"))					//	Material Shipments
-				/**solve 1648131 bug vpj-cd e-evolution */
-				{
-						boolean IsSOTrx = "Y".equals(trxFlag);
-						if (IsSOTrx)
-							mTab.setValue("MovementType", "C-");	// Customer Shipments
-						else
-							mTab.setValue("MovementType", "V-");	// Vendor Return
-
-				}
-				/**END vpj-cd e-evolution */
-				else if (DocBaseType.equals("MMR"))				//	Material Receipts
-			    /**solve 1648131 bug vpj-cd e-evolution  */
-				{
-						boolean IsSOTrx = "Y".equals(trxFlag);
-						if (IsSOTrx)
-							mTab.setValue("MovementType", "C+"); // Customer Return
-						else
-							mTab.setValue("MovementType", "V+"); // Vendor Receipts
-				}				
-				/**END vpj-cd e-evolution */
-
+				
+				mTab.setValue("MovementType", MInOut.getMovementType(ctx, C_DocType_ID, IsSOTrx, null));
+				
 				//	DocumentNo
 				if (rs.getString("IsDocNoControlled").equals("Y"))
 				{

--- a/org.adempiere.base/src/org/compiere/model/MInOut.java
+++ b/org.adempiere.base/src/org/compiere/model/MInOut.java
@@ -1037,7 +1037,34 @@ public class MInOut extends X_M_InOut implements DocAction
             MDocType docType = MDocType.get(getCtx(), rma.getC_DocType_ID());
             setC_DocType_ID(docType.getC_DocTypeShipment_ID());
         }
+        
+        // Set MovementType
+        if(newRecord || (get_ValueDifference("C_DocType") != null)) {
+			MDocType docType = new MDocType(getCtx(), getC_DocType_ID(), get_TrxName());
+			String DocBaseType = docType.getDocBaseType();
+			Boolean IsSOTrx = docType.isSOTrx();
+			
+			if (DocBaseType.equals("MMS"))					//	Material Shipments
+				
+				{
+						if (IsSOTrx)
+							setMovementType("C-");				// Customer Shipments
+						else
+							setMovementType("V-");				// Vendor Return
 
+				}
+				
+			else if (DocBaseType.equals("MMR"))				//	Material Receipts
+			    
+				{
+						if (IsSOTrx)
+							setMovementType("C+");				 // Customer Return
+						else
+							setMovementType("V+");				 // Vendor Receipts
+				}				
+				
+		}
+        
 		return true;
 	}	//	beforeSave
 

--- a/org.adempiere.base/src/org/compiere/model/MInOut.java
+++ b/org.adempiere.base/src/org/compiere/model/MInOut.java
@@ -977,9 +977,19 @@ public class MInOut extends X_M_InOut implements DocAction
 		}
 	}	//	setM_Warehouse_ID
 
+	/**
+	 * Gets Movement Type based on Document Type's DocBaseType and isSOTrx
+	 * @param ctx 
+	 * @param C_DocType_ID Document Type ID
+	 * @param issotrx is sales transaction
+	 * @param trxName transaction name
+	 * @return Movement Type
+	 */
 	public static String getMovementType(Properties ctx, int C_DocType_ID, boolean issotrx, String trxName) {
 		String movementType = null;
-		MDocType docType = new MDocType(ctx, C_DocType_ID, trxName);
+		MDocType docType = MDocType.get(C_DocType_ID);
+		
+		if (docType == null) return null;
 		
         if (docType.getDocBaseType().equals(MDocType.DOCBASETYPE_MaterialDelivery)) 
             movementType = docType.isSOTrx() ? MOVEMENTTYPE_CustomerShipment : MOVEMENTTYPE_VendorReturns; 
@@ -989,6 +999,9 @@ public class MInOut extends X_M_InOut implements DocAction
 		return movementType;
 	}
 
+	/**
+	 * Sets Movement Type based on Document Type's DocBaseType and isSOTrx
+	 */
 	public void setMovementType() {
 		
 		if(getC_DocType_ID() <= 0) {


### PR DESCRIPTION
When we call m_inout then - field - movementtype must be set by frontend - otherwise REST call fail.
We suggest to add to beforesave from callout - then m_inout.movementtype will be handled by backend.