### PR TITLE
IDEMPIERE-5433 Separate invoices for different BPs (fixes release9)

### DIFF
--- a/org.adempiere.base.process/src/org/compiere/process/InvoiceGenerate.java
+++ b/org.adempiere.base.process/src/org/compiere/process/InvoiceGenerate.java
@@ -91,6 +91,8 @@ public class InvoiceGenerate extends SvrProcess
 	private BigDecimal p_MinimumAmtInvSched = null;
 	/**	Per Invoice Savepoint */
 	private Savepoint m_savepoint = null;
+	/** BPartner on the last order processed */
+	private int m_bpartnerID = 0;
 
 	/**
 	 *  Prepare - e.g., get Parameters.
@@ -176,7 +178,7 @@ public class InvoiceGenerate extends SvrProcess
 			//
 			sql.append(") AND o.C_DocType_ID IN (SELECT C_DocType_ID FROM C_DocType ")
 					.append("WHERE DocBaseType='SOO' AND DocSubTypeSO NOT IN ('ON','OB','WR')) ")
-				.append("ORDER BY AD_Org_ID, M_Warehouse_ID, PriorityRule, C_BPartner_ID, Bill_Location_ID, C_Order_ID");
+				.append("ORDER BY AD_Org_ID, M_Warehouse_ID, PriorityRule, C_BPartner_ID, Bill_Location_ID, Bill_User_ID, C_Order_ID");
 		}
 	//	sql += " FOR UPDATE";
 		
@@ -228,9 +230,12 @@ public class InvoiceGenerate extends SvrProcess
 				statusUpdate(msgsup.toString());
 				
 				//	New Invoice Location
-				if (!p_ConsolidateDocument 
+				if (!p_ConsolidateDocument
+					|| (m_bpartnerID != 0
+					&& m_bpartnerID != order.getC_BPartner_ID())
 					|| (m_invoice != null 
-					&& m_invoice.getC_BPartner_Location_ID() != order.getBill_Location_ID()) )
+					&& (m_invoice.getC_BPartner_Location_ID() != order.getBill_Location_ID() ||
+						m_invoice.getAD_User_ID() != order.getBill_User_ID()) ) )
 					completeInvoice();
 				boolean completeOrder = MOrder.INVOICERULE_AfterOrderDelivered.equals(order.getInvoiceRule());
 				
@@ -349,6 +354,7 @@ public class InvoiceGenerate extends SvrProcess
 						m_line += 1000;
 					}
 				}	//	complete Order
+				m_bpartnerID = order.getC_BPartner_ID();
 			}	//	for all orders
 		}
 		catch (Exception e)


### PR DESCRIPTION
Fixes https://idempiere.atlassian.net/browse/IDEMPIERE-5433. Now a new invoice will be created for a new ship-to BPartner as well as for a new invoice-to BP Location, so that you don't inadvertently mix ship-to BPs on the same invoice. Sorting by BPartner first, then Bill_Location_ID takes care of most of this, but as noted in the JIRA ticket there are some edge cases that are not covered.

While looking at this code, I also noticed that if you have two invoices with the same Bill_Location_ID but different Bill_User_ID, they will still consolidate onto the same invoice. But if you have two different contacts, it would probably be best if they each got their own invoice even if they are for the same location.

The only thing that is misisng from this PR (I think) is a specific regression test. All the existing tests pass, but I couldn't find a test specifically for InvoiceGenerate where I could add a regression test for this issue.  If someone can point me in the direction of the correct place to put such a test, I can consider adding one.