### PR TITLE
IDEMPIERE-5637 - Improve GridField to allow setting the default values of GridFieldVO programmatically with a method

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/GridField.java
+++ b/org.adempiere.base/src/org/compiere/model/GridField.java
@@ -92,6 +92,10 @@ public class GridField
 	private static final Character SYSTEM_PREFERENCE_DEFAULT = '5';
 	private static final Character PANEL_PREFERENCE_DEFAULT = '6';
 	private static final Character DATA_TYPE_DEFAULT = '7';
+	private static final String DEFAULT_PRIORITY_ORDER = "123457";
+	
+	//default is preference for field > special case > default logic > sql default > data-type default
+	private static final String DEFAULT_PRIORITY_ORDER_FOR_PANEL = "623";
 
 	/**
 	 *  Field Constructor.
@@ -632,11 +636,9 @@ public class GridField
 		if (isIgnoreDefault())
 			return null;
 		
-		String orderGetDefault = "123457";// this value can put to system configuration
-		
 		Object defaultValue = null;
 		
-		if ((defaultValue = getDefault (orderGetDefault)) != null){
+		if ((defaultValue = getDefault (DEFAULT_PRIORITY_ORDER)) != null){
 			return defaultValue;
 		}
 		
@@ -652,9 +654,7 @@ public class GridField
 	 * @return
 	 */
 	public Object getDefaultForPanel (){
-		//default is preference for field > special case > default logic > sql default > data-type default
-		String defaultSeq = "623";
-		return getDefault (MSysConfig.getValue(MSysConfig.ZK_SEQ_DEFAULT_VALUE_PANEL, defaultSeq, Env.getAD_Client_ID(m_vo.ctx)));
+		return getDefault (MSysConfig.getValue(MSysConfig.ZK_SEQ_DEFAULT_VALUE_PANEL, DEFAULT_PRIORITY_ORDER_FOR_PANEL, Env.getAD_Client_ID(m_vo.ctx)));
 	}
 	
 	/**

--- a/org.adempiere.base/src/org/compiere/model/GridField.java
+++ b/org.adempiere.base/src/org/compiere/model/GridField.java
@@ -84,6 +84,14 @@ public class GridField
 	 * 
 	 */
 	private static final long serialVersionUID = 405469916055906825L;
+	
+	private static final Character SPECIAL_CASE_DEFAULT = '1';
+	private static final Character SQL_DEFAULT = '2';
+	private static final Character DEFAULT_LOGIC = '3';
+	private static final Character USER_PREFERENCE_DEFAULT = '4';
+	private static final Character SYSTEM_PREFERENCE_DEFAULT = '5';
+	private static final Character PANEL_PREFERENCE_DEFAULT = '6';
+	private static final Character DATA_TYPE_DEFAULT = '7';
 
 	/**
 	 *  Field Constructor.
@@ -671,7 +679,7 @@ public class GridField
 	public Object getDefault(ParseSeq seqGetDefaultValue){
 		Object defaultValue = null;
 		for (Character seqType : seqGetDefaultValue){
-			if (   seqType == '3'  // default from Expression 
+			if (   seqType == DEFAULT_LOGIC  // default from Expression 
 				&& m_vo.DefaultValue != null
 				&& m_vo.DefaultValue.toUpperCase().equals("NULL")) // IDEMPIERE-2678
 				return null;
@@ -695,17 +703,17 @@ public class GridField
 	 * @return
 	 */
 	protected Object getDefaultValueByType (Character defaultValueType){
-		if (defaultValueType.equals('1')){
+		if (defaultValueType.equals(SPECIAL_CASE_DEFAULT)) {
 			return defaultForSpecialCase();
-		}else if (defaultValueType.equals('2')){
+		}else if (defaultValueType.equals(SQL_DEFAULT)) {
 			return defaultFromSQLExpression();
-		}else if (defaultValueType.equals('3')){
+		}else if (defaultValueType.equals(DEFAULT_LOGIC)) {
 			return defaultFromExpression();
-		}else if (defaultValueType.equals('4') || defaultValueType.equals('5')){
+		}else if (defaultValueType.equals(USER_PREFERENCE_DEFAULT) || defaultValueType.equals(SYSTEM_PREFERENCE_DEFAULT)) {
 			return defaultFromPreference(defaultValueType);
-		}else if (defaultValueType.equals('6')){
+		}else if (defaultValueType.equals(PANEL_PREFERENCE_DEFAULT)) {
 			return defaultFromPreferenceForPanel();
-		}else if (defaultValueType.equals('7')){
+		}else if (defaultValueType.equals(DATA_TYPE_DEFAULT)) {
 			return defaultFromDatatype();
 		}
 		

--- a/org.adempiere.base/src/org/compiere/model/GridField.java
+++ b/org.adempiere.base/src/org/compiere/model/GridField.java
@@ -83,7 +83,7 @@ public class GridField
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = 496387784464611123L;
+	private static final long serialVersionUID = 405469916055906825L;
 
 	/**
 	 *  Field Constructor.
@@ -591,6 +591,13 @@ public class GridField
 		m_inserting = inserting;
 	}   //  setInserting
 
+	public void setDefaultLogic(String defaultValue) {
+		m_vo.DefaultValue = defaultValue;
+	}
+
+	public void setDefault2Logic(String defaultValue2) {
+		m_vo.DefaultValue2 = defaultValue2;
+	}
 	
 	/**************************************************************************
 	 *	Create default value.


### PR DESCRIPTION
…default value programmatically

https://idempiere.atlassian.net/browse/IDEMPIERE-5637

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

