### PR TITLE
Fixed user defined JDBC URL override not working.

### DIFF
--- a/org.compiere.db.oracle.provider/META-INF/pool/server.default.properties
+++ b/org.compiere.db.oracle.provider/META-INF/pool/server.default.properties
@@ -52,7 +52,7 @@ connectionTimeout=60000
 # will block for up to connectionTimeout milliseconds before timing out. Please 
 # read about pool sizing: https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
 # Default: 10
-maximumPoolSize=30
+maximumPoolSize=90
 
 # This property controls the maximum lifetime of a connection in the pool. An 
 # in-use connection will never be retired, only when it is closed will it then be 

--- a/org.compiere.db.oracle.provider/src/org/compiere/db/DB_Oracle.java
+++ b/org.compiere.db.oracle.provider/src/org/compiere/db/DB_Oracle.java
@@ -721,13 +721,13 @@ public class DB_Oracle implements AdempiereDatabase
     		Properties poolProperties = getPoolProperties();
     		// Do not override values which might have been read from the users
     		// hikaricp.properties file.
-    		if(!poolProperties.contains("jdbcUrl")) {
+    		if(!poolProperties.containsKey("jdbcUrl")) {
     			poolProperties.put("jdbcUrl", getConnectionURL(connection));
     		}
-    		if (!poolProperties.contains("username")) {
+    		if (!poolProperties.containsKey("username")) {
     			poolProperties.put("username", connection.getDbUid());
     		}
-    		if (!poolProperties.contains("password")) {
+    		if (!poolProperties.containsKey("password")) {
     			poolProperties.put("password", connection.getDbPwd());
     		}
     		

--- a/org.compiere.db.postgresql.provider/META-INF/pool/server.default.properties
+++ b/org.compiere.db.postgresql.provider/META-INF/pool/server.default.properties
@@ -52,7 +52,7 @@ connectionTimeout=60000
 # will block for up to connectionTimeout milliseconds before timing out. Please 
 # read about pool sizing: https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
 # Default: 10
-maximumPoolSize=30
+maximumPoolSize=90
 
 # This property controls the maximum lifetime of a connection in the pool. An 
 # in-use connection will never be retired, only when it is closed will it then be 

--- a/org.compiere.db.postgresql.provider/src/org/compiere/db/DB_PostgreSQL.java
+++ b/org.compiere.db.postgresql.provider/src/org/compiere/db/DB_PostgreSQL.java
@@ -747,13 +747,13 @@ public class DB_PostgreSQL implements AdempiereDatabase
     		Properties poolProperties = getPoolProperties();
     		// Do not override values which might have been read from the users
     		// hikaricp.properties file.
-    		if(!poolProperties.contains("jdbcUrl")) {
+    		if(!poolProperties.containsKey("jdbcUrl")) {
     			poolProperties.put("jdbcUrl", getConnectionURL(connection));
     		}
-    		if (!poolProperties.contains("username")) {
+    		if (!poolProperties.containsKey("username")) {
     			poolProperties.put("username", connection.getDbUid());
     		}
-    		if (!poolProperties.contains("password")) {
+    		if (!poolProperties.containsKey("password")) {
     			poolProperties.put("password", connection.getDbPwd());
     		}
 


### PR DESCRIPTION
Fixes logic error in the way a user defined `jdbcUrl` in `hikaricp.properties` is handled.

Additionally changed the default max pool size to the previous limit of 90 connections. PR #926 originally also had this but this apparently fell out. Testing showed that during first time server startup a flood of connection can be made and a connection pool of 30 can be overwhelmed in some cases (depending on the speed of your setup). This results in callers waiting on a connection which will time-out.
