### PR TITLE
IDEMPIERE-5262 Implement readonly protection for DB.getSQLValueEx call

### DIFF
--- a/org.adempiere.base/src/org/compiere/util/Trx.java
+++ b/org.adempiere.base/src/org/compiere/util/Trx.java
@@ -483,8 +483,11 @@ public class Trx
 		if (m_connection == null)
 			return true;
 		
-		if (isActive())
-			commit();
+		try {
+			if (isActive() && !m_connection.isReadOnly())
+				commit();
+		} catch (SQLException e) {			
+		}
 			
 		//	Close Connection
 		try


### PR DESCRIPTION
- Avoid unnecessary commit call.