### PR TITLE
IDEMPIERE-5168 column AD_AuthorizationAccount.AccessToken is short on some case

### DIFF
--- a/migration/i9/oracle/202201302336_IDEMPIERE-5168.sql
+++ b/migration/i9/oracle/202201302336_IDEMPIERE-5168.sql
@@ -1,0 +1,49 @@
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- IDEMPIERE-5168 column AD_AuthorizationAccount.AccessToken is short on some case
+-- Jan 30, 2022, 11:18:41 PM CET
+UPDATE AD_Column SET FieldLength=4000,Updated=TO_DATE('2022-01-30 23:18:41','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=8805
+;
+
+-- Jan 30, 2022, 11:18:43 PM CET
+ALTER TABLE AD_ChangeLog MODIFY NewValue VARCHAR2(4000 CHAR) DEFAULT NULL 
+;
+
+-- Jan 30, 2022, 11:18:50 PM CET
+UPDATE AD_Column SET FieldLength=4000,Updated=TO_DATE('2022-01-30 23:18:50','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=8815
+;
+
+-- Jan 30, 2022, 11:18:52 PM CET
+ALTER TABLE AD_ChangeLog MODIFY OldValue VARCHAR2(4000 CHAR) DEFAULT NULL 
+;
+
+-- Jan 30, 2022, 11:32:57 PM CET
+UPDATE AD_Column SET FieldLength=0, AD_Reference_ID=14,Updated=TO_DATE('2022-01-30 23:32:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=214402
+;
+
+-- Jan 30, 2022, 11:33:02 PM CET
+ALTER TABLE AD_AuthorizationAccount MODIFY AccessToken CLOB DEFAULT NULL 
+;
+
+UPDATE AD_Column
+SET AD_Reference_ID=14, FieldLength=0
+WHERE AD_Reference_ID=36
+AND AD_Column_ID IN (
+214590, /* AD_Package_Exp_Detail.ExecCode */
+214591, /* AD_Package_Imp_Detail.ExecCode */
+214592, /* AD_Package_Imp_Detail.Result */
+1206, /* AD_WF_Node.Help */
+2290, /* AD_WF_Node_Trl.Help */
+238, /* AD_Workflow.Help */
+316, /* AD_Workflow_Trl.Help */
+51012, /* PA_DashboardContent.HTML */
+210868, /* PA_DashboardContent_Trl.HTML */
+5414, /* R_MailText.MailText */
+14615 /* R_MailText_Trl.MailText */
+)
+;
+
+SELECT register_migration_script('202201302336_IDEMPIERE-5168.sql') FROM dual
+;
+

--- a/migration/i9/postgresql/202201302336_IDEMPIERE-5168.sql
+++ b/migration/i9/postgresql/202201302336_IDEMPIERE-5168.sql
@@ -1,0 +1,46 @@
+-- IDEMPIERE-5168 column AD_AuthorizationAccount.AccessToken is short on some case
+-- Jan 30, 2022, 11:18:41 PM CET
+UPDATE AD_Column SET FieldLength=4000,Updated=TO_TIMESTAMP('2022-01-30 23:18:41','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=8805
+;
+
+-- Jan 30, 2022, 11:18:43 PM CET
+INSERT INTO t_alter_column values('ad_changelog','NewValue','VARCHAR(4000)',null,'NULL')
+;
+
+-- Jan 30, 2022, 11:18:50 PM CET
+UPDATE AD_Column SET FieldLength=4000,Updated=TO_TIMESTAMP('2022-01-30 23:18:50','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=8815
+;
+
+-- Jan 30, 2022, 11:18:52 PM CET
+INSERT INTO t_alter_column values('ad_changelog','OldValue','VARCHAR(4000)',null,'NULL')
+;
+
+-- Jan 30, 2022, 11:32:57 PM CET
+UPDATE AD_Column SET FieldLength=0, AD_Reference_ID=14,Updated=TO_TIMESTAMP('2022-01-30 23:32:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=214402
+;
+
+-- Jan 30, 2022, 11:33:02 PM CET
+INSERT INTO t_alter_column values('ad_authorizationaccount','AccessToken','TEXT',null,'NULL')
+;
+
+UPDATE AD_Column
+SET AD_Reference_ID=14, FieldLength=0
+WHERE AD_Reference_ID=36
+AND AD_Column_ID IN (
+214590, /* AD_Package_Exp_Detail.ExecCode */
+214591, /* AD_Package_Imp_Detail.ExecCode */
+214592, /* AD_Package_Imp_Detail.Result */
+1206, /* AD_WF_Node.Help */
+2290, /* AD_WF_Node_Trl.Help */
+238, /* AD_Workflow.Help */
+316, /* AD_Workflow_Trl.Help */
+51012, /* PA_DashboardContent.HTML */
+210868, /* PA_DashboardContent_Trl.HTML */
+5414, /* R_MailText.MailText */
+14615 /* R_MailText_Trl.MailText */
+)
+;
+
+SELECT register_migration_script('202201302336_IDEMPIERE-5168.sql') FROM dual
+;
+

--- a/org.adempiere.base/src/org/compiere/model/MColumn.java
+++ b/org.adempiere.base/src/org/compiere/model/MColumn.java
@@ -361,7 +361,7 @@ public class MColumn extends X_AD_Column implements ImmutablePOSupport
 			if (getFieldLength() != 0)
 				setFieldLength(0);
 		}
-		else if (getFieldLength() == 0) 
+		else if (getFieldLength() == 0 && displayType != DisplayType.Text) 
 		{
 			if (DisplayType.isID(displayType))
 				setFieldLength(10);

--- a/org.adempiere.base/src/org/compiere/util/DisplayType.java
+++ b/org.adempiere.base/src/org/compiere/util/DisplayType.java
@@ -775,7 +775,7 @@ public final class DisplayType
 		if (displayType == DisplayType.Binary)
 			return getDatabase().getBlobDataType();
 		if (displayType == DisplayType.TextLong
-			|| (displayType == DisplayType.Text && fieldLength >= 4000))
+			|| (displayType == DisplayType.Text && (fieldLength == 0 || fieldLength >= 4000)))
 			return getDatabase().getClobDataType();
 		if (displayType == DisplayType.YesNo)
 			return getDatabase().getCharacterDataType()+"(1)";

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/DefaultEditorFactory.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/DefaultEditorFactory.java
@@ -82,7 +82,8 @@ public class DefaultEditorFactory implements IEditorFactory {
         /** String (clear/password) */
         if (displayType == DisplayType.String
             || displayType == DisplayType.PrinterName || displayType == DisplayType.Color
-            || (tableEditor && (displayType == DisplayType.Text || displayType == DisplayType.TextLong)))
+            || displayType == DisplayType.Text || displayType == DisplayType.TextLong
+            || displayType == DisplayType.Memo)
         {
             if (gridField.isEncryptedField())
             {
@@ -109,8 +110,8 @@ public class DefaultEditorFactory implements IEditorFactory {
         {
         	editor = new WFileDirectoryEditor(gridField, tableEditor, editorConfiguration);
         }
-        /** Number */
-        else if (DisplayType.isNumeric(displayType))
+        /** Number or ID */
+        else if (DisplayType.isNumeric(displayType) || displayType == DisplayType.ID)
         {
             editor = new WNumberEditor(gridField, tableEditor, editorConfiguration);
         }
@@ -121,15 +122,6 @@ public class DefaultEditorFactory implements IEditorFactory {
             editor = new WYesNoEditor(gridField, tableEditor, editorConfiguration);
             if (tableEditor)
             	((WYesNoEditor)editor).getComponent().setLabel("");
-        }
-
-        /** Text */
-        else if (displayType == DisplayType.Text || displayType == DisplayType.Memo || displayType == DisplayType.TextLong || displayType == DisplayType.ID)
-        {
-        	if (gridField.isHtml())
-        		editor = new WHtmlEditor(gridField, tableEditor, editorConfiguration);
-        	else
-        		editor = new WStringEditor(gridField, tableEditor, editorConfiguration);
         }
 
         /** Date */


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5168

- Allow reference Text with length 0 to be managed as CLOB/TEXT
- Increase AD_ChangeLog.OldValue/NewValue to 4000 to allow saving more information about changing long texts
- Change AD_AuthorizationAccount.AccessToken to CLOB/TEXT
- Change some important actual columns defined as Text Long, to Text with length 0 (this allows changelog, better 2Pack, encryption)