### PR TITLE
[pipo] Throw useful exception when table not found

### DIFF
--- a/org.adempiere.pipo/src/org/adempiere/pipo2/POFinder.java
+++ b/org.adempiere.pipo/src/org/adempiere/pipo2/POFinder.java
@@ -48,6 +48,9 @@ public class POFinder {
 		if (AD_Client_ID==0)
 			return uuid;
 		MTable table = MTable.get(ctx, tableName);
+		if (table == null) {
+			throw new IllegalStateException("getTargetUUID couldn't find table named " + tableName);
+		}
 		String sql = "SELECT Target_UUID FROM AD_Package_UUID_Map WHERE AD_Client_ID=? AND AD_Table_ID=? AND Source_UUID=?";
 		String uid = DB.getSQLValueString(trxName, sql, AD_Client_ID, table.getAD_Table_ID(), uuid);
 		return Util.isEmpty(uid) ? uuid : uid;


### PR DESCRIPTION
With this commit, Pack In will throw an informative error message if it can't find a table (including the table name).

Without this fix, you simply get an NPE which isn't very helpful for debugging.

Implements https://idempiere.atlassian.net/browse/IDEMPIERE-5366