### PR TITLE
IDEMPIERE-5446 : Property to know an AttachmentEntry has been updated

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MAttachment.java
+++ b/org.adempiere.base/src/org/compiere/model/MAttachment.java
@@ -638,6 +638,7 @@ public class MAttachment extends X_AD_Attachment
 		MAttachmentEntry entry = getEntry(i);
 		if (entry == null) return false;
 		entry.setData(data);
+		entry.setUpdated(true);
 		return true;
 	}
 

--- a/org.adempiere.base/src/org/compiere/model/MAttachmentEntry.java
+++ b/org.adempiere.base/src/org/compiere/model/MAttachmentEntry.java
@@ -108,7 +108,7 @@ public class MAttachmentEntry
 	/** Lazy Data Source */
 	private IAttachmentLazyDataSource m_ds = null;
 
-	/** True if the entry has been updated (on upload, when a file with same name is already there) */
+	/** True if the entry has been updated (sets by MAttachment.updateEntry(int, byte[]) */
 	private boolean m_isUpdated = false;
 
 	/**
@@ -355,10 +355,16 @@ public class MAttachmentEntry
 		return m_ds;
 	}
 
+	/** Set the updated property 
+	 * @param updated
+	 */
 	public void setUpdated(boolean updated) {
 		m_isUpdated = updated;
 	}
 
+	/** Get the updated property 
+	 * @return updated
+	 */
 	public boolean isUpdated() {
 		return m_isUpdated;
 	}

--- a/org.adempiere.base/src/org/compiere/model/MAttachmentEntry.java
+++ b/org.adempiere.base/src/org/compiere/model/MAttachmentEntry.java
@@ -108,6 +108,9 @@ public class MAttachmentEntry
 	/** Lazy Data Source */
 	private IAttachmentLazyDataSource m_ds = null;
 
+	/** True if the entry has been updated (on upload, when a file with same name is already there) */
+	private boolean m_isUpdated = false;
+
 	/**
 	 * @return Returns the data.
 	 */
@@ -350,6 +353,14 @@ public class MAttachmentEntry
 	 */
 	public IAttachmentLazyDataSource getLazyDataSource() {
 		return m_ds;
+	}
+
+	public void setUpdated(boolean updated) {
+		m_isUpdated = updated;
+	}
+
+	public boolean isUpdated() {
+		return m_isUpdated;
 	}
 
 }	//	MAttachmentItem


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5446

# Pull Request Checklist

## Checklist:

- [X] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [X] My code follows the best practices of this project
- [X] I have performed a self-review of my own code
- [X] My code is easy to understand and review. 
- [ ] In hard-to-understand areas, I have commented my code.
- [X] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

