### PR TITLE
Fixes IDEMPIERE-5673 Wrong character causes java.awt.IllegalComponentStateException: This component must have a parent in order to determine its locale on reports

### DIFF
--- a/org.adempiere.base/src/org/compiere/print/layout/HTMLRenderer.java
+++ b/org.adempiere.base/src/org/compiere/print/layout/HTMLRenderer.java
@@ -18,6 +18,7 @@ package org.compiere.print.layout;
 
 import java.awt.Container;
 import java.awt.Graphics;
+import java.awt.IllegalComponentStateException;
 import java.awt.Rectangle;
 import java.awt.Shape;
 import java.io.Externalizable;
@@ -102,7 +103,11 @@ public class HTMLRenderer extends View implements Externalizable
 		m_container = new Container();
 		m_element = m_view.getElement();
 		// initially layout to the preferred size
-		setSize(m_view.getPreferredSpan(X_AXIS), m_view.getPreferredSpan(Y_AXIS));
+		try {
+			setSize(m_view.getPreferredSpan(X_AXIS), m_view.getPreferredSpan(Y_AXIS));
+		} catch (IllegalComponentStateException e) {
+			if (log.isLoggable(Level.INFO)) log.info("Exception ignored: " + e.toString() + " " + e.getLocalizedMessage());
+		}
 	}	//	HTMLRenderer
 
 	private int 			m_width;


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5673

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
