### PR TITLE
Minor - solve two new eclipse 2022-09 warnings

### DIFF
--- a/db/.settings/org.eclipse.core.resources.prefs
+++ b/db/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/migration/.settings/org.eclipse.core.resources.prefs
+++ b/migration/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
In eclipse 2022-09 two new warnings are shown:
Project 'db' has no explicit encoding set
Project 'migration' has no explicit encoding
