### PR TITLE
IDEMPIERE-5665 - [Multi Selection] - Negate option in process parameter

### DIFF
--- a/org.adempiere.base/src/org/compiere/process/SvrProcess.java
+++ b/org.adempiere.base/src/org/compiere/process/SvrProcess.java
@@ -762,19 +762,21 @@ public abstract class SvrProcess implements ProcessCall
             String name = parameter.getParameterName().trim().toLowerCase();
             Field field = map.get(name);
             Field toField = map.containsKey(name + "_to") ? map.get(name + "_to") : null;
+            Field notField = map.containsKey(name + "_not") ? map.get(name + "_not") : null;
 
             // try to match fields using the "p_" prefix convention
             if(field==null) {
             	String candidate = "p_" + name;
                 field = map.get(candidate);
                 toField = map.containsKey(candidate + "_to") ? map.get(candidate + "_to") : null;
+                notField = map.containsKey(candidate + "_not") ? map.get(candidate + "_not") : null;
             }
 
             // try to match fields with same name as metadata declaration after stripping "_"
             if(field==null) {
             	String candidate = name.replace("_", "");
                 field = map.get(candidate);
-                toField = map.containsKey(candidate + "to") ? map.get(candidate + "to") : null;
+                notField = map.containsKey(candidate + "to") ? map.get(candidate + "to") : null;
             }
 
             if(field==null)
@@ -788,6 +790,8 @@ public abstract class SvrProcess implements ProcessCall
                     	toField.set(this, parameter.getParameter_ToAsInt());
                 } else if (type.equals(String.class)) {
                     field.set(this, (String) parameter.getParameter());
+                    if(notField != null)
+                    	notField.set(this, (boolean) parameter.isNotClause());
                 } else if (type.equals(java.sql.Timestamp.class)) {
                     field.set(this, (Timestamp) parameter.getParameter());
                     if(parameter.getParameter_To()!=null && toField != null)

--- a/org.adempiere.base/src/org/compiere/process/SvrProcess.java
+++ b/org.adempiere.base/src/org/compiere/process/SvrProcess.java
@@ -776,7 +776,8 @@ public abstract class SvrProcess implements ProcessCall
             if(field==null) {
             	String candidate = name.replace("_", "");
                 field = map.get(candidate);
-                notField = map.containsKey(candidate + "to") ? map.get(candidate + "to") : null;
+                toField = map.containsKey(candidate + "to") ? map.get(candidate + "to") : null;
+                notField = map.containsKey(candidate + "not") ? map.get(candidate + "not") : null;
             }
 
             if(field==null)


### PR DESCRIPTION
# Pull Request Checklist

- [X] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [X] My code follows the best practices of this project
- [X] I have performed a self-review of my own code
- [X] My code is easy to understand and review. 
- [X] I have checked my code and corrected any misspellings
- [X] In hard-to-understand areas, I have commented my code.
- [X] My changes generate no new warnings
### Tests
- [X] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

