### PR TITLE
IDEMPIERE-5206 - HTML Report CSS style - add AD_FieldStyle_ID on AD_PrintFormatItem table

### DIFF
--- a/migration/iD10/oracle/202202280901_IDEMPIERE-5206.sql
+++ b/migration/iD10/oracle/202202280901_IDEMPIERE-5206.sql
@@ -1,0 +1,26 @@
+-- IDEMPIERE - 5206
+SELECT register_migration_script('202202280901_IDEMPIERE-5206.sql') FROM dual;
+
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Feb 28, 2022, 9:08:21 AM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Reference_Value_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,FKConstraintType,IsHtml) VALUES (214710,0,'Field Style','Field CSS Style ',489,'AD_FieldStyle_ID',10,'N','N','N','N','N',0,'N',18,200121,0,0,'Y',TO_TIMESTAMP('2022-02-28 09:08:20','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2022-02-28 09:08:20','YYYY-MM-DD HH24:MI:SS'),100,203012,'Y','N','D','N','N','N','Y','351765e8-316e-419c-b264-a717b9148ffe','Y',0,'N','N','N','N')
+;
+
+-- Feb 28, 2022, 9:08:31 AM CET
+UPDATE AD_Column SET FKConstraintName='ADFieldStyle_ADPrintFormatItem', FKConstraintType='N',Updated=TO_TIMESTAMP('2022-02-28 09:08:31','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=214710
+;
+
+-- Feb 28, 2022, 9:08:31 AM CET
+ALTER TABLE AD_PrintFormatItem ADD AD_FieldStyle_ID NUMBER(10) DEFAULT NULL 
+;
+
+-- Feb 28, 2022, 9:08:31 AM CET
+ALTER TABLE AD_PrintFormatItem ADD CONSTRAINT ADFieldStyle_ADPrintFormatItem FOREIGN KEY (AD_FieldStyle_ID) REFERENCES ad_style(ad_style_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Feb 28, 2022, 9:15:01 AM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,SortNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan,NumLines,IsQuickEntry,IsDefaultFocus,IsAdvancedField,IsQuickForm) VALUES (206903,'Field Style','Field CSS Style ',426,214710,'Y',0,412,0,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2022-02-28 09:15:01','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2022-02-28 09:15:01','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','2cc55c6b-6341-4d0b-83ca-7494809f5701','Y',580,1,1,1,'N','N','N','N')
+;
+

--- a/migration/iD10/postgresql/202202280901_IDEMPIERE-5206.sql
+++ b/migration/iD10/postgresql/202202280901_IDEMPIERE-5206.sql
@@ -1,0 +1,23 @@
+-- IDEMPIERE - 5206
+SELECT register_migration_script('202202280901_IDEMPIERE-5206.sql') FROM dual;
+
+-- Feb 28, 2022, 9:08:21 AM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Reference_Value_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,FKConstraintType,IsHtml) VALUES (214710,0,'Field Style','Field CSS Style ',489,'AD_FieldStyle_ID',10,'N','N','N','N','N',0,'N',18,200121,0,0,'Y',TO_TIMESTAMP('2022-02-28 09:08:20','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2022-02-28 09:08:20','YYYY-MM-DD HH24:MI:SS'),100,203012,'Y','N','D','N','N','N','Y','351765e8-316e-419c-b264-a717b9148ffe','Y',0,'N','N','N','N')
+;
+
+-- Feb 28, 2022, 9:08:31 AM CET
+UPDATE AD_Column SET FKConstraintName='ADFieldStyle_ADPrintFormatItem', FKConstraintType='N',Updated=TO_TIMESTAMP('2022-02-28 09:08:31','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=214710
+;
+
+-- Feb 28, 2022, 9:08:31 AM CET
+ALTER TABLE AD_PrintFormatItem ADD COLUMN AD_FieldStyle_ID NUMERIC(10) DEFAULT NULL 
+;
+
+-- Feb 28, 2022, 9:08:31 AM CET
+ALTER TABLE AD_PrintFormatItem ADD CONSTRAINT ADFieldStyle_ADPrintFormatItem FOREIGN KEY (AD_FieldStyle_ID) REFERENCES ad_style(ad_style_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Feb 28, 2022, 9:15:01 AM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,SortNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan,NumLines,IsQuickEntry,IsDefaultFocus,IsAdvancedField,IsQuickForm) VALUES (206903,'Field Style','Field CSS Style ',426,214710,'Y',0,412,0,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2022-02-28 09:15:01','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2022-02-28 09:15:01','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','2cc55c6b-6341-4d0b-83ca-7494809f5701','Y',580,1,1,1,'N','N','N','N')
+;
+

--- a/org.adempiere.base/src/org/compiere/model/I_AD_PrintFormatItem.java
+++ b/org.adempiere.base/src/org/compiere/model/I_AD_PrintFormatItem.java
@@ -22,7 +22,7 @@ import org.compiere.util.KeyNamePair;
 
 /** Generated Interface for AD_PrintFormatItem
  *  @author iDempiere (generated) 
- *  @version Release 9
+ *  @version Release 10
  */
 public interface I_AD_PrintFormatItem 
 {
@@ -63,6 +63,21 @@ public interface I_AD_PrintFormatItem
 	public int getAD_Column_ID();
 
 	public org.compiere.model.I_AD_Column getAD_Column() throws RuntimeException;
+
+    /** Column name AD_FieldStyle_ID */
+    public static final String COLUMNNAME_AD_FieldStyle_ID = "AD_FieldStyle_ID";
+
+	/** Set Field Style.
+	  * Field CSS Style 
+	  */
+	public void setAD_FieldStyle_ID (int AD_FieldStyle_ID);
+
+	/** Get Field Style.
+	  * Field CSS Style 
+	  */
+	public int getAD_FieldStyle_ID();
+
+	public org.compiere.model.I_AD_Style getAD_FieldStyle() throws RuntimeException;
 
     /** Column name AD_Org_ID */
     public static final String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
@@ -122,21 +137,6 @@ public interface I_AD_PrintFormatItem
 
 	public org.compiere.model.I_AD_PrintFormat getAD_PrintFormatChild() throws RuntimeException;
 
-    /** Column name AD_PrintFormat_ID */
-    public static final String COLUMNNAME_AD_PrintFormat_ID = "AD_PrintFormat_ID";
-
-	/** Set Print Format.
-	  * Data Print Format
-	  */
-	public void setAD_PrintFormat_ID (int AD_PrintFormat_ID);
-
-	/** Get Print Format.
-	  * Data Print Format
-	  */
-	public int getAD_PrintFormat_ID();
-
-	public org.compiere.model.I_AD_PrintFormat getAD_PrintFormat() throws RuntimeException;
-
     /** Column name AD_PrintFormatItem_ID */
     public static final String COLUMNNAME_AD_PrintFormatItem_ID = "AD_PrintFormatItem_ID";
 
@@ -158,6 +158,21 @@ public interface I_AD_PrintFormatItem
 
 	/** Get AD_PrintFormatItem_UU	  */
 	public String getAD_PrintFormatItem_UU();
+
+    /** Column name AD_PrintFormat_ID */
+    public static final String COLUMNNAME_AD_PrintFormat_ID = "AD_PrintFormat_ID";
+
+	/** Set Print Format.
+	  * Data Print Format
+	  */
+	public void setAD_PrintFormat_ID (int AD_PrintFormat_ID);
+
+	/** Get Print Format.
+	  * Data Print Format
+	  */
+	public int getAD_PrintFormat_ID();
+
+	public org.compiere.model.I_AD_PrintFormat getAD_PrintFormat() throws RuntimeException;
 
     /** Column name AD_PrintGraph_ID */
     public static final String COLUMNNAME_AD_PrintGraph_ID = "AD_PrintGraph_ID";
@@ -538,19 +553,6 @@ public interface I_AD_PrintFormatItem
 	  */
 	public boolean isPrintBarcodeText();
 
-    /** Column name IsPrinted */
-    public static final String COLUMNNAME_IsPrinted = "IsPrinted";
-
-	/** Set Printed.
-	  * Indicates if this document / line is printed
-	  */
-	public void setIsPrinted (boolean IsPrinted);
-
-	/** Get Printed.
-	  * Indicates if this document / line is printed
-	  */
-	public boolean isPrinted();
-
     /** Column name IsPrintInstanceAttributes */
     public static final String COLUMNNAME_IsPrintInstanceAttributes = "IsPrintInstanceAttributes";
 
@@ -563,6 +565,19 @@ public interface I_AD_PrintFormatItem
 	  * Print each attributes as report column instead of printing the description of attribute set instance
 	  */
 	public boolean isPrintInstanceAttributes();
+
+    /** Column name IsPrinted */
+    public static final String COLUMNNAME_IsPrinted = "IsPrinted";
+
+	/** Set Printed.
+	  * Indicates if this document / line is printed
+	  */
+	public void setIsPrinted (boolean IsPrinted);
+
+	/** Get Printed.
+	  * Indicates if this document / line is printed
+	  */
+	public boolean isPrinted();
 
     /** Column name IsRelativePosition */
     public static final String COLUMNNAME_IsRelativePosition = "IsRelativePosition";

--- a/org.adempiere.base/src/org/compiere/model/X_AD_PrintFormatItem.java
+++ b/org.adempiere.base/src/org/compiere/model/X_AD_PrintFormatItem.java
@@ -23,7 +23,7 @@ import org.compiere.util.KeyNamePair;
 
 /** Generated Model for AD_PrintFormatItem
  *  @author iDempiere (generated) 
- *  @version Release 9 - $Id$ */
+ *  @version Release 10 - $Id$ */
 @org.adempiere.base.Model(table="AD_PrintFormatItem")
 public class X_AD_PrintFormatItem extends PO implements I_AD_PrintFormatItem, I_Persistent 
 {
@@ -31,7 +31,7 @@ public class X_AD_PrintFormatItem extends PO implements I_AD_PrintFormatItem, I_
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20220116L;
+	private static final long serialVersionUID = 20220225L;
 
     /** Standard Constructor */
     public X_AD_PrintFormatItem (Properties ctx, int AD_PrintFormatItem_ID, String trxName)
@@ -40,8 +40,8 @@ public class X_AD_PrintFormatItem extends PO implements I_AD_PrintFormatItem, I_
       /** if (AD_PrintFormatItem_ID == 0)
         {
 			setAD_PrintFormatChild_ID (0);
-			setAD_PrintFormat_ID (0);
 			setAD_PrintFormatItem_ID (0);
+			setAD_PrintFormat_ID (0);
 			setFieldAlignmentType (null);
 // D
 			setImageIsAttached (false);
@@ -67,10 +67,10 @@ public class X_AD_PrintFormatItem extends PO implements I_AD_PrintFormatItem, I_
 			setIsPageBreak (false);
 			setIsPrintBarcodeText (true);
 // Y
-			setIsPrinted (true);
-// Y
 			setIsPrintInstanceAttributes (false);
 // N
+			setIsPrinted (true);
+// Y
 			setIsRelativePosition (true);
 // Y
 			setIsRunningTotal (false);
@@ -106,8 +106,8 @@ public class X_AD_PrintFormatItem extends PO implements I_AD_PrintFormatItem, I_
       /** if (AD_PrintFormatItem_ID == 0)
         {
 			setAD_PrintFormatChild_ID (0);
-			setAD_PrintFormat_ID (0);
 			setAD_PrintFormatItem_ID (0);
+			setAD_PrintFormat_ID (0);
 			setFieldAlignmentType (null);
 // D
 			setImageIsAttached (false);
@@ -133,10 +133,10 @@ public class X_AD_PrintFormatItem extends PO implements I_AD_PrintFormatItem, I_
 			setIsPageBreak (false);
 			setIsPrintBarcodeText (true);
 // Y
-			setIsPrinted (true);
-// Y
 			setIsPrintInstanceAttributes (false);
 // N
+			setIsPrinted (true);
+// Y
 			setIsRelativePosition (true);
 // Y
 			setIsRunningTotal (false);
@@ -216,6 +216,34 @@ public class X_AD_PrintFormatItem extends PO implements I_AD_PrintFormatItem, I_
 	public int getAD_Column_ID()
 	{
 		Integer ii = (Integer)get_Value(COLUMNNAME_AD_Column_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	public org.compiere.model.I_AD_Style getAD_FieldStyle() throws RuntimeException
+	{
+		return (org.compiere.model.I_AD_Style)MTable.get(getCtx(), org.compiere.model.I_AD_Style.Table_ID)
+			.getPO(getAD_FieldStyle_ID(), get_TrxName());
+	}
+
+	/** Set Field Style.
+		@param AD_FieldStyle_ID Field CSS Style 
+	*/
+	public void setAD_FieldStyle_ID (int AD_FieldStyle_ID)
+	{
+		if (AD_FieldStyle_ID < 1)
+			set_Value (COLUMNNAME_AD_FieldStyle_ID, null);
+		else
+			set_Value (COLUMNNAME_AD_FieldStyle_ID, Integer.valueOf(AD_FieldStyle_ID));
+	}
+
+	/** Get Field Style.
+		@return Field CSS Style 
+	  */
+	public int getAD_FieldStyle_ID()
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_AD_FieldStyle_ID);
 		if (ii == null)
 			 return 0;
 		return ii.intValue();
@@ -305,34 +333,6 @@ public class X_AD_PrintFormatItem extends PO implements I_AD_PrintFormatItem, I_
 		return ii.intValue();
 	}
 
-	public org.compiere.model.I_AD_PrintFormat getAD_PrintFormat() throws RuntimeException
-	{
-		return (org.compiere.model.I_AD_PrintFormat)MTable.get(getCtx(), org.compiere.model.I_AD_PrintFormat.Table_ID)
-			.getPO(getAD_PrintFormat_ID(), get_TrxName());
-	}
-
-	/** Set Print Format.
-		@param AD_PrintFormat_ID Data Print Format
-	*/
-	public void setAD_PrintFormat_ID (int AD_PrintFormat_ID)
-	{
-		if (AD_PrintFormat_ID < 1)
-			set_ValueNoCheck (COLUMNNAME_AD_PrintFormat_ID, null);
-		else
-			set_ValueNoCheck (COLUMNNAME_AD_PrintFormat_ID, Integer.valueOf(AD_PrintFormat_ID));
-	}
-
-	/** Get Print Format.
-		@return Data Print Format
-	  */
-	public int getAD_PrintFormat_ID()
-	{
-		Integer ii = (Integer)get_Value(COLUMNNAME_AD_PrintFormat_ID);
-		if (ii == null)
-			 return 0;
-		return ii.intValue();
-	}
-
 	/** Set Print Format Item.
 		@param AD_PrintFormatItem_ID Item/Column in the Print format
 	*/
@@ -368,6 +368,34 @@ public class X_AD_PrintFormatItem extends PO implements I_AD_PrintFormatItem, I_
 	public String getAD_PrintFormatItem_UU()
 	{
 		return (String)get_Value(COLUMNNAME_AD_PrintFormatItem_UU);
+	}
+
+	public org.compiere.model.I_AD_PrintFormat getAD_PrintFormat() throws RuntimeException
+	{
+		return (org.compiere.model.I_AD_PrintFormat)MTable.get(getCtx(), org.compiere.model.I_AD_PrintFormat.Table_ID)
+			.getPO(getAD_PrintFormat_ID(), get_TrxName());
+	}
+
+	/** Set Print Format.
+		@param AD_PrintFormat_ID Data Print Format
+	*/
+	public void setAD_PrintFormat_ID (int AD_PrintFormat_ID)
+	{
+		if (AD_PrintFormat_ID < 1)
+			set_ValueNoCheck (COLUMNNAME_AD_PrintFormat_ID, null);
+		else
+			set_ValueNoCheck (COLUMNNAME_AD_PrintFormat_ID, Integer.valueOf(AD_PrintFormat_ID));
+	}
+
+	/** Get Print Format.
+		@return Data Print Format
+	  */
+	public int getAD_PrintFormat_ID()
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_AD_PrintFormat_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
 	}
 
 	public org.compiere.model.I_AD_PrintGraph getAD_PrintGraph() throws RuntimeException
@@ -427,14 +455,14 @@ public class X_AD_PrintFormatItem extends PO implements I_AD_PrintFormatItem, I_
 	public static final String BARCODETYPE_Code128CCharacterSet = "28C";
 	/** Codabar 2 of 7 linear = 2o9 */
 	public static final String BARCODETYPE_Codabar2Of7Linear = "2o9";
-	/** Code 39 w/o Checksum = 39c */
-	public static final String BARCODETYPE_Code39WOChecksum = "39c";
 	/** Code 39 with Checksum = 39C */
 	public static final String BARCODETYPE_Code39WithChecksum = "39C";
-	/** Code 39  3 of 9 linear w/o Checksum = 3o9 */
-	public static final String BARCODETYPE_Code393Of9LinearWOChecksum = "3o9";
+	/** Code 39 w/o Checksum = 39c */
+	public static final String BARCODETYPE_Code39WOChecksum = "39c";
 	/** Code 39  3 of 9 linear with Checksum = 3O9 */
 	public static final String BARCODETYPE_Code393Of9LinearWithChecksum = "3O9";
+	/** Code 39  3 of 9 linear w/o Checksum = 3o9 */
+	public static final String BARCODETYPE_Code393Of9LinearWOChecksum = "3o9";
 	/** PDF417 two dimensional = 417 */
 	public static final String BARCODETYPE_PDF417TwoDimensional = "417";
 	/** SCC-14 shipping code UCC/EAN 128 = C14 */
@@ -443,8 +471,6 @@ public class X_AD_PrintFormatItem extends PO implements I_AD_PrintFormatItem, I_
 	public static final String BARCODETYPE_SSCC_18NumberUCCEAN128 = "C18";
 	/** Code 128 dynamically switching = C28 */
 	public static final String BARCODETYPE_Code128DynamicallySwitching = "C28";
-	/** Code 39 linear w/o Checksum = c39 */
-	public static final String BARCODETYPE_Code39LinearWOChecksum = "c39";
 	/** Code 39 linear with Checksum = C39 */
 	public static final String BARCODETYPE_Code39LinearWithChecksum = "C39";
 	/** Codeabar linear = COD */
@@ -467,14 +493,16 @@ public class X_AD_PrintFormatItem extends PO implements I_AD_PrintFormatItem, I_
 	public static final String BARCODETYPE_UCC128 = "U28";
 	/** UPC-A = UPA */
 	public static final String BARCODETYPE_UPC_A = "UPA";
-	/** Code 39 USD3 w/o Checksum = us3 */
-	public static final String BARCODETYPE_Code39USD3WOChecksum = "us3";
 	/** Code 39 USD3 with Checksum = US3 */
 	public static final String BARCODETYPE_Code39USD3WithChecksum = "US3";
 	/** Codabar USD-4 linear = US4 */
 	public static final String BARCODETYPE_CodabarUSD_4Linear = "US4";
 	/** US Postal Service UCC/EAN 128 = USP */
 	public static final String BARCODETYPE_USPostalServiceUCCEAN128 = "USP";
+	/** Code 39 linear w/o Checksum = c39 */
+	public static final String BARCODETYPE_Code39LinearWOChecksum = "c39";
+	/** Code 39 USD3 w/o Checksum = us3 */
+	public static final String BARCODETYPE_Code39USD3WOChecksum = "us3";
 	/** Set Barcode Type.
 		@param BarcodeType Type of barcode
 	*/
@@ -1002,29 +1030,6 @@ public class X_AD_PrintFormatItem extends PO implements I_AD_PrintFormatItem, I_
 		return false;
 	}
 
-	/** Set Printed.
-		@param IsPrinted Indicates if this document / line is printed
-	*/
-	public void setIsPrinted (boolean IsPrinted)
-	{
-		set_Value (COLUMNNAME_IsPrinted, Boolean.valueOf(IsPrinted));
-	}
-
-	/** Get Printed.
-		@return Indicates if this document / line is printed
-	  */
-	public boolean isPrinted()
-	{
-		Object oo = get_Value(COLUMNNAME_IsPrinted);
-		if (oo != null) 
-		{
-			 if (oo instanceof Boolean) 
-				 return ((Boolean)oo).booleanValue(); 
-			return "Y".equals(oo);
-		}
-		return false;
-	}
-
 	/** Set Print Attributes.
 		@param IsPrintInstanceAttributes Print each attributes as report column instead of printing the description of attribute set instance
 	*/
@@ -1039,6 +1044,29 @@ public class X_AD_PrintFormatItem extends PO implements I_AD_PrintFormatItem, I_
 	public boolean isPrintInstanceAttributes()
 	{
 		Object oo = get_Value(COLUMNNAME_IsPrintInstanceAttributes);
+		if (oo != null) 
+		{
+			 if (oo instanceof Boolean) 
+				 return ((Boolean)oo).booleanValue(); 
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	/** Set Printed.
+		@param IsPrinted Indicates if this document / line is printed
+	*/
+	public void setIsPrinted (boolean IsPrinted)
+	{
+		set_Value (COLUMNNAME_IsPrinted, Boolean.valueOf(IsPrinted));
+	}
+
+	/** Get Printed.
+		@return Indicates if this document / line is printed
+	  */
+	public boolean isPrinted()
+	{
+		Object oo = get_Value(COLUMNNAME_IsPrinted);
 		if (oo != null) 
 		{
 			 if (oo instanceof Boolean) 

--- a/org.adempiere.base/src/org/compiere/print/ReportEngine.java
+++ b/org.adempiere.base/src/org/compiere/print/ReportEngine.java
@@ -931,25 +931,27 @@ queued-job-count = 0  (class javax.print.attribute.standard.QueuedJobCount)
 							Object obj = instanceAttributeColumn != null ? instanceAttributeColumn.getPrintDataElement(row)
 									: m_printData.getNodeByPrintFormatItemId(item.getAD_PrintFormatItem_ID());
 							//set style
-                            MStyle style = MStyle.get(Env.getCtx(), item.getAD_FieldStyle_ID());
-                            X_AD_StyleLine[] lines = style.getStyleLines();
-                            StringBuilder styleBuilder = new StringBuilder();
-                            for (X_AD_StyleLine line : lines)
-                            {
-                                
-                                String inlineStyle = line.getInlineStyle().trim();
-                                String displayLogic = line.getDisplayLogic();
-                                if (!Util.isEmpty(displayLogic))
-                                {
-                                    if (!Evaluator.evaluateLogic(new PrintDataEvaluatee(null, m_printData), displayLogic))
-                                        continue;
-                                }
-                                if (styleBuilder.length() > 0 && !(styleBuilder.charAt(styleBuilder.length()-1)==';'))
-                                    styleBuilder.append("; ");
-                                styleBuilder.append(inlineStyle);
-                            }
-                            if(styleBuilder != null)
-                                td.setStyle(styleBuilder.toString());
+							int AD_FieldStyle_ID = item.getAD_FieldStyle_ID();
+							if(AD_FieldStyle_ID > 0) {
+	                            MStyle style = MStyle.get(Env.getCtx(), AD_FieldStyle_ID);
+	                            X_AD_StyleLine[] lines = style.getStyleLines();
+	                            StringBuilder styleBuilder = new StringBuilder();
+	                            for (X_AD_StyleLine line : lines)
+	                            {
+	                                String inlineStyle = line.getInlineStyle().trim();
+	                                String displayLogic = line.getDisplayLogic();
+	                                if (!Util.isEmpty(displayLogic))
+	                                {
+	                                    if (!Evaluator.evaluateLogic(new PrintDataEvaluatee(null, m_printData), displayLogic))
+	                                        continue;
+	                                }
+	                                if (styleBuilder.length() > 0 && !(styleBuilder.charAt(styleBuilder.length()-1)==';'))
+	                                    styleBuilder.append("; ");
+	                                styleBuilder.append(inlineStyle);
+	                            }
+	                            if(styleBuilder.length() > 0)
+	                                td.setStyle(styleBuilder.toString());
+							}
                             //
 							if (obj == null || !isDisplayPFItem(item)){
 								td.addElement("&nbsp;");

--- a/org.adempiere.base/src/org/compiere/print/ReportEngine.java
+++ b/org.adempiere.base/src/org/compiere/print/ReportEngine.java
@@ -928,31 +928,31 @@ queued-job-count = 0  (class javax.print.attribute.standard.QueuedJobCount)
 						{
 							td td = new td();
 							tr.addElement(td);
-							Object obj = instanceAttributeColumn != null ? instanceAttributeColumn.getPrintDataElement(row)
-									: m_printData.getNodeByPrintFormatItemId(item.getAD_PrintFormatItem_ID());
 							//set style
 							int AD_FieldStyle_ID = item.getAD_FieldStyle_ID();
 							if(AD_FieldStyle_ID > 0) {
-	                            MStyle style = MStyle.get(Env.getCtx(), AD_FieldStyle_ID);
-	                            X_AD_StyleLine[] lines = style.getStyleLines();
-	                            StringBuilder styleBuilder = new StringBuilder();
-	                            for (X_AD_StyleLine line : lines)
-	                            {
-	                                String inlineStyle = line.getInlineStyle().trim();
-	                                String displayLogic = line.getDisplayLogic();
-	                                if (!Util.isEmpty(displayLogic))
-	                                {
-	                                    if (!Evaluator.evaluateLogic(new PrintDataEvaluatee(null, m_printData), displayLogic))
-	                                        continue;
-	                                }
-	                                if (styleBuilder.length() > 0 && !(styleBuilder.charAt(styleBuilder.length()-1)==';'))
-	                                    styleBuilder.append("; ");
-	                                styleBuilder.append(inlineStyle);
-	                            }
-	                            if(styleBuilder.length() > 0)
-	                                td.setStyle(styleBuilder.toString());
+								MStyle style = MStyle.get(Env.getCtx(), AD_FieldStyle_ID);
+								X_AD_StyleLine[] lines = style.getStyleLines();
+								StringBuilder styleBuilder = new StringBuilder();
+								for (X_AD_StyleLine line : lines)
+								{
+									String inlineStyle = line.getInlineStyle().trim();
+									String displayLogic = line.getDisplayLogic();
+									if (!Util.isEmpty(displayLogic))
+									{
+										if (!Evaluator.evaluateLogic(new PrintDataEvaluatee(null, m_printData), displayLogic))
+											continue;
+									}
+									if (styleBuilder.length() > 0 && !(styleBuilder.charAt(styleBuilder.length()-1)==';'))
+										styleBuilder.append("; ");
+									styleBuilder.append(inlineStyle);
+								}
+								if(styleBuilder.length() > 0)
+									td.setStyle(styleBuilder.toString());
 							}
-                            //
+							//
+							Object obj = instanceAttributeColumn != null ? instanceAttributeColumn.getPrintDataElement(row)
+									: m_printData.getNodeByPrintFormatItemId(item.getAD_PrintFormatItem_ID());
 							if (obj == null || !isDisplayPFItem(item)){
 								td.addElement("&nbsp;");
 								if (colSuppressRepeats != null && colSuppressRepeats[printColIndex]){

--- a/org.adempiere.base/src/org/compiere/print/ReportEngine.java
+++ b/org.adempiere.base/src/org/compiere/print/ReportEngine.java
@@ -88,8 +88,10 @@ import org.compiere.model.MProject;
 import org.compiere.model.MQuery;
 import org.compiere.model.MRfQResponse;
 import org.compiere.model.MRole;
+import org.compiere.model.MStyle;
 import org.compiere.model.MTable;
 import org.compiere.model.PrintInfo;
+import org.compiere.model.X_AD_StyleLine;
 import org.compiere.print.layout.InstanceAttributeColumn;
 import org.compiere.print.layout.InstanceAttributeData;
 import org.compiere.print.layout.LayoutEngine;
@@ -928,6 +930,27 @@ queued-job-count = 0  (class javax.print.attribute.standard.QueuedJobCount)
 							tr.addElement(td);
 							Object obj = instanceAttributeColumn != null ? instanceAttributeColumn.getPrintDataElement(row)
 									: m_printData.getNodeByPrintFormatItemId(item.getAD_PrintFormatItem_ID());
+							//set style
+                            MStyle style = MStyle.get(Env.getCtx(), item.getAD_FieldStyle_ID());
+                            X_AD_StyleLine[] lines = style.getStyleLines();
+                            StringBuilder styleBuilder = new StringBuilder();
+                            for (X_AD_StyleLine line : lines)
+                            {
+                                
+                                String inlineStyle = line.getInlineStyle().trim();
+                                String displayLogic = line.getDisplayLogic();
+                                if (!Util.isEmpty(displayLogic))
+                                {
+                                    if (!Evaluator.evaluateLogic(new PrintDataEvaluatee(null, m_printData), displayLogic))
+                                        continue;
+                                }
+                                if (styleBuilder.length() > 0 && !(styleBuilder.charAt(styleBuilder.length()-1)==';'))
+                                    styleBuilder.append("; ");
+                                styleBuilder.append(inlineStyle);
+                            }
+                            if(styleBuilder != null)
+                                td.setStyle(styleBuilder.toString());
+                            //
 							if (obj == null || !isDisplayPFItem(item)){
 								td.addElement("&nbsp;");
 								if (colSuppressRepeats != null && colSuppressRepeats[printColIndex]){


### PR DESCRIPTION
Ticket: https://idempiere.atlassian.net/browse/IDEMPIERE-5206

Try to add AD_FieldStyle_ID on AD_PrintFormatItem table.

Improvement: you will be able to change css style of data in single cells of HTML report, based on the Display Logic defined in AD_FieldStyle.