### PR TITLE
IDEMPIERE-5049 Zk Session and Desktop object not destroy immediately …

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/AdempiereWebUI.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/AdempiereWebUI.java
@@ -192,10 +192,16 @@ public class AdempiereWebUI extends Window implements EventListener<Event>, IWeb
 		//clear context, invalidate session
 		Env.getCtx().clear();		
 		Adempiere.getThreadPoolExecutor().schedule(() -> {
-			((SessionCtrl)session).invalidateNow();
-			desktop.setAttribute(DESKTOP_SESSION_INVALIDATED_ATTR, Boolean.TRUE);
-		    try {
-				desktopCache.removeDesktop(desktop);
+			try {
+				((SessionCtrl)session).invalidateNow();
+			} catch (Throwable t) {
+				t.printStackTrace();
+			}	
+		    try {		   
+		    	if (desktopCache.getDesktopIfAny(desktop.getId()) != null) {
+		    		desktop.setAttribute(DESKTOP_SESSION_INVALIDATED_ATTR, Boolean.TRUE);
+		    		desktopCache.removeDesktop(desktop);
+		    	}
 			} catch (Throwable t) {
 				t.printStackTrace();
 			}


### PR DESCRIPTION
…after logout

Fix "zkoss.removeDesktop:70: Removing non-existent desktop: [Desktop z_7zm:/index.zul]" warning at server log (from curl/wget request with X-PING http header).