### PR TITLE
IDEMPIERE-5520 Navigation between Tabs leave Detached DOM objects (Leak)

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/FindWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/FindWindow.java
@@ -350,6 +350,7 @@ public class FindWindow extends Window implements EventListener<Event>, ValueCha
         
         this.setWidgetAttribute(AdempiereWebUI.WIDGET_INSTANCE_NAME, "findWindow");
         this.setId("findWindow_"+targetWindowNo+"_"+targetTabNo);
+        System.out.println("this.setId -> findWindow_"+targetWindowNo+"_"+targetTabNo);
         LayoutUtils.addSclass("find-window", this);
         
         addEventListener(Events.ON_CANCEL, e -> onCancel());
@@ -389,6 +390,7 @@ public class FindWindow extends Window implements EventListener<Event>, ValueCha
     	if ((title == null && m_title != null) || (title != null && m_title == null) || !(title.equals(m_title))) return false;
     	if (AD_Table_ID != m_AD_Table_ID) return false;
     	if ((tableName == null && m_tableName != null) || (tableName != null && m_tableName == null) || !(tableName.equals(m_tableName))) return false;
+    	whereExtended = Env.parseContext(Env.getCtx(), targetWindowNo, whereExtended, false);
     	if ((whereExtended == null && m_whereExtended != null) || (whereExtended != null && m_whereExtended == null) || !(whereExtended.equals(m_whereExtended))) return false;
     	if (adTabId != m_AD_Tab_ID) return false;
     	if ((findFields == null && m_findFields != null) || (findFields != null && m_findFields == null) || (findFields.length != m_findFields.length)) return false;


### PR DESCRIPTION
- Fix "Not unique in the ID space of" when tab where clause have context variables
