### PR TITLE
IDEMPIERE-5169 OAuth2: add same email account on other client will break it on old client

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MAuthorizationAccount.java
+++ b/org.adempiere.base/src/org/compiere/model/MAuthorizationAccount.java
@@ -100,24 +100,44 @@ public class MAuthorizationAccount extends X_AD_AuthorizationAccount {
 	 * Synchronize information on other accounts with same email in the same credential
 	 */
 	public void syncOthers() {
-		final String script = "UPDATE AD_AuthorizationAccount "
-				+ "SET AccessToken=?, AccessTokenTimestamp=?, ExpireInSeconds=? "
+		final String clientSql =
+				"SELECT DISTINCT AD_Client_ID "
+				+ "FROM AD_AuthorizationAccount "
 				+ "WHERE AD_AuthorizationAccount_ID!=? "
 				+ "AND EMail=? "
 				+ "AND AD_AuthorizationCredential_ID=? "
 				+ "AND IsAuthorized='Y' "
 				+ "AND RefreshToken IS NOT NULL";
-		String accessToken = getAccessToken();
-		accessToken = SecureEngine.encrypt(accessToken, getAD_Client_ID());
-		DB.executeUpdateEx(script.toString(), new Object[] {
-				accessToken,
-				getAccessTokenTimestamp(),
-				getExpireInSeconds(),
+		int[] clientIds = DB.getIDsEx(get_TrxName(), clientSql, get_KeyColumns(),
 				getAD_AuthorizationAccount_ID(),
 				getEMail(),
-				getAD_AuthorizationCredential_ID()
-				},
-				get_TrxName());
+				getAD_AuthorizationCredential_ID());
+		if (clientIds.length > 0) {
+			final String script = "UPDATE AD_AuthorizationAccount "
+					+ "SET AccessToken=?, AccessTokenTimestamp=?, ExpireInSeconds=? "
+					+ "WHERE AD_AuthorizationAccount_ID!=? "
+					+ "AND EMail=? "
+					+ "AND AD_AuthorizationCredential_ID=? "
+					+ "AND IsAuthorized='Y' "
+					+ "AND RefreshToken IS NOT NULL"
+					+ "AND AD_Client_ID=?";
+			MColumn column = MColumn.get(getCtx(), Table_Name, COLUMNNAME_AccessToken);
+			for (int clientId : clientIds) {
+				String accessToken = getAccessToken();
+				if (column.isEncrypted())
+					accessToken = SecureEngine.encrypt(accessToken, clientId);
+				DB.executeUpdateEx(script.toString(), new Object[] {
+							accessToken,
+							getAccessTokenTimestamp(),
+							getExpireInSeconds(),
+							getAD_AuthorizationAccount_ID(),
+							getEMail(),
+							getAD_AuthorizationCredential_ID(),
+							clientId
+						},
+						get_TrxName());
+			}
+		}
 	}
 
 	/**

--- a/org.adempiere.base/src/org/compiere/model/MAuthorizationAccount.java
+++ b/org.adempiere.base/src/org/compiere/model/MAuthorizationAccount.java
@@ -108,7 +108,7 @@ public class MAuthorizationAccount extends X_AD_AuthorizationAccount {
 				+ "AND AD_AuthorizationCredential_ID=? "
 				+ "AND IsAuthorized='Y' "
 				+ "AND RefreshToken IS NOT NULL";
-		int[] clientIds = DB.getIDsEx(get_TrxName(), clientSql, get_KeyColumns(),
+		int[] clientIds = DB.getIDsEx(get_TrxName(), clientSql,
 				getAD_AuthorizationAccount_ID(),
 				getEMail(),
 				getAD_AuthorizationCredential_ID());

--- a/org.adempiere.base/src/org/compiere/model/MAuthorizationAccount.java
+++ b/org.adempiere.base/src/org/compiere/model/MAuthorizationAccount.java
@@ -119,7 +119,7 @@ public class MAuthorizationAccount extends X_AD_AuthorizationAccount {
 					+ "AND EMail=? "
 					+ "AND AD_AuthorizationCredential_ID=? "
 					+ "AND IsAuthorized='Y' "
-					+ "AND RefreshToken IS NOT NULL"
+					+ "AND RefreshToken IS NOT NULL "
 					+ "AND AD_Client_ID=?";
 			MColumn column = MColumn.get(getCtx(), Table_Name, COLUMNNAME_AccessToken);
 			for (int clientId : clientIds) {


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5169

Opening this in draft because is not tested against real potential cases:

- column AD_AuthorizationAccount.AccessToken encrypted and unencrypted
- multitenant
- potentially different encryption keys in different tenants
