### PR TITLE
IDEMPIERE-5230 DesktopImpl.warn: UUID recycle is enabled and it's better to disable it by specifying a library property 'org.zkoss.zk.ui.uuidRecycle.disabled' with true to prevent some unwanted widget uuid reusing at client side accidentally.

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/zk.xml
+++ b/org.adempiere.ui.zk/WEB-INF/zk.xml
@@ -135,4 +135,8 @@
     	<name>org.zkoss.zk.ui.WebApp.name</name>
     	<value>iDempiere</value>
 	</preference>
+    <library-property>
+        <name>org.zkoss.zk.ui.uuidRecycle.disabled</name>
+        <value>true</value>
+    </library-property>
 </zk>


### PR DESCRIPTION
[…](https://idempiere.atlassian.net/browse/IDEMPIERE-5230)