### PR TITLE
IDEMPIERE-3831 - css style replaces the entire style, instead of append

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/WInfoWindowListItemRenderer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/WInfoWindowListItemRenderer.java
@@ -37,7 +37,6 @@ import org.compiere.model.MStyle;
 import org.compiere.util.Env;
 import org.compiere.util.Evaluatee;
 import org.compiere.util.KeyNamePair;
-import org.compiere.util.Util;
 import org.zkoss.zul.Listcell;
 
 public class WInfoWindowListItemRenderer extends WListItemRenderer
@@ -157,15 +156,7 @@ public class WInfoWindowListItemRenderer extends WListItemRenderer
 					String zclass = styleStr.substring(MStyle.ZCLASS_PREFIX.length());
 					listcell.setZclass(zclass);
 				} else {
-					
-					String prevStyle = listcell.getStyle();
-										
-					if(!Util.isEmpty(prevStyle)) {
-						listcell.setStyle(prevStyle + ";" + styleStr);
-					}
-					else {
-						listcell.setStyle(styleStr);
-					}
+					ZkCssHelper.appendStyle(listcell, styleStr);
 				}
 			}
 		}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/WInfoWindowListItemRenderer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/WInfoWindowListItemRenderer.java
@@ -156,7 +156,7 @@ public class WInfoWindowListItemRenderer extends WListItemRenderer
 					String zclass = styleStr.substring(MStyle.ZCLASS_PREFIX.length());
 					listcell.setZclass(zclass);
 				} else {
-					listcell.setStyle(styleStr);
+					listcell.setStyle(listcell.getStyle() + ";" + styleStr);
 				}
 			}
 		}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/WInfoWindowListItemRenderer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/WInfoWindowListItemRenderer.java
@@ -37,6 +37,7 @@ import org.compiere.model.MStyle;
 import org.compiere.util.Env;
 import org.compiere.util.Evaluatee;
 import org.compiere.util.KeyNamePair;
+import org.compiere.util.Util;
 import org.zkoss.zul.Listcell;
 
 public class WInfoWindowListItemRenderer extends WListItemRenderer
@@ -156,7 +157,15 @@ public class WInfoWindowListItemRenderer extends WListItemRenderer
 					String zclass = styleStr.substring(MStyle.ZCLASS_PREFIX.length());
 					listcell.setZclass(zclass);
 				} else {
-					listcell.setStyle(listcell.getStyle() + ";" + styleStr);
+					
+					String prevStyle = listcell.getStyle();
+										
+					if(!Util.isEmpty(prevStyle)) {
+						listcell.setStyle(prevStyle + ";" + styleStr);
+					}
+					else {
+						listcell.setStyle(styleStr);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Issue: CSS style replaces the entire style, instead of appending.

Ticket: https://idempiere.atlassian.net/browse/IDEMPIERE-3831

Use case: Product Info: OnHandQty @QtyOnHand@>5 then color: green.

In this case 'replacelD' style was removed, ensure number right alignment, just the color was added. So cells with the colors were aligned left, w/o right (legacy)

solution: append style instead replace.