### PR TITLE
IDEMPIERE-5013 set HikariCP initial pool size to 10 - as it was in c3p0

### DIFF
--- a/org.compiere.db.postgresql.provider/META-INF/pool/server.default.properties
+++ b/org.compiere.db.postgresql.provider/META-INF/pool/server.default.properties
@@ -42,7 +42,7 @@ connectionTimeout=60000
 # recommend not setting this value and instead allowing HikariCP to act as a 
 # fixed size connection pool. 
 # Default: same as maximumPoolSize
-#minimumIdle=
+minimumIdle=10
 
 # This property controls the maximum size that the pool is allowed to reach, 
 # including both idle and in-use connections. Basically this value will determine 


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5013?focusedCommentId=48859

c3p0 had initial pool size set to 10.

HikariCP suggest a fixed pool size approach, so it starts immediately the 90 connections.

Changing the default back to 10 so it mimics better our previous c3p0 behavior.