### PR TITLE
IDEMPIERE-5284 Create method EMail.sendEx to have access to the full Exception when sending EMails (FHCA-3587)

### DIFF
--- a/org.adempiere.base.process/src/org/compiere/process/EMailTest.java
+++ b/org.adempiere.base.process/src/org/compiere/process/EMailTest.java
@@ -110,7 +110,7 @@ public class EMailTest extends SvrProcess
 				if (! from.contains("@"))
 					from = "test@" + from;
 				email.setFrom(from);
-				String msg = email.send();
+				String msg = email.sendEx();
 				if (EMail.SENT_OK.equals (msg))
 				{
 					if (log.isLoggable(Level.INFO)) log.info("Sent Test EMail to " + client.getRequestEMail());

--- a/org.adempiere.base/src/org/compiere/util/EMail.java
+++ b/org.adempiere.base/src/org/compiere/util/EMail.java
@@ -247,7 +247,32 @@ public final class EMail implements Serializable
 	 *	Send Mail direct
 	 *	@return OK or error message
 	 */
-	public String send ()
+	public String send()
+	{
+		String msg;
+		try {
+			msg = send(false);
+		} catch (Exception e) {
+			msg = e.getLocalizedMessage();
+		}
+		return msg;
+	}
+
+	/**
+	 *	Send Mail direct
+	 *	@return OK or error message
+	 */
+	public String sendEx() throws Exception
+	{
+		return send(true);
+	}
+
+	/**
+	 *	Send Mail direct
+	 *	@return OK or error message
+	 * @throws Exception 
+	 */
+	public String send(boolean throwException) throws Exception
 	{
 		if (!m_forceUseTenantSmtp && getFrom() != null) {
 			MSMTP smtp = MSMTP.get(m_ctx, Env.getAD_Client_ID(m_ctx), getFrom().getAddress());
@@ -325,6 +350,8 @@ public final class EMail implements Serializable
 		}
 		catch (SecurityException se)
 		{
+			if (throwException)
+				throw se;
 			log.log(Level.WARNING, "Auth=" + m_auth + " - " + se.toString());
 			m_sentMsg = se.toString();
 			Env.getCtx().put(EMAIL_SEND_MSG, m_sentMsg);
@@ -332,6 +359,8 @@ public final class EMail implements Serializable
 		}
 		catch (Exception e)
 		{
+			if (throwException)
+				throw e;
 			log.log(Level.SEVERE, "Auth=" + m_auth, e);
 			m_sentMsg = e.toString();
 			Env.getCtx().put(EMAIL_SEND_MSG, m_sentMsg);
@@ -420,6 +449,8 @@ public final class EMail implements Serializable
 		}
 		catch (MessagingException me)
 		{
+			if (throwException)
+				throw me;
 			me.printStackTrace();
 			Exception ex = me;
 			StringBuilder sb = new StringBuilder("(ME)");
@@ -504,6 +535,8 @@ public final class EMail implements Serializable
 		}
 		catch (Exception e)
 		{
+			if (throwException)
+				throw e;
 			log.log(Level.SEVERE, "", e);
 			m_sentMsg = e.getLocalizedMessage();
 			Env.getCtx().put(EMAIL_SEND_MSG, m_sentMsg);
@@ -560,13 +593,13 @@ public final class EMail implements Serializable
 	 */
 	private void dumpMessage()
 	{
-		if (m_msg == null)
+		if (m_msg == null || !log.isLoggable(Level.FINEST))
 			return;
 		try
 		{
 			Enumeration<?> e = m_msg.getAllHeaderLines ();
 			while (e.hasMoreElements ())
-				if (log.isLoggable(Level.FINE)) log.fine("- " + e.nextElement ());
+				log.finest("- " + e.nextElement ());
 		}
 		catch (MessagingException ex)
 		{


### PR DESCRIPTION


- improved also the dumpMessage, is just called when the level is finest, but it was logging on fine level, also the if must be out of the loop

https://idempiere.atlassian.net/browse/IDEMPIERE-5284