### PR TITLE
IDEMPIERE-5063 Improve Unit Tests

### DIFF
--- a/org.idempiere.test/src/org/idempiere/test/AbstractTestCase.java
+++ b/org.idempiere.test/src/org/idempiere/test/AbstractTestCase.java
@@ -33,6 +33,7 @@ import org.compiere.Adempiere;
 import org.compiere.model.MAcctSchema;
 import org.compiere.model.MClientInfo;
 import org.compiere.model.MRole;
+import org.compiere.util.DB;
 import org.compiere.util.Env;
 import org.compiere.util.Language;
 import org.compiere.util.Trx;
@@ -225,5 +226,6 @@ public abstract class AbstractTestCase {
 	 */
 	static void shutdown() {
 		Adempiere.stop();
+		DB.getDatabase().close();
 	}
 }

--- a/org.idempiere.test/src/org/idempiere/test/base/POTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/base/POTest.java
@@ -459,13 +459,13 @@ public class POTest extends AbstractTestCase
 
 		// asynchronous (default) virtual column loading
 		assertTrue(null == testPo.get_ValueOld(MTest.COLUMNNAME_TestVirtualQty));
-		BigDecimal expected = new BigDecimal(123.45d).setScale(2, RoundingMode.HALF_DOWN);
-		assertTrue(expected.compareTo(testPo.getTestVirtualQty()) == 0);
+		BigDecimal expected = new BigDecimal("123.45");
+		assertEquals(expected, testPo.getTestVirtualQty().setScale(2, RoundingMode.HALF_UP), "Wrong value returned");
 
 		// synchronous virtual column loading
 		testPo = new MTest(Env.getCtx(), testPo.get_ID(), getTrxName(), MTest.COLUMNNAME_TestVirtualQty);
 		assertTrue(null != testPo.get_ValueOld(MTest.COLUMNNAME_TestVirtualQty));
-		assertTrue(expected.compareTo(testPo.getTestVirtualQty()) == 0);
+		assertEquals(expected, testPo.getTestVirtualQty().setScale(2, RoundingMode.HALF_UP), "Wrong value returned");
 	}
 
 }

--- a/org.idempiere.test/src/org/idempiere/test/base/QueryTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/base/QueryTest.java
@@ -380,27 +380,27 @@ public class QueryTest extends AbstractTestCase {
 		PO testPo = new MTest(Env.getCtx(), getClass().getName(), 1);
 		testPo.save();
 
-		BigDecimal expected = new BigDecimal(123.45d).setScale(2, RoundingMode.HALF_DOWN);
+		BigDecimal expected = new BigDecimal("123.45");
 
 		// virtual column lazy loading
 		Query query = new Query(Env.getCtx(), MTest.Table_Name, MTest.COLUMNNAME_Test_ID + "=?", getTrxName());
 		testPo = query.setParameters(testPo.get_ID()).first();
 		I_Test testRecord = POWrapper.create(testPo, I_Test.class);
 		assertTrue(null == testPo.get_ValueOld(MTest.COLUMNNAME_TestVirtualQty));
-		assertTrue(expected.compareTo(testRecord.getTestVirtualQty()) == 0);
+		assertEquals(expected, testRecord.getTestVirtualQty().setScale(2, RoundingMode.HALF_UP), "Wrong value returned");
 
 		// without virtual column lazy loading
 		testPo = query.setNoVirtualColumn(false).setParameters(testPo.get_ID()).first();
 		assertTrue(null != testPo.get_ValueOld(MTest.COLUMNNAME_TestVirtualQty));
 		testRecord = POWrapper.create(testPo, I_Test.class);
-		assertTrue(expected.compareTo(testRecord.getTestVirtualQty()) == 0);
+		assertEquals(expected, testRecord.getTestVirtualQty().setScale(2, RoundingMode.HALF_UP), "Wrong value returned");
 
 		// single virtual column without lazy loading
 		testPo = query.setVirtualColumns(I_Test.COLUMNNAME_TestVirtualQty)
 				.setParameters(testPo.get_ID()).first();
 		assertTrue(null != testPo.get_ValueOld(MTest.COLUMNNAME_TestVirtualQty));
 		testRecord = POWrapper.create(testPo, I_Test.class);
-		assertTrue(expected.compareTo(testRecord.getTestVirtualQty()) == 0);
+		assertEquals(expected, testRecord.getTestVirtualQty().setScale(2, RoundingMode.HALF_UP), "Wrong value returned");
 	}
 
 }


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5063
- Close DB connections after each unit test class
- POTest and QueryTest: use assert equals, use bigdecimal string constructor in preference to double

When running the Unit Tests, the number of DB connections continuously grows until all the tests are completed. Currently this is  over 80 connections. As the number of unit tests increase, this could become an issue. Closing the database after each test class greatly reduces the number of concurrent connections and doesn't add more than a couple of seconds to the total time taken to run all the tests.

Also added some minor improvevements to POTest and QueryTest.