### PR TITLE
IDEMPIERE-5399: issue when first value is 01:00 and component is usin…

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WTestTimeEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WTestTimeEditor.java
@@ -1,0 +1,59 @@
+package org.adempiere.webui.apps.form;
+
+import org.adempiere.webui.component.Label;
+import org.adempiere.webui.editor.WTimeEditor;
+import org.adempiere.webui.event.ValueChangeEvent;
+import org.adempiere.webui.event.ValueChangeListener;
+import org.adempiere.webui.panel.ADForm;
+import org.zkoss.zk.ui.event.Event;
+import org.zkoss.zk.ui.event.EventListener;
+import org.zkoss.zk.ui.event.Events;
+import org.zkoss.zul.Hlayout;
+import org.zkoss.zul.Vbox;
+
+@org.idempiere.ui.zk.annotation.Form
+public class WTestTimeEditor extends ADForm implements EventListener<Event>, ValueChangeListener {
+	private static final long serialVersionUID = -5661912464378243252L;
+
+	private WTimeEditor fTimeBoxValueChange = new WTimeEditor();
+	private WTimeEditor fTimeBoxEvent = new WTimeEditor();
+
+	public WTestTimeEditor() {
+		super();
+	}
+
+	@Override
+	protected void initForm() {
+
+		fTimeBoxValueChange.getComponent().setFormat("HH:mm");
+		fTimeBoxValueChange.addValueChangeListener(this);
+		fTimeBoxEvent.getComponent().setFormat("HH:mm");
+		fTimeBoxEvent.getComponent().addEventListener(Events.ON_BLUR, this);
+
+		Vbox vbox = new Vbox();
+		Hlayout hl = new Hlayout();
+		hl.setValign("middle");
+		hl.appendChild(new Label("ValueChange"));
+		hl.appendChild(fTimeBoxValueChange.getComponent());
+		vbox.appendChild(hl);
+
+		hl = new Hlayout();
+		hl.setValign("middle");
+		hl.appendChild(new Label("Event"));
+		hl.appendChild(fTimeBoxEvent.getComponent());
+		vbox.appendChild(hl);
+
+		appendChild(vbox);
+
+	}
+
+	public void onEvent(Event event) throws Exception {
+		System.out.println("Event " + event.getTarget() + " - " + fTimeBoxEvent.getValue());
+	}
+
+	@Override
+	public void valueChange(ValueChangeEvent evt) {
+		System.out.println("ValueChange" + evt.getSource() + " - " + evt.getOldValue() + " -> "+ evt.getNewValue());
+	}
+
+}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WTimeEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WTimeEditor.java
@@ -128,6 +128,9 @@ public class WTimeEditor extends WEditor implements ContextMenuListener
 
 	        if (date != null)
 	        {
+	        	// newValue = new Timestamp(date.getTime()); // Before IDEMPIERE-5399
+	        	
+	        	/* IDEMPIERE-5399
 				Calendar cal = Calendar.getInstance();
 				cal.setTime(date);
 				cal.set(Calendar.YEAR, 1970);
@@ -136,6 +139,19 @@ public class WTimeEditor extends WEditor implements ContextMenuListener
 				Date dateIn1970 = new Date(cal.getTimeInMillis());
 				getComponent().setValue(dateIn1970);
 	            newValue = new Timestamp(dateIn1970.getTime());
+	            */
+	        	
+	        	//IDEMPIERE-5399 - possible patch
+				Calendar cal = Calendar.getInstance();
+				cal.setTime(date);
+				cal.set(Calendar.YEAR, 1970);
+				cal.set(Calendar.MONTH, 0);
+				cal.set(Calendar.DAY_OF_MONTH, 1);
+				cal.set(Calendar.MILLISECOND, 1);
+				Date dateIn1970 = new Date(cal.getTimeInMillis());
+				getComponent().setValue(dateIn1970);
+	            newValue = new Timestamp(dateIn1970.getTime());
+	            
 	        }
 
 	        if (oldValue != null && newValue != null && oldValue.equals(newValue)) {


### PR DESCRIPTION
…g ValueChangeListener

https://idempiere.atlassian.net/browse/IDEMPIERE-5399

# Pull Request Checklist

## Checklist:

- [ ] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [ ] My code follows the best practices of this project
- [ ] I have performed a self-review of my own code
- [ ] My code is easy to understand and review. 
- [ ] In hard-to-understand areas, I have commented my code.
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

