### PR TITLE
IDEMPIERE-5540 : Incorrect automatic parameters for setDocAction WebS…

### DIFF
--- a/org.idempiere.webservices/WEB-INF/src/org/idempiere/webservices/model/MWebServiceType.java
+++ b/org.idempiere.webservices/WEB-INF/src/org/idempiere/webservices/model/MWebServiceType.java
@@ -57,7 +57,7 @@ public class MWebServiceType extends X_WS_WebServiceType implements ImmutablePOS
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = -6105547694847198509L;
+	private static final long serialVersionUID = -3735256212187060831L;
 
 	/**	Parameters	*/
 	private MWebServicePara[]	m_para = null;
@@ -343,6 +343,11 @@ public class MWebServiceType extends X_WS_WebServiceType implements ImmutablePOS
 				addWsParameter("AD_Process_ID", X_WS_WebService_Para.PARAMETERTYPE_Constant, ""); // can't fill it as the process is unknown
 				addWsParameter("AD_Menu_ID", X_WS_WebService_Para.PARAMETERTYPE_Constant, "0");
 				addWsParameter("AD_Record_ID", X_WS_WebService_Para.PARAMETERTYPE_Free, "");
+			} else if ("setDocAction".equals(method)) {
+				addWsParameter("tableName", X_WS_WebService_Para.PARAMETERTYPE_Constant, MTable.get(getCtx(), getAD_Table_ID()).getTableName());
+				addWsParameter("docAction", X_WS_WebService_Para.PARAMETERTYPE_Constant, ""); // to be filled manually by user
+				addWsParameter("recordID", X_WS_WebService_Para.PARAMETERTYPE_Free, "");
+				addWsParameter("recordIDVariable", X_WS_WebService_Para.PARAMETERTYPE_Free, "");
 			} else {
 				String value = "";
 				if ("createData".equals(method))


### PR DESCRIPTION
…ervices

https://idempiere.atlassian.net/browse/IDEMPIERE-5540

# Pull Request Checklist

## Checklist:

- [X] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [X] My code follows the best practices of this project
- [X] I have performed a self-review of my own code
- [ X My code is easy to understand and review. 
- [X] In hard-to-understand areas, I have commented my code.
- [X] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

