### PR TITLE
IDEMPIERE-5643 - Error during document's workflows are not displayed on Workflow Activities form.

### DIFF
--- a/org.adempiere.base/src/org/compiere/wf/MWFActivity.java
+++ b/org.adempiere.base/src/org/compiere/wf/MWFActivity.java
@@ -85,7 +85,7 @@ public class MWFActivity extends X_AD_WF_Activity implements Runnable
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = 8180781075902940080L;
+	private static final long serialVersionUID = -9119089506977887142L;
 
 	private static final String CURRENT_WORKFLOW_PROCESS_INFO_ATTR = "Workflow.ProcessInfo";
 	
@@ -2156,6 +2156,14 @@ public class MWFActivity extends X_AD_WF_Activity implements Runnable
 			+ " WHERE AD_WF_Activity.AD_WF_Activity_ID=r.AD_WF_Activity_ID AND r.AD_User_ID=? AND r.isActive = 'Y')" 
 			+ ") AND AD_WF_Activity.AD_Client_ID=?";	//	#5
 		return where;
+	}
+
+	public String getProcessMsg() {
+
+		if (m_process == null)
+			return null;
+
+		return m_process.getProcessMsg();
 	}
 
 }	//	MWFActivity

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WWFActivity.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WWFActivity.java
@@ -19,7 +19,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
 
-import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.webui.LayoutUtils;
 import org.adempiere.webui.apps.AEnv;
 import org.adempiere.webui.component.Button;
@@ -659,7 +658,7 @@ public class WWFActivity extends ADForm implements EventListener<Event>
 					wfpr.checkCloseActivities(m_activity.get_TrxName());
 					
 					if (!Util.isEmpty(m_activity.getProcessMsg(), true))
-						throw new AdempiereException(m_activity.getProcessMsg());
+						Dialog.error(m_WindowNo, m_activity.getProcessMsg());
 				}
 				catch (Exception e)
 				{
@@ -680,6 +679,9 @@ public class WWFActivity extends ADForm implements EventListener<Event>
 					m_activity.setUserConfirmation(AD_User_ID, textMsg);
 					MWFProcess wfpr = new MWFProcess(m_activity.getCtx(), m_activity.getAD_WF_Process_ID(), m_activity.get_TrxName());
 					wfpr.checkCloseActivities(m_activity.get_TrxName());
+					
+					if (!Util.isEmpty(m_activity.getProcessMsg(), true))
+						Dialog.error(m_WindowNo, m_activity.getProcessMsg());
 				}
 				catch (Exception e)
 				{

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WWFActivity.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WWFActivity.java
@@ -19,6 +19,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
 
+import org.adempiere.exceptions.AdempiereException;
 import org.adempiere.webui.LayoutUtils;
 import org.adempiere.webui.apps.AEnv;
 import org.adempiere.webui.component.Button;
@@ -656,11 +657,14 @@ public class WWFActivity extends ADForm implements EventListener<Event>
 					m_activity.setUserChoice(AD_User_ID, value, dt, textMsg);
 					MWFProcess wfpr = new MWFProcess(m_activity.getCtx(), m_activity.getAD_WF_Process_ID(), m_activity.get_TrxName());
 					wfpr.checkCloseActivities(m_activity.get_TrxName());
+					
+					if (!Util.isEmpty(m_activity.getProcessMsg(), true))
+						throw new AdempiereException(m_activity.getProcessMsg());
 				}
 				catch (Exception e)
 				{
 					log.log(Level.SEVERE, node.getName(), e);
-					Dialog.error(m_WindowNo, "Error", e.toString());
+					Dialog.error(m_WindowNo, "Error", e.getLocalizedMessage() != null ? e.getLocalizedMessage() : e.getMessage());
 					trx.rollback();
 					trx.close();
 					return;


### PR DESCRIPTION
Jira ticket: [IDEMPIERE-5643](https://idempiere.atlassian.net/browse/IDEMPIERE-5643)
# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

# Changes
During development, I notice that the `MWFProcess.m_processMsg` field is not accessible for WWFActivity. Like showed below, there is an instance of MWFProcess, despite that, the `getProcessMsg()` does not returns the error, givin that it is another instance, where `m_processMsg` is null.

![originalCode](https://user-images.githubusercontent.com/71560285/228232854-83b84bbe-ece6-4f95-bde3-c851d9af69ed.png)

To fix that problem and make the cited field accessible, I created a method `MWFActivity.getProcessMsg()` that returns the `MWFProcess.getProcessMsg()` method.

![newMethod](https://user-images.githubusercontent.com/71560285/228232911-39b615a0-775f-4b66-9b79-51368a04ae5b.png)

Using it, the Exception can be thrown with the correct error message.

![throw](https://user-images.githubusercontent.com/71560285/228232953-5c8c4080-ac04-4bae-9d64-0d52ae6cd7c1.png)

# Test
Sales Order which can't be completed:
![salesOrder](https://user-images.githubusercontent.com/71560285/228233449-f1cc0908-0059-45c5-8fec-153adaa7733b.png)

After user attempt to complete that document, as expected, it falls on Sales Order Workflow and waits for approve.
![form](https://user-images.githubusercontent.com/71560285/228233508-9a464312-9f1d-4f51-ae04-68395b4f0641.png)

After approval, the exception is thrown at the Workflow Acitivities form.
![error](https://user-images.githubusercontent.com/71560285/228233567-0a768c4c-9210-4ee6-97c4-34f1f359ff69.png)


[IDEMPIERE-5643]: https://idempiere.atlassian.net/browse/IDEMPIERE-5643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ