### PR TITLE
IDEMPIERE-5295 Trial Balance Report creates wrong Opening Balance

### DIFF
--- a/migration/iD10/oracle/202206282000_IDEMPIERE-5295.sql
+++ b/migration/iD10/oracle/202206282000_IDEMPIERE-5295.sql
@@ -13,7 +13,7 @@ INSERT INTO AD_Process_Para (AD_Process_Para_ID,AD_Client_ID,AD_Org_ID,IsActive,
 ;
 
 ALTER TABLE t_trialbalance 
-DROP CONSTRAINT t_trialbalance_pkey
+DROP CONSTRAINT t_trialbalance_key
 ;
 
 ALTER TABLE t_trialbalance


### PR DESCRIPTION
fix oracle script - caused by mismatch in primary key name IDEMPIERE-5227

https://idempiere.atlassian.net/browse/IDEMPIERE-5295?focusedCommentId=48499