### PR TITLE
IDEMPIERE-5520 Navigation between Tabs leave Detached DOM objects (Leak)

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/AbstractADWindowContent.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/AbstractADWindowContent.java
@@ -4332,6 +4332,11 @@ public abstract class AbstractADWindowContent extends AbstractUIPart implements 
 		if (findWindow != null && isCurrentFindWindowValid()) {
 			toolbar.setSelectedUserQuery(findWindow.getAD_UserQuery_ID());
 		} else {
+			if (findWindow != null) {
+				if (findWindow.getParent() != null)
+					findWindow.getParent().removeChild(findWindow);
+				tabFindWindowHashMap.remove(adTabbox.getSelectedGridTab(), findWindow);
+			}
 			findWindow = new FindWindow (adTabbox.getSelectedGridTab().getWindowNo(), adTabbox.getSelectedGridTab().getTabNo(), adTabbox.getSelectedGridTab().getName(),
 					adTabbox.getSelectedGridTab().getAD_Table_ID(), adTabbox.getSelectedGridTab().getTableName(),
 					adTabbox.getSelectedGridTab().getWhereExtended(), findFields, 1, adTabbox.getSelectedGridTab().getAD_Tab_ID(), this);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/AbstractADWindowContent.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/AbstractADWindowContent.java
@@ -4333,9 +4333,13 @@ public abstract class AbstractADWindowContent extends AbstractUIPart implements 
 			toolbar.setSelectedUserQuery(findWindow.getAD_UserQuery_ID());
 		} else {
 			if (findWindow != null) {
-				if (findWindow.getParent() != null)
-					findWindow.getParent().removeChild(findWindow);
-				tabFindWindowHashMap.remove(adTabbox.getSelectedGridTab(), findWindow);
+				//reset to no/auto id
+				FindWindow old = findWindow;
+				old.setId("");
+				if (old.getDesktop() != null) {
+					AEnv.detachInputElement(old);
+					Executions.schedule(old.getDesktop(), e -> old.detach(), new Event("onDetachOldFindWindow"));
+				}
 			}
 			findWindow = new FindWindow (adTabbox.getSelectedGridTab().getWindowNo(), adTabbox.getSelectedGridTab().getTabNo(), adTabbox.getSelectedGridTab().getName(),
 					adTabbox.getSelectedGridTab().getAD_Table_ID(), adTabbox.getSelectedGridTab().getTableName(),

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/FindWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/FindWindow.java
@@ -389,7 +389,10 @@ public class FindWindow extends Window implements EventListener<Event>, ValueCha
     	if ((title == null && m_title != null) || (title != null && m_title == null) || !(title.equals(m_title))) return false;
     	if (AD_Table_ID != m_AD_Table_ID) return false;
     	if ((tableName == null && m_tableName != null) || (tableName != null && m_tableName == null) || !(tableName.equals(m_tableName))) return false;
-    	whereExtended = Env.parseContext(Env.getCtx(), targetWindowNo, whereExtended, false);
+    	if (whereExtended.contains("@"))
+    		whereExtended = Env.parseContext(Env.getCtx(), targetWindowNo, whereExtended, false);
+    	if (m_whereExtended.contains("@"))
+    		m_whereExtended = Env.parseContext(Env.getCtx(), targetWindowNo, whereExtended, false);
     	if ((whereExtended == null && m_whereExtended != null) || (whereExtended != null && m_whereExtended == null) || !(whereExtended.equals(m_whereExtended))) return false;
     	if (adTabId != m_AD_Tab_ID) return false;
     	if ((findFields == null && m_findFields != null) || (findFields != null && m_findFields == null) || (findFields.length != m_findFields.length)) return false;


### PR DESCRIPTION
- Fix another "Not unique in the ID space of" when tab where clause have context variables and is navigated using zoom
- Add extra cleanup in the unexpected case a Find window is created again

## Checklist:

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
