### PR TITLE
IDEMPIERE-5481 PostgreSQL: trunc(timestamp,format) missing version fo…

### DIFF
--- a/db/postgresql/functions/trunc.sql
+++ b/db/postgresql/functions/trunc.sql
@@ -33,7 +33,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
-CREATE OR REPLACE FUNCTION trunc(datetime TIMESTAMP WITH TIME ZONE, format varchar)
+CREATE OR REPLACE FUNCTION trunc(datetime TIMESTAMP WITHOUT TIME ZONE, format varchar)
 RETURNS DATE AS $$
 BEGIN
 	IF format = 'Q' THEN
@@ -49,6 +49,13 @@ BEGIN
 	ELSE
 		RETURN CAST(datetime AS DATE);
 	END IF;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION trunc(datetime TIMESTAMP WITH TIME ZONE, format varchar)
+RETURNS DATE AS $$
+BEGIN
+		RETURN trunc(cast(datetime as timestamp without time zone), format);
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 

--- a/migration/i9/oracle/202211180700_IDEMPIERE-5481.sql
+++ b/migration/i9/oracle/202211180700_IDEMPIERE-5481.sql
@@ -1,0 +1,6 @@
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+SELECT register_migration_script('202211180700_IDEMPIERE-5481.sql') FROM dual;
+
+-- PostgreSQL Only

--- a/migration/i9/postgresql/202211180700_IDEMPIERE-5481.sql
+++ b/migration/i9/postgresql/202211180700_IDEMPIERE-5481.sql
@@ -1,0 +1,27 @@
+SELECT register_migration_script('202211180700_IDEMPIERE-5481.sql') FROM dual;
+
+CREATE OR REPLACE FUNCTION trunc(datetime TIMESTAMP WITHOUT TIME ZONE, format varchar)
+RETURNS DATE AS $$
+BEGIN
+	IF format = 'Q' THEN
+		RETURN CAST(DATE_Trunc('quarter',datetime) as DATE);
+	ELSIF format = 'Y' or format = 'YEAR' THEN
+		RETURN CAST(DATE_Trunc('year',datetime) as DATE);
+	ELSIF format = 'MM' or format = 'MONTH' THEN
+		RETURN CAST(DATE_Trunc('month',datetime) as DATE);
+	ELSIF format = 'DD' THEN
+		RETURN CAST(DATE_Trunc('day',datetime) as DATE);
+	ELSIF format = 'DY' THEN
+		RETURN CAST(DATE_Trunc('day',datetime) as DATE);
+	ELSE
+		RETURN CAST(datetime AS DATE);
+	END IF;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION trunc(datetime TIMESTAMP WITH TIME ZONE, format varchar)
+RETURNS DATE AS $$
+BEGIN
+		RETURN trunc(cast(datetime as timestamp without time zone), format);
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;


### PR DESCRIPTION
…r TIMESTAMP WITHOUT TIME ZONE

https://idempiere.atlassian.net/browse/IDEMPIERE-5481
# Pull Request Checklist

## Checklist:

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

