### PR TITLE
IDEMPIERE-5560 Cannot save more than one order line when an _ID field…

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/GridTable.java
+++ b/org.adempiere.base/src/org/compiere/model/GridTable.java
@@ -2752,6 +2752,11 @@ public class GridTable extends AbstractTableModel
 			for (int i = 0; i < size; i++)
 			{
 				GridField field = (GridField)m_fields.get(i);
+				if (field.getGridTab() != null) {
+					//avoid getting default from previous row
+					String key = field.getVO().WindowNo+"|"+field.getVO().TabNo+"|"+field.getVO().ColumnName;
+					field.getVO().ctx.remove(key);
+				}
 				Object value = field.getDefault();
 				field.setValue(value, m_inserting);
 				field.validateValueNoDirect();

--- a/org.idempiere.test/src/org/idempiere/test/adwindow/GridTabTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/adwindow/GridTabTest.java
@@ -193,9 +193,8 @@ public class GridTabTest extends AbstractTestCase {
 		boolean displayGridOri = field.isDisplayed();
 		try {
 			/* IDEMPIERE-5560 */
-			DB.executeUpdateEx("UPDATE AD_Field SET IsDisplayed='N', IsDisplayedGrid='N' WHERE AD_Field_ID=?", new Object[] {FIELD_ORDERLINE_SHIPPER}, getTrxName());
-			// we need to commit here for the test case below to get the update
-			commit();
+			// must not use trx here for the test case below to get the update
+			DB.executeUpdateEx("UPDATE AD_Field SET IsDisplayed='N', IsDisplayedGrid='N' WHERE AD_Field_ID=?", new Object[] {FIELD_ORDERLINE_SHIPPER}, null);
 			CacheMgt.get().reset();
 
 			// Sales Order
@@ -253,6 +252,8 @@ public class GridTabTest extends AbstractTestCase {
 			assertTrue(gTab0.dataNew(false));
 			assertTrue(gTab0.isNew(), "Grid Tab dataNew call not working as expected");
 			gTab0.setValue(MOrder.COLUMNNAME_C_BPartner_ID, DictionaryIDs.C_BPartner.C_AND_W.id);
+			gTab0.setValue(MOrder.COLUMNNAME_C_DocTypeTarget_ID, DictionaryIDs.C_DocType.STANDARD_ORDER.id);
+			gTab0.setValue(MOrder.COLUMNNAME_SalesRep_ID, DictionaryIDs.AD_User.GARDEN_USER.id);
 			assertTrue(gTab0.dataSave(true), CLogger.retrieveWarningString("Could not save order"));
 
 			GridTab gTab1 = gridWindow.getTab(1);
@@ -269,9 +270,7 @@ public class GridTabTest extends AbstractTestCase {
 		} finally {
 			// rollback the work from the test
 			rollback();
-			DB.executeUpdateEx("UPDATE AD_Field SET IsDisplayed=?, IsDisplayedGrid=? WHERE AD_Field_ID=?", new Object[] {displayOri, displayGridOri, FIELD_ORDERLINE_SHIPPER}, getTrxName());
-			// commit the cleanup
-			commit();
+			DB.executeUpdateEx("UPDATE AD_Field SET IsDisplayed=?, IsDisplayedGrid=? WHERE AD_Field_ID=?", new Object[] {displayOri, displayGridOri, FIELD_ORDERLINE_SHIPPER}, null);
 			CacheMgt.get().reset();
 		}
 


### PR DESCRIPTION
… is not displayed

https://idempiere.atlassian.net/browse/IDEMPIERE-5560

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

