### PR TITLE
IDEMPIERE-5256  Add Cache to MSession

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/PO.java
+++ b/org.adempiere.base/src/org/compiere/model/PO.java
@@ -2661,7 +2661,7 @@ public abstract class PO
 		lobReset();
 
 		//	Change Log
-		MSession session = MSession.get (p_ctx, false);
+		MSession session = MSession.get (p_ctx, false, true);
 		if (session == null)
 			log.fine("No Session found");
 		int AD_ChangeLog_ID = 0;
@@ -3123,7 +3123,7 @@ public abstract class PO
 		lobReset();
 
 		//	Change Log
-		MSession session = MSession.get (p_ctx, false);
+		MSession session = MSession.get (p_ctx, false, true);
 		if (session == null)
 			log.fine("No Session found");
 		int AD_ChangeLog_ID = 0;
@@ -3719,7 +3719,7 @@ public abstract class PO
 					if( p_info.isChangeLog())
 					{
 						//	Change Log
-						MSession session = MSession.get (p_ctx, false);
+						MSession session = MSession.get (p_ctx, false, true);
 						if (session == null)
 							log.fine("No Session found");
 						else if (m_IDs.length == 1)

--- a/org.adempiere.base/src/org/compiere/process/ProcessInfo.java
+++ b/org.adempiere.base/src/org/compiere/process/ProcessInfo.java
@@ -912,7 +912,7 @@ public class ProcessInfo implements Serializable
 	}
 	
 	private Timestamp getLastServerRebootDate() {
-		MSession currentSession = MSession.get(Env.getCtx(), false);
+		MSession currentSession = MSession.get(Env.getCtx(), false, true);
 		if (currentSession == null)
 			return null;
 		

--- a/org.adempiere.base/src/org/compiere/util/Env.java
+++ b/org.adempiere.base/src/org/compiere/util/Env.java
@@ -176,7 +176,7 @@ public final class Env
 		//hengsin, avoid unncessary query of session when exit without log in
 		if (DB.isConnected(false)) {
 			//	End Session
-			MSession session = MSession.get(Env.getCtx(), false);	//	finish
+			MSession session = MSession.get(Env.getCtx(), false, false);	//	finish
 			if (session != null)
 				session.logout();
 		}
@@ -195,7 +195,7 @@ public final class Env
 	public static void logout()
 	{
 		//	End Session
-		MSession session = MSession.get(Env.getCtx(), false);	//	finish
+		MSession session = MSession.get(Env.getCtx(), false, false);	//	finish
 		if (session != null)
 			session.logout();
 		//

--- a/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/AdempiereActivator.java
+++ b/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/AdempiereActivator.java
@@ -98,7 +98,7 @@ public class AdempiereActivator extends AbstractActivator {
 			MSession localSession = null;
 			//Create Session to be able to create records in AD_ChangeLog
 			if (Env.getContextAsInt(Env.getCtx(), Env.AD_SESSION_ID) <= 0) {
-				localSession = MSession.get(Env.getCtx(), true);
+				localSession = MSession.get(Env.getCtx(), true, false);
 				localSession.setWebSession("AdempiereActivator");
 				localSession.saveEx();
 			}

--- a/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/Incremental2PackActivator.java
+++ b/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/Incremental2PackActivator.java
@@ -212,7 +212,7 @@ public class Incremental2PackActivator extends AbstractActivator {
 			MSession localSession = null;
 			//Create Session to be able to create records in AD_ChangeLog
 			if (Env.getContextAsInt(Env.getCtx(), Env.AD_SESSION_ID) <= 0) {
-				localSession = MSession.get(Env.getCtx(), true);
+				localSession = MSession.get(Env.getCtx(), true, false);
 				localSession.setWebSession("Incremental2PackActivator");
 				localSession.saveEx();
 			}

--- a/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/PackInApplicationActivator.java
+++ b/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/PackInApplicationActivator.java
@@ -101,7 +101,7 @@ public class PackInApplicationActivator extends AbstractActivator{
 			if (getDBLock()) {
 				//Create Session to be able to create records in AD_ChangeLog
 				if (Env.getContextAsInt(Env.getCtx(), Env.AD_SESSION_ID) <= 0) {
-					localSession = MSession.get(Env.getCtx(), true);
+					localSession = MSession.get(Env.getCtx(), true, false);
 					localSession.setWebSession("PackInApplicationActivator");
 					localSession.saveEx();
 				}

--- a/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/Version2PackActivator.java
+++ b/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/Version2PackActivator.java
@@ -151,7 +151,7 @@ public class Version2PackActivator extends AbstractActivator{
 			if (getDBLock()) {
 				//Create Session to be able to create records in AD_ChangeLog
 				if (Env.getContextAsInt(Env.getCtx(), Env.AD_SESSION_ID) <= 0) {
-					localSession = MSession.get(Env.getCtx(), true);
+					localSession = MSession.get(Env.getCtx(), true, false);
 					localSession.setWebSession("Version2PackActivator");
 					localSession.saveEx();
 				}

--- a/org.adempiere.server/src/main/server/org/compiere/server/AdempiereServerMgr.java
+++ b/org.adempiere.server/src/main/server/org/compiere/server/AdempiereServerMgr.java
@@ -119,7 +119,7 @@ public class AdempiereServerMgr implements ServiceTrackerCustomizer<IServerFacto
 		log.info("");
 		
 		//	Set Session
-		MSession session = MSession.get(getCtx(), true);
+		MSession session = MSession.get(getCtx(), true, false);
 		session.setWebStoreSession(false);
 		session.setWebSession("Server");
 		session.saveEx();

--- a/org.adempiere.server/src/main/server/org/compiere/server/Scheduler.java
+++ b/org.adempiere.server/src/main/server/org/compiere/server/Scheduler.java
@@ -132,7 +132,7 @@ public class Scheduler extends AdempiereServer
 		Env.setContext(getCtx(), Env.DATE, dateFormat4Timestamp.format(ts)+" 00:00:00" );    //  JDBC format
 
 		//Create new Session and set #AD_Session_ID to context
-		MSession session = MSession.get(getCtx(), true);
+		MSession session = MSession.get(getCtx(), true, false);
 		MProcess process = new MProcess(getCtx(), scheduler.getAD_Process_ID(), null);
 		try
 		{

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/AdempiereWebUI.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/AdempiereWebUI.java
@@ -273,7 +273,7 @@ public class AdempiereWebUI extends Window implements EventListener<Event>, IWeb
         String x_Forward_IP = Executions.getCurrent().getHeader("X-Forwarded-For");
         
 		MSession mSession = MSession.get (ctx, x_Forward_IP!=null ? x_Forward_IP : Executions.getCurrent().getRemoteAddr(),
-			Executions.getCurrent().getRemoteHost(), httpSess.getId() );
+			Executions.getCurrent().getRemoteHost(), httpSess.getId(), false );
 		if (clientInfo.userAgent != null) {
 			mSession.setDescription(mSession.getDescription() + "\n" + clientInfo.toString());
 			mSession.saveEx();

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/AEnv.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/AEnv.java
@@ -211,7 +211,7 @@ public final class AEnv
 		}
 		windowCache.remove(sessionID);
 		//	End Session
-		MSession session = MSession.get(Env.getCtx(), false);	//	finish
+		MSession session = MSession.get(Env.getCtx(), false, false);	//	finish
 		if (session != null)
 			session.logout();
 		

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/session/SessionContextListener.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/session/SessionContextListener.java
@@ -265,7 +265,7 @@ public class SessionContextListener implements ExecutionInit,
 				}
 			}
 		
-			MSession mSession = MSession.get(Env.getCtx(), false);
+			MSession mSession = MSession.get(Env.getCtx(), false, false);
 			if(mSession!=null && !mSession.isProcessed()) {
 				
 		        mSession.setProcessed(true);
@@ -318,7 +318,7 @@ public class SessionContextListener implements ExecutionInit,
     	{
 			setupExecutionContextFromSession(Executions.getCurrent());
     	}
-		MSession mSession = MSession.get(Env.getCtx(), false);
+		MSession mSession = MSession.get(Env.getCtx(), false, false);
 		if(mSession!=null){
 			if (mSession.isProcessed()) {
 				mSession.setProcessed(false);

--- a/org.idempiere.webservices/WEB-INF/src/org/idempiere/adinterface/CompiereService.java
+++ b/org.idempiere.webservices/WEB-INF/src/org/idempiere/adinterface/CompiereService.java
@@ -288,10 +288,10 @@ public class CompiereService {
 		Env.setContext(getCtx(), Env.LANGUAGE, m_language.getAD_Language());
 		
 		// Create session
-		MSession session = MSession.get (getCtx(), false);
+		MSession session = MSession.get (getCtx(), false, false);
 		if (session == null){
 			log.fine("No Session found");
-			session = MSession.get (getCtx(), true);    	
+			session = MSession.get (getCtx(), true, false);    	
 		}
 		session.setWebSession("WebService");
 		


### PR DESCRIPTION
Jira Ticket: https://idempiere.atlassian.net/browse/IDEMPIERE-5256

Added Caching to MSession. Added Parameter IsImmutable to select if we want to return immutable object (cached) or load from DB.

It Looks like Vector had some validation logic (Records Check) which cannot be copied to new Caching. Updating MSession record will delete cached data. 

Added Deprecated tag to previous methods.