### PR TITLE
IDEMPIERE-5389 - improve Status Line as Dashboard Content height

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/desktop/DashboardController.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/desktop/DashboardController.java
@@ -761,10 +761,7 @@ public class DashboardController implements EventListener<Event> {
     		statusLineHtml.setContent(sl.parseLine(0));
     		Div div = new Div();
     		div.appendChild(statusLineHtml);
-    		if(content instanceof HtmlBasedComponent)
-    			((HtmlBasedComponent) content).setSclass("statusline-gadget");
-    		else
-    			div.setSclass("statusline-gadget");
+    		div.setSclass("statusline-gadget");
     		content.appendChild(div);
     		empty = false;
     	}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/desktop/DashboardController.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/desktop/DashboardController.java
@@ -467,7 +467,6 @@ public class DashboardController implements EventListener<Event> {
 				panel = newGadgetPanel(dp, dc);
 				panel.setAttribute(FLEX_GROW_ATTRIBUTE, String.valueOf(flexGrow));
 		        	ZKUpdateUtil.setHflex(panel, String.valueOf(flexGrow));
-				ZKUpdateUtil.setHeight(panel, "100%");
 	        	}
 			if (panel != null && panel.getAttribute(PANEL_EMPTY_ATTRIBUTE) == null) {
 	        		dashboardLineLayout.appendChild(panel);
@@ -762,6 +761,7 @@ public class DashboardController implements EventListener<Event> {
     		Div div = new Div();
     		div.appendChild(statusLineHtml);
     		div.setSclass("statusline-gadget");
+    		((HtmlBasedComponent) content.getParent()).setSclass("statusline-wrapper");
     		content.appendChild(div);
     		empty = false;
     	}

--- a/org.adempiere.ui.zk/WEB-INF/src/web/theme/default/css/fragment/gadget.css.dsp
+++ b/org.adempiere.ui.zk/WEB-INF/src/web/theme/default/css/fragment/gadget.css.dsp
@@ -224,6 +224,8 @@
 	display: flex;
  	justify-content: center;
  	align-items: center;
+ 	margin: 20px 0px 20px 0px;
+ 	height: -webkit-fill-available;
 }
 
 .help-content

--- a/org.adempiere.ui.zk/WEB-INF/src/web/theme/default/css/fragment/gadget.css.dsp
+++ b/org.adempiere.ui.zk/WEB-INF/src/web/theme/default/css/fragment/gadget.css.dsp
@@ -10,7 +10,24 @@
 	background-image: none; background-color: #FFFFFF;
 }
 
+.statusline-wrapper > .z-panel-head {
+	position: absolute;
+	top: 1;
+	z-index: 1;
+	width: calc(100% - 8px);
+}
+
 .dashboard-widget > .z-panel-body {
+	height: 100%;
+}
+
+.statusline-wrapper {
+	height: 100%;
+}
+
+.statusline-wrapper > .z-panel-body {
+	position: relative;
+	top: 0;
 	height: 100%;
 }
 
@@ -26,6 +43,7 @@
 
 .z-panelchildren {
 	border: none;
+	height: 100%;
 }
 
 .z-panel-head {
@@ -61,6 +79,7 @@
 	margin-right: auto;
 	position: relative;
 	width: 99%;	
+	height: 100%;
 }
 
 .dashboard-widget-max {
@@ -70,10 +89,6 @@
 
 .dashboard-widget.dashboard-widget-max > .z-panel-body > .z-panelchildren {
 	overflow: auto;
-}
-
-.dashboard-widget > .z-panel-body > .z-panelchildren {
-	height: 100% !important;
 }
 
 .dashboard-report-iframe {
@@ -222,10 +237,11 @@
 
 .statusline-gadget {
 	display: flex;
+	flex-direction: column;
  	justify-content: center;
  	align-items: center;
- 	margin: 20px 0px 20px 0px;
- 	height: -webkit-fill-available;
+ 	padding: 40px 0px 10px;
+ 	height: 100%;
 }
 
 .help-content


### PR DESCRIPTION
JIRA ticket: https://idempiere.atlassian.net/browse/IDEMPIERE-5389

**Before:**
![IDEMPIERE-5389 - Padding Multiplied](https://user-images.githubusercontent.com/93127072/188828306-bae2bea8-f4fe-4c7b-9520-60b218041e6d.png)

**After:**
![IDEMPIERE-5389 - Padding Fixed](https://user-images.githubusercontent.com/93127072/188828393-77ec229c-2f98-4b5c-a605-f76fc5296682.png)

You can see, that the Performance Widget is partially hidden, also as chart doesn't fit widget height (next image)

![IDEMPIERE-5389 - Chart Issue](https://user-images.githubusercontent.com/93127072/188830360-5f0f8541-fb61-4088-b1fa-6a0ab7caf9ff.png)


For better testing we provide Pack Out for Status Line: https://idempiere.atlassian.net/browse/IDEMPIERE-5410
