### PR TITLE
IDEMPIERE-3831 - Implement AD_FieldStyle for Info Windows

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MInOutLine.java
+++ b/org.adempiere.base/src/org/compiere/model/MInOutLine.java
@@ -544,7 +544,22 @@ public class MInOutLine extends X_M_InOutLine
 		{
 			if (getM_Locator_ID() <= 0 && getC_Charge_ID() <= 0)
 			{
-				throw new FillMandatoryException(COLUMNNAME_M_Locator_ID);
+				// Try to load Default Locator
+				 I_M_Locator product_Locator = getM_Product().getM_Locator();
+
+				MWarehouse warehouse = (MWarehouse) getParent().getM_Warehouse();
+				if(warehouse != null) {
+					MLocator defaultLocator = warehouse.getDefaultLocator();
+
+					if(product_Locator != null && product_Locator.getM_Warehouse_ID() == warehouse.getM_Warehouse_ID()) {
+						setM_Locator_ID(product_Locator.getM_Locator_ID());
+					} else if(defaultLocator != null) {
+						setM_Locator_ID(defaultLocator.getM_Locator_ID());
+					}
+				}
+
+				if (getM_Locator_ID() <= 0)
+					throw new FillMandatoryException(COLUMNNAME_M_Locator_ID);
 			}
 		}
 

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/WInfoWindowListItemRenderer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/WInfoWindowListItemRenderer.java
@@ -156,7 +156,7 @@ public class WInfoWindowListItemRenderer extends WListItemRenderer
 					String zclass = styleStr.substring(MStyle.ZCLASS_PREFIX.length());
 					listcell.setZclass(zclass);
 				} else {
-					listcell.setStyle(styleStr);
+					listcell.setStyle(listcell.getStyle() + ";" + styleStr);
 				}
 			}
 		}


### PR DESCRIPTION
Issue: CSS style replaces the entire style, instead of appending.

Ticket: https://idempiere.atlassian.net/browse/IDEMPIERE-3831

Use case: Product Info: OnHandQty @QtyOnHand@>5 then color: green.

In this case 'replacelD' style was removed, ensure number right alignment,  just the color was added. So cells with the colors were aligned left, w/o right (legacy)

solution: append style instead replace.