### PR TITLE
IDEMPIERE-5588 - Multiselect Chosenbox Editor Doesn't Initialise its List when Tab First Opened

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MLookupFactory.java
+++ b/org.adempiere.base/src/org/compiere/model/MLookupFactory.java
@@ -603,6 +603,11 @@ public class MLookupFactory
 		lookupDisplayColumns.add(lookupDisplayColumn != null ? lookupDisplayColumn : DisplayColumn);
 		s_cacheRefTable.put(key.toString(), retValue.cloneIt());
 		retValue.lookupDisplayColumns = lookupDisplayColumns;
+		if(list != null) {
+			for (LookupDisplayColumn ldc : list) {
+				retValue.lookupDisplayColumnNames.add(ldc.ColumnName);
+			}
+		}
 		return retValue;
 	}	//	getLookup_Table
 

--- a/org.adempiere.base/src/org/compiere/model/MLookupInfo.java
+++ b/org.adempiere.base/src/org/compiere/model/MLookupInfo.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.logging.Level;
@@ -211,6 +212,8 @@ public class MLookupInfo implements Serializable, Cloneable
 	public int InfoWindowId;
 	
 	public List<String> lookupDisplayColumns = null;
+	
+	public List<String> lookupDisplayColumnNames = new ArrayList<String>();
 
 	/**
 	 * String representation

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/InfoListSubModel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/InfoListSubModel.java
@@ -98,7 +98,7 @@ public class InfoListSubModel implements ListSubModel<ValueNamePair> {
 				.append(nRows);
 			if (lookup instanceof MLookup) {
 				MLookup mlookup = (MLookup) lookup;
-				List<String> displayColumns = mlookup.getLookupInfo().lookupDisplayColumns;
+				List<String> displayColumns = mlookup.getLookupInfo().lookupDisplayColumnNames;
 				if (displayColumns != null && displayColumns.size() > 0) {
 					queryBuilder.append(",")
 						.append("searchcolumn:")


### PR DESCRIPTION
JIRA ticket: https://idempiere.atlassian.net/browse/IDEMPIERE-5588

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

