### PR TITLE
IDEMPIERE-4900 SQL statement added as an option to define WF Next Node Condition

### DIFF
--- a/org.adempiere.base/src/org/compiere/util/DB.java
+++ b/org.adempiere.base/src/org/compiere/util/DB.java
@@ -2610,7 +2610,7 @@ public final class DB
 		String removeQuotedStrings = "'(?:.|[\\n\\r])*?'";
 		String removeLeadingSpaces = "^\\s+";
 		String cleanSql = sql.toLowerCase().replaceAll(removeComments, "").replaceAll(removeQuotedStrings, "").replaceFirst(removeLeadingSpaces, "");
-		if(cleanSql.matches("^select\s.*$") && !cleanSql.contains(";"))
+		if(cleanSql.matches("^select\\s.*$") && !cleanSql.contains(";"))
 			return true;
 		else
 			return false;


### PR DESCRIPTION

https://idempiere.atlassian.net/browse/IDEMPIERE-4900

Fix wrong matches pattern -> eclipse 2021-12 complains with error
Invalid escape sequence (valid ones are  \b  \t  \n  \f  \r  \"  \'  \\ )