### PR TITLE
IDEMPIERE-5368 Pack In doesn't close resources properly on failure

### DIFF
--- a/org.adempiere.pipo/src/org/adempiere/pipo2/PackIn.java
+++ b/org.adempiere.pipo/src/org/adempiere/pipo2/PackIn.java
@@ -131,8 +131,7 @@ public class PackIn {
 			if (log.isLoggable(Level.INFO)) log.info("importXML:" + msg);
 			return msg;
 		}
-		try {
-			FileInputStream input = new FileInputStream(in);
+		try (FileInputStream input = new FileInputStream(in)) {
 			return importXML(input, ctx, trxName);
 		} catch (Exception e) {
 			log.log(Level.SEVERE, "importXML:", e);


### PR DESCRIPTION
The input stream was not explicitly closed on exit (whether a success or failure). This leaves a resource leak and for added misery for Windows users meant that you can't pack in more than once without restarting the server.

Fixes [IDEMPIERE-5368](https://idempiere.atlassian.net/jira/software/c/projects/IDEMPIERE/issues/IDEMPIERE-5368)

_Edit: changed link to the correct issue in JIRA_