### PR TITLE
IDEMPIERE-4561 Font Icons not used in several points

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WFactReconcile.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WFactReconcile.java
@@ -157,7 +157,10 @@ implements IFormController, EventListener<Event>, WTableModelListener, ValueChan
 		bZoomDoc.setId(bZoomDoc.getId() + "Doc"); // to avoid 'org.zkoss.zk.ui.UiException: Not unique in the ID space of <Grid null>: Zoom'
 		bZoomDoc.setLabel(Msg.translate(Env.getCtx(), "ZoomDocument"));
 		bSelect.setMode("toggle");
-		bSelect.setImage(ThemeManager.getThemeResource("images/SelectAll24.png"));
+		if (ThemeManager.isUseFontIconForImage())
+			bSelect.setIconSclass("z-icon-SelectAll");
+		else
+			bSelect.setImage(ThemeManager.getThemeResource("images/SelectAll24.png"));
 		bSelect.setTooltiptext(Msg.getCleanMsg(Env.getCtx(), "SelectAll"));
 		bSelect.addEventListener(Events.ON_CLICK, this);
 		

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WTreeMaintenance.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WTreeMaintenance.java
@@ -126,10 +126,17 @@ public class WTreeMaintenance extends TreeMaintenance implements IFormController
 	 */
 	private void jbInit () throws Exception
 	{
-		bAddAll.setImage(ThemeManager.getThemeResource("images/FastBack24.png"));
-		bAdd.setImage(ThemeManager.getThemeResource("images/StepBack24.png"));
-		bDelete.setImage(ThemeManager.getThemeResource("images/StepForward24.png"));
-		bDeleteAll.setImage(ThemeManager.getThemeResource("images/FastForward24.png"));
+		if (ThemeManager.isUseFontIconForImage()) {
+			bAddAll.setIconSclass("z-icon-FastBack");
+			bAdd.setIconSclass("z-icon-StepBack");
+			bDelete.setIconSclass("z-icon-StepForward");
+			bDeleteAll.setIconSclass("z-icon-FastForward");
+		} else {
+			bAddAll.setImage(ThemeManager.getThemeResource("images/FastBack24.png"));
+			bAdd.setImage(ThemeManager.getThemeResource("images/StepBack24.png"));
+			bDelete.setImage(ThemeManager.getThemeResource("images/StepForward24.png"));
+			bDeleteAll.setImage(ThemeManager.getThemeResource("images/FastForward24.png"));
+		}
 		
 		ZKUpdateUtil.setWidth(form,"100%");
 		ZKUpdateUtil.setHeight(form, "100%");

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/desktop/DashboardController.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/desktop/DashboardController.java
@@ -470,7 +470,10 @@ public class DashboardController implements EventListener<Event> {
     		//link to open performance detail
     		Div div = new Div();
     		Toolbarbutton link = new Toolbarbutton();
-            link.setImage(ThemeManager.getThemeResource("images/Zoom16.png"));
+    		if (ThemeManager.isUseFontIconForImage())
+    			link.setIconSclass("z-icon-Zoom");
+    		else
+    			link.setImage(ThemeManager.getThemeResource("images/Zoom16.png"));
             link.setAttribute("PA_Goal_ID", PA_Goal_ID);
             link.addEventListener(Events.ON_CLICK, new EventListener<Event>() {
 				public void onEvent(Event event) throws Exception {

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/desktop/DefaultDesktop.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/desktop/DefaultDesktop.java
@@ -396,14 +396,20 @@ public class DefaultDesktop extends TabbedDesktop implements MenuListener, Seria
 	        	
 	        };
 	        toolbar.appendChild(showHeader);
-	        showHeader.setImage(ThemeManager.getThemeResource(IMAGES_THREELINE_MENU_PNG));
+	        if (ThemeManager.isUseFontIconForImage())
+	        	showHeader.setIconSclass("z-icon-ThreeLineMenu");
+			else
+				showHeader.setImage(ThemeManager.getThemeResource(IMAGES_THREELINE_MENU_PNG));
 	        showHeader.addEventListener(Events.ON_CLICK, this);
 	        showHeader.setSclass("window-container-toolbar-btn");
 	        showHeader.setVisible(false);
 	        
 	        max = new ToolBarButton();
 	        toolbar.appendChild(max);
-	        max.setImage(ThemeManager.getThemeResource(IMAGES_UPARROW_PNG));
+	        if (ThemeManager.isUseFontIconForImage())
+	        	max.setIconSclass("z-icon-Collapsing");
+			else
+				max.setImage(ThemeManager.getThemeResource(IMAGES_UPARROW_PNG));
 	        max.addEventListener(Events.ON_CLICK, this);
 	        max.setSclass("window-container-toolbar-btn");
 		}
@@ -428,7 +434,10 @@ public class DefaultDesktop extends TabbedDesktop implements MenuListener, Seria
         
         if (mobile) {
 	        westBtn = new ToolBarButton();
-	        westBtn.setImage(ThemeManager.getThemeResource(IMAGES_THREELINE_MENU_PNG));
+	        if (ThemeManager.isUseFontIconForImage())
+	        	westBtn.setIconSclass("z-icon-ThreeLineMenu");
+			else
+				westBtn.setImage(ThemeManager.getThemeResource(IMAGES_THREELINE_MENU_PNG));
 	        westBtn.addEventListener(Events.ON_CLICK, this);
 	        westBtn.setSclass("window-container-toolbar-btn");
 	        westBtn.setStyle("cursor: pointer; padding: 0px; margin: 0px;");
@@ -721,7 +730,10 @@ public class DefaultDesktop extends TabbedDesktop implements MenuListener, Seria
 
 	protected void restoreHeader() {
 		layout.getNorth().setVisible(true);
-		max.setImage(ThemeManager.getThemeResource(IMAGES_UPARROW_PNG));
+		if (ThemeManager.isUseFontIconForImage())
+        	max.setIconSclass("z-icon-Collapsing");
+		else
+			max.setImage(ThemeManager.getThemeResource(IMAGES_UPARROW_PNG));
 		showHeader.setVisible(false);
 		pnlHead.detach();
 		headerContainer.appendChild(pnlHead);
@@ -731,7 +743,10 @@ public class DefaultDesktop extends TabbedDesktop implements MenuListener, Seria
 
 	protected void collapseHeader() {
 		layout.getNorth().setVisible(false);
-		max.setImage(ThemeManager.getThemeResource(IMAGES_DOWNARROW_PNG));
+		if (ThemeManager.isUseFontIconForImage())
+        	max.setIconSclass("z-icon-Expanding");
+		else
+			max.setImage(ThemeManager.getThemeResource(IMAGES_DOWNARROW_PNG));
 		showHeader.setVisible(true);
 		pnlHead.detach();
 		if (headerPopup == null) 

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/MenuTreeSearchPanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/MenuTreeSearchPanel.java
@@ -83,7 +83,10 @@ public class MenuTreeSearchPanel extends TreeSearchPanel {
 
 	protected void createOpenButton() {
 		openBtn = new Toolbarbutton();
-		openBtn.setImage(ThemeManager.getThemeResource("images/Open16.png"));
+		if (ThemeManager.isUseFontIconForImage())
+			openBtn.setIconSclass("z-icon-Open");
+		else
+			openBtn.setImage(ThemeManager.getThemeResource("images/Open16.png"));
 		openBtn.setSclass("menu-search-toggle-on");
 		openBtn.setDisabled(true);
 		openBtn.addEventListener(Events.ON_CLICK, new EventListener<Event>() {
@@ -102,7 +105,10 @@ public class MenuTreeSearchPanel extends TreeSearchPanel {
 
 	protected void createNewButton() {
 		newBtn = new Toolbarbutton();
-		newBtn.setImage(ThemeManager.getThemeResource("images/New16.png"));
+		if (ThemeManager.isUseFontIconForImage())
+			newBtn.setIconSclass("z-icon-New");
+		else
+			newBtn.setImage(ThemeManager.getThemeResource("images/New16.png"));
 		newBtn.setSclass("menu-search-toggle-off");
 		newBtn.addEventListener(Events.ON_CLICK, new EventListener<Event>() {
 			@Override

--- a/org.adempiere.ui.zk/WEB-INF/src/web/theme/default/css/fragment/font-icons.css.dsp
+++ b/org.adempiere.ui.zk/WEB-INF/src/web/theme/default/css/fragment/font-icons.css.dsp
@@ -72,6 +72,12 @@
 .z-icon-Export:before {	
 	content: "\f0ed";
 }
+.z-icon-FastBack:before {
+	content: "\f049";
+}
+.z-icon-FastForward:before {
+	content: "\f050";
+}
 .z-icon-FieldSuggestion:before {
 	content: "\f0e5";
 }
@@ -132,6 +138,9 @@
 .z-icon-InfoInvoice:before {	
 	content: "\f14b";
 }
+.z-icon-InfoLocator:before {
+	content: "\f1b2";
+}
 .z-icon-InfoOrder:before {	
 	content: "\f0c9";
 }
@@ -146,6 +155,9 @@
 }
 .z-icon-InfoSchedule:before {	
 	content: "\f017";
+}
+.z-icon-InfoShipment:before {
+	content: "\f0d1";
 }
 .z-icon-LastRecord:before {
 	content: "\f051";
@@ -265,6 +277,9 @@
 .z-icon-Search:before {
 	content: "\f002";
 }
+.z-icon-SelectAll:before {
+	content: "\f248";
+}
 .z-icon-SendMail:before {
 	content: "\f003";
 }
@@ -279,6 +294,12 @@
 }
 .z-icon-Single:before {	
 	content: "\f044";
+}
+.z-icon-StepBack:before {
+	content: "\f04a";
+}
+.z-icon-StepForward:before {
+	content: "\f04e";
 }
 .z-icon-Task:before {
 	content: "\f0ae";

--- a/org.adempiere.ui.zk/WEB-INF/src/web/theme/default/css/fragment/font-icons.css.dsp
+++ b/org.adempiere.ui.zk/WEB-INF/src/web/theme/default/css/fragment/font-icons.css.dsp
@@ -16,6 +16,9 @@
 .z-icon-Calculator:before {
 	content: "\f1ec";
 }
+.z-icon-Calendar:before {
+	content: "\f073";
+}
 .z-icon-Cancel:before {
 	content: "\f00d";
 }
@@ -26,8 +29,14 @@
 .z-icon-Chat:before {
 	content: "\f0e6";
 }
+.z-icon-Collapsing:before {
+	content: "\f102";
+}
 .z-icon-Copy:before {	
 	content: "\f0c5";
+}
+.z-icon-CSVImport:before {
+	content: "\f0f6";
 }
 .z-icon-Customize:before {
 	content: "\f0db";
@@ -57,6 +66,9 @@
 .z-icon-Expand:before {
 	content: "\f0d7";
 }
+.z-icon-Expanding:before {
+	content: "\f103";
+}
 .z-icon-Export:before {	
 	content: "\f0ed";
 }
@@ -77,6 +89,9 @@
 }
 .z-icon-Form:before {
 	content: "\f00b";
+}
+.z-icon-GetMail:before {
+	content: "\f0e0";
 }
 .z-icon-Help:before {
 	content: "\f059";
@@ -214,6 +229,9 @@
 .z-icon-Process:before {
 	content: "\f013";
 }
+.z-icon-ProcessMenu:before {
+	content: "\f085";
+}
 .z-icon-Product:before {	
 	content: "\f07a";
 }
@@ -222,6 +240,9 @@
 	font-size: 32px;
 	color: green;
 	font-family: FontAwesome;
+}
+.z-icon-QuickForm:before {
+	content: "\f0ae";
 }
 .z-icon-Refresh:before {
 	content: "\f021";
@@ -247,17 +268,38 @@
 .z-icon-SendMail:before {
 	content: "\f003";
 }
+.z-icon-SequenceChange:before {
+	content: "\f14d";
+}
+.z-icon-Share:before {
+	content: "\f0ac";
+}
+.z-icon-ShowMore:before {
+	content: "\f142";
+}
 .z-icon-Single:before {	
 	content: "\f044";
 }
 .z-icon-Task:before {
 	content: "\f0ae";
 }
+.z-icon-ThreeLineMenu:before {
+	content: "\f0c9";
+}
+.z-icon-Translate:before {
+	content: "\f1ab";
+}
 .z-icon-Trash:before {
 	content: "\f014";
 }
+.z-icon-TreeFavNodeAdd:before {
+	content: "\f07b";
+}
 .z-icon-UnprocessedDoc:before {	
 	content: "\f044";
+}
+.z-icon-UnSort:before {
+	content: "\f074";
 }
 .z-icon-VPreference:before {
 	content: "\f039";
@@ -276,37 +318,4 @@
 }
 .z-icon-ZoomAcross:before {	
 	content: "\f00e";
-}
-.z-icon-CSVImport:before {
-	content: "\f0f6";
-}
-.z-icon-ShowMore:before {
-	content: "\f142";
-}
-.z-icon-Share:before {
-	content: "\f0ac";
-}
-.z-icon-QuickForm:before {
-	content: "\f0ae";
-}
-.z-icon-UnSort:before {
-	content: "\f074";
-}
-.z-icon-GetMail:before {
-	content: "\f0e0";
-}
-.z-icon-Calendar:before {
-	content: "\f073";
-}
-.z-icon-TreeFavNodeAdd:before {
-	content: "\f07b";
-}
-.z-icon-Expanding:before {
-	content: "\f103";
-}
-.z-icon-SequenceChange:before {
-	content: "\f14d";
-}
-.z-icon-Translate:before {
-	content: "\f1ab";
 }


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-4561
I only fix the straightforward ones

New Icon Class
- z-icon-Collapsing
- z-icon-ProcessMenu
- z-icon-ThreeLineMenu

Copy from iceblue_c
- z-icon-FastBack
- z-icon-FastForward
- z-icon-InfoLocator
- z-icon-InfoShipment
- z-icon-SelectAll
- z-icon-StepBack
- z-icon-StepForward

Also sort the font icons by name for easy comparison between themes