### PR TITLE
IDEMPIERE-5528 Context parsing on process Parameter not considering t…

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/GridField.java
+++ b/org.adempiere.base/src/org/compiere/model/GridField.java
@@ -1344,6 +1344,11 @@ public class GridField
 	 */
 	public String get_ValueAsString (Properties ctx, String variableName)
 	{
+		if (m_parentEvaluatee != null) {
+			String value = m_parentEvaluatee.get_ValueAsString(variableName);
+			if (value != null)
+				return value;
+		}
 		return new DefaultEvaluatee(getGridTab(), m_vo.WindowNo, m_vo.TabNo).get_ValueAsString(ctx, variableName);
 	}	//	get_ValueAsString
 
@@ -2423,6 +2428,9 @@ public class GridField
 	
 	/** Is the initial context value for this field backup ? - teo_sarca [ 1699826 ] */
 	private boolean m_isBackupValue = false;
+
+	/** Optional Parent Evaluatee that take precedence over the value return from GridField's Evaluatee implementation */
+	private Evaluatee m_parentEvaluatee = null;
 	
 	/**
 	 * Backup the context value
@@ -2704,5 +2712,13 @@ public class GridField
 				setValue(valueStr, false);
 			}
 		}
+	}
+
+	/**
+	 * Set parent Evaluatee that take precedence over value return from GridField's Evaluatee implementation.
+	 * @param evaluatee
+	 */
+	public void setParentEvaluatee(Evaluatee evaluatee) {
+		m_parentEvaluatee  = evaluatee;
 	}
 }   //  GridField


### PR DESCRIPTION
…ab no

- implement parent Evaluatee for GridField and ProcessParameterPanel

https://idempiere.atlassian.net/browse/IDEMPIERE-5528

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

