### PR TITLE
IDEMPIERE-5128 JUnit test fail to launch with Eclipse 2021-12 (4.22)

### DIFF
--- a/org.idempiere.p2.targetplatform/org.idempiere.p2.targetplatform.target
+++ b/org.idempiere.p2.targetplatform/org.idempiere.p2.targetplatform.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="idempiere-210901" sequenceNumber="1636543592">
+<target name="idempiere-210901" sequenceNumber="1640585624">
   <locations>
     <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="zcommon" version="9.6.0.1"/>
@@ -94,23 +94,28 @@
       <unit id="org.eclipse.core.variables" version="3.5.0.v20210510-1945"/>
       <unit id="org.eclipse.jdt.core" version="3.26.0.v20210609-0549"/>
       <unit id="org.eclipse.text" version="3.12.0.v20210512-1644"/>
-      <unit id="org.opentest4j" version="1.2.0.v20190826-0900"/>
-      <unit id="org.apiguardian" version="1.1.0.v20190826-0900"/>
-      <unit id="org.junit" version="4.13.0.v20200204-1500"/>
-      <unit id="org.junit.jupiter.api" version="5.7.1.v20210222-1948"/>
-      <unit id="org.junit.jupiter.params" version="5.7.1.v20210222-1948"/>
-      <unit id="org.junit.jupiter.engine" version="5.7.1.v20210222-1948"/>
-      <unit id="org.junit.jupiter.migrationsupport" version="5.7.1.v20210222-1948"/>
-      <unit id="org.junit.vintage.engine" version="5.7.1.v20210222-1948"/>
-      <unit id="org.junit.platform.engine" version="1.7.1.v20210222-1948"/>
-      <unit id="org.junit.platform.commons" version="1.7.1.v20210222-1948"/>
-      <unit id="org.junit.platform.launcher" version="1.7.1.v20210222-1948"/>
-      <unit id="org.junit.platform.runner" version="1.7.1.v20210222-1948"/>
-      <unit id="org.junit.platform.suite.api" version="1.7.1.v20210222-1948"/>
-      <unit id="org.eclipse.pde.junit.runtime" version="3.6.0.v20210513-1344"/>
-      <unit id="org.eclipse.jdt.junit.runtime" version="3.6.0.v20210326-1249"/>
-      <unit id="org.eclipse.jdt.junit5.runtime" version="1.0.1300.v20210320-1132"/>
       <repository location="https://download.eclipse.org/eclipse/updates/4.20"/>
+    </location>
+    <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
+      <unit id="org.opentest4j" version="1.2.0.v20211018-1956"/>
+      <unit id="org.apiguardian" version="1.1.2.v20211018-1956"/>
+      <unit id="org.junit" version="4.13.2.v20211018-1956"/>
+      <unit id="org.junit.jupiter.api" version="5.8.1.v20211018-1956"/>
+      <unit id="org.junit.jupiter.params" version="5.8.1.v20211018-1956"/>
+      <unit id="org.junit.jupiter.engine" version="5.8.1.v20211018-1956"/>
+      <unit id="org.junit.jupiter.migrationsupport" version="5.8.1.v20211018-1956"/>
+      <unit id="org.junit.vintage.engine" version="5.8.1.v20211018-1956"/>
+      <unit id="org.junit.platform.engine" version="1.8.1.v20211018-1956"/>
+      <unit id="org.junit.platform.commons" version="1.8.1.v20211018-1956"/>
+      <unit id="org.junit.platform.launcher" version="1.8.1.v20211018-1956"/>
+      <unit id="org.junit.platform.runner" version="1.8.1.v20211018-1956"/>
+      <unit id="org.junit.platform.suite.api" version="1.8.1.v20211018-1956"/>
+      <unit id="org.junit.platform.suite.commons" version="1.8.1.v20211018-1956"/>
+      <unit id="org.junit.platform.suite.engine" version="1.8.1.v20211028-1957"/>
+      <unit id="org.eclipse.pde.junit.runtime" version="3.6.100.v20211112-1151"/>
+      <unit id="org.eclipse.jdt.junit.runtime" version="3.6.100.v20210708-1502"/>
+      <unit id="org.eclipse.jdt.junit5.runtime" version="1.0.1400.v20211108-0640"/>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.22"/>
     </location>
     <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.apache.ant" version="1.10.10.v20210426-1926"/>
@@ -133,7 +138,7 @@
       <unit id="org.krysalis.barcode4j" version="2.1.0"/>
       <repository location="https://sourceforge.net/projects/jasperstudio/files/updatesite/6.17.0"/>
     </location>
-	<!-- com.google -->
+    <!-- com.google -->
     <location includeSource="true" missingManifest="generate" type="Maven">
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>

--- a/org.idempiere.p2.targetplatform/org.idempiere.p2.targetplatform.tpd
+++ b/org.idempiere.p2.targetplatform/org.idempiere.p2.targetplatform.tpd
@@ -99,11 +99,13 @@ location "https://download.eclipse.org/eclipse/updates/4.20" {
 	org.eclipse.core.resources
 	org.eclipse.core.variables
 	org.eclipse.jdt.core
-	org.eclipse.text
-	
+	org.eclipse.text	
+}
+
+location "https://download.eclipse.org/eclipse/updates/4.22" {
 	//<< for test
 	org.opentest4j
-	org.apiguardian
+	org.apiguardian	
 	org.junit
 	org.junit.jupiter.api
 	org.junit.jupiter.params
@@ -115,10 +117,11 @@ location "https://download.eclipse.org/eclipse/updates/4.20" {
 	org.junit.platform.launcher
 	org.junit.platform.runner
 	org.junit.platform.suite.api
+	org.junit.platform.suite.commons
+	org.junit.platform.suite.engine
 	org.eclipse.pde.junit.runtime
 	org.eclipse.jdt.junit.runtime
 	org.eclipse.jdt.junit5.runtime
-	//>>
 }
 
 location "https://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository" {

--- a/org.idempiere.test/idempiere.unit.test.launch
+++ b/org.idempiere.test/idempiere.unit.test.launch
@@ -273,6 +273,8 @@
         <setEntry value="org.junit.platform.launcher@default:default"/>
         <setEntry value="org.junit.platform.runner@default:default"/>
         <setEntry value="org.junit.platform.suite.api@default:default"/>
+        <setEntry value="org.junit.platform.suite.commons@default:default"/>
+        <setEntry value="org.junit.platform.suite.engine@default:default"/>
         <setEntry value="org.junit.vintage.engine@default:default"/>
         <setEntry value="org.junit@default:default"/>
         <setEntry value="org.jvnet.mimepull@default:default"/>


### PR DESCRIPTION
Update JUnit to 5.8.1 from Eclipse 4.22

https://idempiere.atlassian.net/browse/IDEMPIERE-5128