### PR TITLE
IDEMPIERE-5078 - fix typo C_DocType should be C_DocType_ID

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MInOut.java
+++ b/org.adempiere.base/src/org/compiere/model/MInOut.java
@@ -1021,7 +1021,7 @@ public class MInOut extends X_M_InOut implements DocAction, IDocsPostProcess
 	 */
 	protected boolean beforeSave (boolean newRecord)
 	{
-		if(newRecord || is_ValueChanged("C_DocType")) {
+		if(newRecord || is_ValueChanged("C_DocType_ID")) {
 			setMovementType();
 		}
 		


### PR DESCRIPTION
Found a typo in beforeSave method, C_DocType should have been C_DocType_ID