### PR TITLE
IDEMPIERE-5063 Improve Unit Tests - fix ProductionTest RollUp test

### DIFF
--- a/org.idempiere.test/src/org/idempiere/test/model/ProductionTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/ProductionTest.java
@@ -383,7 +383,10 @@ public class ProductionTest extends AbstractTestCase {
 		try {
 			int rollUpProcessId = 53230;
 			int mulchId = 137;
-			MProduct mulch = MProduct.get(mulchId);
+			MProduct mulch = new MProduct(Env.getCtx(), mulchId, getTrxName());
+			mulch.setM_Product_Category_ID(category.get_ID());
+			mulch.saveEx();
+			
 			BigDecimal componentCost = MCost.getCurrentCost(mulch, 0, getTrxName());
 									
 			MProduct mulchX = new MProduct(Env.getCtx(), 0, getTrxName());


### PR DESCRIPTION
- set mulch product category to Standard Costing category, so that the standard cost of the component is compared to the standard cost of the parent, mulchx.
Currently the test is comparing the Average PO cost of mulch with the rolled up Standard Cost of mulchx. In the seed database the Average PO and Standard Cost of mulch are the same, so the test passes.