### PR TITLE
# IDEMPIERE-5582 - Removes Default Logic from SQL Columns

### DIFF
--- a/migration/iD10/oracle/202302161520_IDEMPIERE-5582.sql
+++ b/migration/iD10/oracle/202302161520_IDEMPIERE-5582.sql
@@ -1,0 +1,9 @@
+-- IDEMPIERE-5582
+SELECT register_migration_script('202302161520_IDEMPIERE-5582.sql') FROM dual;
+
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- That UPDATE removes all Default Values from Vitual Columns.
+UPDATE AD_Column SET DefaultValue = NULL
+WHERE ColumnSQL IS NOT NULL AND DefaultValue IS NOT NULL

--- a/migration/iD10/oracle/202302161520_IDEMPIERE-5582.sql
+++ b/migration/iD10/oracle/202302161520_IDEMPIERE-5582.sql
@@ -4,6 +4,14 @@ SELECT register_migration_script('202302161520_IDEMPIERE-5582.sql') FROM dual;
 SET SQLBLANKLINES ON
 SET DEFINE OFF
 
--- That UPDATE removes all Default Values from Vitual Columns.
-UPDATE AD_Column SET DefaultValue = NULL
-WHERE ColumnSQL IS NOT NULL AND DefaultValue IS NOT NULL
+-- Feb 17, 2023, 5:20:47 PM BRT
+UPDATE AD_Column SET DefaultValue=NULL,Updated=TO_TIMESTAMP('2023-02-17 17:20:47','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=14395
+;
+
+-- Feb 17, 2023, 5:24:39 PM BRT
+UPDATE AD_Column SET DefaultValue=NULL,Updated=TO_TIMESTAMP('2023-02-17 17:24:39','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=13481
+;
+
+-- Feb 17, 2023, 5:25:34 PM BRT
+UPDATE AD_Column SET DefaultValue=NULL,Updated=TO_TIMESTAMP('2023-02-17 17:25:34','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=14335
+;

--- a/migration/iD10/postgresql/202302161520_IDEMPIERE-5582.sql
+++ b/migration/iD10/postgresql/202302161520_IDEMPIERE-5582.sql
@@ -1,0 +1,6 @@
+-- IDEMPIERE-5582
+SELECT register_migration_script('202302161520_IDEMPIERE-5582.sql') FROM dual;
+
+-- That UPDATE removes all Default Values from Vitual Columns.
+UPDATE AD_Column SET DefaultValue = NULL
+WHERE ColumnSQL IS NOT NULL AND DefaultValue IS NOT NULL

--- a/migration/iD10/postgresql/202302161520_IDEMPIERE-5582.sql
+++ b/migration/iD10/postgresql/202302161520_IDEMPIERE-5582.sql
@@ -1,6 +1,15 @@
 -- IDEMPIERE-5582
 SELECT register_migration_script('202302161520_IDEMPIERE-5582.sql') FROM dual;
 
--- That UPDATE removes all Default Values from Vitual Columns.
-UPDATE AD_Column SET DefaultValue = NULL
-WHERE ColumnSQL IS NOT NULL AND DefaultValue IS NOT NULL
+-- Feb 17, 2023, 5:20:47 PM BRT
+UPDATE AD_Column SET DefaultValue=NULL,Updated=TO_TIMESTAMP('2023-02-17 17:20:47','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=14395
+;
+
+-- Feb 17, 2023, 5:24:39 PM BRT
+UPDATE AD_Column SET DefaultValue=NULL,Updated=TO_TIMESTAMP('2023-02-17 17:24:39','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=13481
+;
+
+-- Feb 17, 2023, 5:25:34 PM BRT
+UPDATE AD_Column SET DefaultValue=NULL,Updated=TO_TIMESTAMP('2023-02-17 17:25:34','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=14335
+;
+


### PR DESCRIPTION
# About the modifications for [IDEMPIERE-5582](https://idempiere.atlassian.net/browse/IDEMPIERE-5582):

All Vitual Columns was updated to remove its Default Logics.

At the first moment, I maded that adjust using an UPDATE to remove that value from AD_COLUMN, but, To prevent other projects from being affected by this change, I maded another commit, removing all the (three) default logics from Dictionary.

After that adjust, I applied the script on database and checked if it worked:
![check](https://user-images.githubusercontent.com/71560285/219760445-154941a7-3397-4271-a5d0-e45e2dfcffe3.png)

Like showed above, all (three) Virtual Columns with Default Logic was removed.

# Pull Request Checklist

## Checklist:

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

[IDEMPIERE-5582]: https://idempiere.atlassian.net/browse/IDEMPIERE-5582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ