### PR TITLE
IDEMPIERE-5542 [DisplayType] - Cache issue

### DIFF
--- a/org.adempiere.base/src/org/compiere/util/DisplayType.java
+++ b/org.adempiere.base/src/org/compiere/util/DisplayType.java
@@ -638,6 +638,10 @@ public final class DisplayType
 		}
 		else
 		{
+			format.setMaximumIntegerDigits(MAX_DIGITS);
+			format.setMaximumFractionDigits(MAX_FRACTION);
+			format.setMinimumFractionDigits(1);
+
 			//not custom type, don't have to check factory
 			if (displayType < 1000000)
 				return format;
@@ -665,10 +669,7 @@ public final class DisplayType
 				}
 				s_customDisplayTypeNegativeCache.put(customTypeKey, Boolean.TRUE);
 			}
-			
-			format.setMaximumIntegerDigits(MAX_DIGITS);
-			format.setMaximumFractionDigits(MAX_FRACTION);
-			format.setMinimumFractionDigits(1);
+
 		}
 		return format;
 	}	//	getDecimalFormat


### PR DESCRIPTION
- Fix problem with the AbstractXLSXExporter going wild, the method getFormatString is trying to create a format with the number of digits supported by the NumberFormat, and as the MaximumIntegerDigits is not set, is trying to create a String with the default which is 2147483647

https://idempiere.atlassian.net/browse/IDEMPIERE-5542

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
