### PR TITLE
IDEMPIERE-5101 InfoGeneralPanel don’t show column headers when opened

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoGeneralPanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoGeneralPanel.java
@@ -320,7 +320,8 @@ public class InfoGeneralPanel extends InfoPanel implements EventListener<Event>
 		if (p_whereClause.length() > 0)
 			where.append(" AND (").append(p_whereClause).append(")");
 		prepareTable(m_generalLayout, p_tableName, where.toString(), "2");
-
+		contentPanel.repaint();
+		
 		//	Set & enable Fields
 
 		lbl1.setValue(Util.cleanAmp(Msg.translate(Env.getCtx(), m_queryColumns.get(0).toString())));
@@ -533,7 +534,7 @@ public class InfoGeneralPanel extends InfoPanel implements EventListener<Event>
 
 				if (colClass != null)
 				{
-					list.add(new ColumnInfo(Msg.translate(Env.getCtx(), columnName), colSql.toString(), colClass));
+					list.add(new ColumnInfo(Msg.translate(Env.getCtx(), columnName), colSql.toString(), colClass, true, columnName ));
 					if (log.isLoggable(Level.FINEST)) log.finest("Added Column=" + columnName);
 				}
 				else if (isDisplayed && DisplayType.isLookup(displayType))
@@ -679,9 +680,9 @@ public class InfoGeneralPanel extends InfoPanel implements EventListener<Event>
 		
 		ColumnInfo columnInfo = null;
 		if (columnName.endsWith("_ID")  && !column.isVirtualColumn())
-			columnInfo = new ColumnInfo(name, embedded, KeyNamePair.class, p_tableName+"."+columnName);
+			columnInfo = new ColumnInfo(name, embedded, KeyNamePair.class, true, false, p_tableName+"."+columnName, columnName);
 		else
-			columnInfo = new ColumnInfo(name, embedded, String.class, null);
+			columnInfo = new ColumnInfo(name, embedded, String.class, true, false, null, columnName);
 		return columnInfo;
 	}
 }

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoPanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoPanel.java
@@ -618,8 +618,10 @@ public abstract class InfoPanel extends Window implements EventListener<Event>, 
         String sql =contentPanel.prepareTable(layout, from,
                 where,p_multipleSelection,
                 getTableName(),false);
-	if (infoWindow != null)	
+        if (infoWindow != null)	
         	contentPanel.setwListBoxName("AD_InfoWindow_UU|"+ infoWindow.getAD_InfoWindow_UU() );
+        else
+	    	contentPanel.setwListBoxName("AD_InfoPanel|"+ from );
         p_layout = contentPanel.getLayout();
 		m_sqlMain = sql;
 		m_sqlCount = "SELECT COUNT(*) FROM " + from + " WHERE " + where;
@@ -2763,7 +2765,7 @@ public abstract class InfoPanel extends Window implements EventListener<Event>, 
 			if (SessionManager.getSessionApplication() != null &&
 				SessionManager.getSessionApplication().getKeylistener() != null)
 				SessionManager.getSessionApplication().getKeylistener().removeEventListener(Events.ON_CTRL_KEY, this);
-			if (infoWindow != null && getFirstChild() != null)
+			if (getFirstChild() != null)
 				saveWlistBoxColumnWidth(getFirstChild());
 		} catch (Exception e){
 			log.log(Level.WARNING, e.getMessage(), e);


### PR DESCRIPTION
All infowindows show the column headers, but this is not the case of lookup search, that uses InfoGeneralPanel. This should be enabled in order to get a consisting look and feel of iDempiere.

This was not captured in the ticket IDEMPIERE-4863 “Enable save column width in WListBox” where the use of WListbox in the infoWindows where implemented.

Examples of these lookups are RMA on Customer Returns, Cash Plan Line on Sales Order.