### PR TITLE
IDEMPIERE-5690 Make WPAttributeEditor and WPAttributeDialog more exte…

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WPAttributeEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WPAttributeEditor.java
@@ -48,15 +48,13 @@ public class WPAttributeEditor extends WEditor implements ContextMenuListener
 
 	private static final CLogger log = CLogger.getCLogger(WPAttributeEditor.class);
 
-	private int m_WindowNo;
+	protected int m_WindowNo;
 
-	private Lookup m_mPAttribute;
+	protected Lookup m_mPAttribute;
 
-	private int m_C_BPartner_ID;
+	protected int m_C_BPartner_ID;
 
-	private Object m_value;
-
-	private GridTab m_GridTab;
+	protected Object m_value;
 
 	/**	No Instance Key					*/
 	private static Integer		NO_INSTANCE = Integer.valueOf(0);
@@ -81,7 +79,7 @@ public class WPAttributeEditor extends WEditor implements ContextMenuListener
 	public WPAttributeEditor(GridTab gridTab, GridField gridField, boolean tableEditor, IEditorConfiguration editorConfiguration)
 	{
 		super(new PAttributebox(), gridField, tableEditor, editorConfiguration);
-		m_GridTab = gridTab;
+		setGridTab(gridTab);
 		initComponents();
 	}
 
@@ -181,12 +179,12 @@ public class WPAttributeEditor extends WEditor implements ContextMenuListener
 		int M_AttributeSetInstance_ID = oldValueInt;
 		int M_Product_ID = 0;
 		int M_ProductBOM_ID = 0;
-		if (m_GridTab != null) {
-			M_Product_ID = Env.getContextAsInt (Env.getCtx (), m_WindowNo, m_GridTab.getTabNo(), "M_Product_ID");
-			M_ProductBOM_ID = Env.getContextAsInt (Env.getCtx (), m_WindowNo, m_GridTab.getTabNo(), "M_ProductBOM_ID");
+		if (gridTab != null) {
+			M_Product_ID = Env.getContextAsInt (Env.getCtx (), m_WindowNo, gridTab.getTabNo(), "M_Product_ID");
+			M_ProductBOM_ID = Env.getContextAsInt (Env.getCtx (), m_WindowNo, gridTab.getTabNo(), "M_ProductBOM_ID");
 			//For third level tab (e.g, LineMA), should take M_Product_ID from Line instead of from Header
-			if (m_GridTab.getTabLevel() > 1 && m_GridTab.getParentTab() != null && m_GridTab.getField("M_Product_ID")==null) {
-				int tmp = Env.getContextAsInt (Env.getCtx (), m_WindowNo, m_GridTab.getParentTab().getTabNo(), "M_Product_ID");
+			if (gridTab.getTabLevel() > 1 && gridTab.getParentTab() != null && gridTab.getField("M_Product_ID")==null) {
+				int tmp = Env.getContextAsInt (Env.getCtx (), m_WindowNo, gridTab.getParentTab().getTabNo(), "M_Product_ID");
 				if (tmp > 0)
 					M_Product_ID = tmp;
 			}
@@ -227,12 +225,12 @@ public class WPAttributeEditor extends WEditor implements ContextMenuListener
 					{
 						getComponent().setText(vad.getM_AttributeSetInstanceName());
 						M_AttributeSetInstance_ID = vad.getM_AttributeSetInstance_ID();
-						if (m_GridTab != null && !productWindow && vad.getM_Locator_ID() > 0)
+						if (gridTab != null && !productWindow && vad.getM_Locator_ID() > 0)
 						{
 							if (gridField.getColumnName().equals("M_AttributeSetInstanceTo_ID"))
-								m_GridTab.setValue("M_LocatorTo_ID", vad.getM_Locator_ID());
+								gridTab.setValue("M_LocatorTo_ID", vad.getM_Locator_ID());
 							else
-								m_GridTab.setValue("M_Locator_ID", vad.getM_Locator_ID());
+								gridTab.setValue("M_Locator_ID", vad.getM_Locator_ID());
 							
 						}
 						changed = true;
@@ -247,44 +245,7 @@ public class WPAttributeEditor extends WEditor implements ContextMenuListener
 			});
 			
 		}
-		/** Selection
-		{
-			//	Get Model
-			MAttributeSetInstance masi = MAttributeSetInstance.get(Env.getCtx(), M_AttributeSetInstance_ID, M_Product_ID);
-			if (masi == null)
-			{
-				log.log(Level.SEVERE, "No Model for M_AttributeSetInstance_ID=" + M_AttributeSetInstance_ID + ", M_Product_ID=" + M_Product_ID);
-			}
-			else
-			{
-				Env.setContext(Env.getCtx(), m_WindowNo, "M_AttributeSet_ID", masi.getM_AttributeSet_ID());
-				//	Get Attribute Set
-				MAttributeSet as = masi.getMAttributeSet();
-				//	Product has no Attribute Set
-				if (as == null)
-					ADialog.error(m_WindowNo, this, "PAttributeNoAttributeSet");
-				//	Product has no Instance Attributes
-				else if (!as.isInstanceAttribute())
-					ADialog.error(m_WindowNo, this, "PAttributeNoInstanceAttribute");
-				else
-				{
-					int M_Warehouse_ID = Env.getContextAsInt (Env.getCtx (), m_WindowNo, "M_Warehouse_ID");
-					int M_Locator_ID = Env.getContextAsInt (Env.getCtx (), m_WindowNo, "M_Locator_ID");
-					String title = "";
-					PAttributeInstance pai = new PAttributeInstance (
-						Env.getFrame(this), title,
-						M_Warehouse_ID, M_Locator_ID, M_Product_ID, m_C_BPartner_ID);
-					if (pai.getM_AttributeSetInstance_ID() != -1)
-					{
-						m_text.setText(pai.getM_AttributeSetInstanceName());
-						M_AttributeSetInstance_ID = pai.getM_AttributeSetInstance_ID();
-						changed = true;
-					}
-				}
-			}
-		}
-		**/		
-	}   //  cmd_file
+	}   //  cmd_dialog
 
 	private void processChanges(int oldValueInt, int M_AttributeSetInstance_ID) {
 		if (log.isLoggable(Level.FINEST)) log.finest("Changed M_AttributeSetInstance_ID=" + M_AttributeSetInstance_ID);
@@ -296,10 +257,10 @@ public class WPAttributeEditor extends WEditor implements ContextMenuListener
 
 		ValueChangeEvent vce = new ValueChangeEvent(this, gridField.getColumnName(), new Object(), getValue());
 		fireValueChange(vce);
-		if (M_AttributeSetInstance_ID == oldValueInt && m_GridTab != null && gridField != null)
+		if (M_AttributeSetInstance_ID == oldValueInt && gridTab != null && gridField != null)
 		{
 			//  force Change - user does not realize that embedded object is already saved.
-			m_GridTab.processFieldChange(gridField);
+			gridTab.processFieldChange(gridField);
 		}
 	}
 

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WPAttributeDialog.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WPAttributeDialog.java
@@ -164,53 +164,53 @@ public class WPAttributeDialog extends Window implements EventListener<Event>
 		AEnv.showCenterScreen(this);
 	}	//	VPAttributeDialog
 
-	private int						m_WindowNo;
-	private MAttributeSetInstance	m_masi;
-	private int 					m_M_AttributeSetInstance_ID;
-	private int 					m_M_Locator_ID;
-	private String					m_M_AttributeSetInstanceName;
-	private int 					m_M_Product_ID;
-	private int						m_C_BPartner_ID;
-	private int						m_AD_Column_ID;
-	private int						m_WindowNoParent;
+	protected int						m_WindowNo;
+	protected MAttributeSetInstance	m_masi;
+	protected int 					m_M_AttributeSetInstance_ID;
+	protected int 					m_M_Locator_ID;
+	protected String					m_M_AttributeSetInstanceName;
+	protected int 					m_M_Product_ID;
+	protected int						m_C_BPartner_ID;
+	protected int						m_AD_Column_ID;
+	protected int						m_WindowNoParent;
 	/**	Enter Product Attributes		*/
-	private boolean					m_productWindow = false;
+	protected boolean					m_productWindow = false;
 	/**	Change							*/
-	private boolean					m_changed = false;
+	protected boolean					m_changed = false;
 	
 	private static final CLogger	log = CLogger.getCLogger(WPAttributeDialog.class);
 	/** Row Counter					*/
 	private int						m_row = 0;
 	/** List of Editors				*/
-	private ArrayList<WEditor>		m_editors = new ArrayList<WEditor>();
+	protected ArrayList<WEditor>		m_editors = new ArrayList<WEditor>();
 
-	private Checkbox	cbNewEdit = new Checkbox();
-	private Button		bNewRecord = new Button(Msg.getMsg(Env.getCtx(), "NewRecord"));
-	private Listbox		existingCombo = new Listbox();
-	private Button		bSelect = new Button(); 
+	protected Checkbox	cbNewEdit = new Checkbox();
+	protected Button		bNewRecord = new Button(Msg.getMsg(Env.getCtx(), "NewRecord"));
+	protected Listbox		existingCombo = new Listbox();
+	protected Button		bSelect = new Button(); 
 	//	Lot
-	private Textbox fieldLotString = new Textbox();
-	private Listbox fieldLot = new Listbox();
-	private Button bLot = new Button(Msg.getMsg (Env.getCtx(), "New"));
+	protected Textbox fieldLotString = new Textbox();
+	protected Listbox fieldLot = new Listbox();
+	protected Button bLot = new Button(Msg.getMsg (Env.getCtx(), "New"));
 	//	Lot Popup
-	Menupopup 					popupMenu = new Menupopup();
-	private Menuitem 			mZoom;
+	protected Menupopup 					popupMenu = new Menupopup();
+	protected Menuitem 			mZoom;
 	//	Ser No
-	private Textbox fieldSerNo = new Textbox();
-	private Button bSerNo = new Button(Msg.getMsg (Env.getCtx(), "New"));
+	protected Textbox fieldSerNo = new Textbox();
+	protected Button bSerNo = new Button(Msg.getMsg (Env.getCtx(), "New"));
 	//	Date
-	private Datebox fieldGuaranteeDate = new Datebox();
+	protected Datebox fieldGuaranteeDate = new Datebox();
 	//
-	private Textbox fieldDescription = new Textbox(); //TODO: set length to 20
+	protected Textbox fieldDescription = new Textbox(); //TODO: set length to 20
 	//
-	private Borderlayout mainLayout = new Borderlayout();
-	private Panel centerPanel = new Panel();
-	private Grid centerLayout = new Grid();
-	private Panel northPanel = new Panel();
-	private Grid northLayout = new Grid();
-	private ConfirmPanel confirmPanel = new ConfirmPanel (true);
+	protected Borderlayout mainLayout = new Borderlayout();
+	protected Panel centerPanel = new Panel();
+	protected Grid centerLayout = new Grid();
+	protected Panel northPanel = new Panel();
+	protected Grid northLayout = new Grid();
+	protected ConfirmPanel confirmPanel = new ConfirmPanel (true);
 	
-	private String m_columnName = null;
+	protected String m_columnName = null;
 
 	/**
 	 *	Layout
@@ -838,14 +838,14 @@ public class WPAttributeDialog extends Window implements EventListener<Event>
 			log.log(Level.SEVERE, "not found - " + e);
 	}	//	actionPerformed
 
-	private void onCancel() {
+	protected void onCancel() {
 		m_changed = false;
 		m_M_AttributeSetInstance_ID = 0;
 		m_M_Locator_ID = 0;
 		dispose();
 	}
 
-	private void cmd_existingCombo() {
+	protected void cmd_existingCombo() {
 		ListItem pp = existingCombo.getSelectedItem();
 		if (pp != null && (Integer)pp.getValue() != -1)
 		{
@@ -865,7 +865,7 @@ public class WPAttributeDialog extends Window implements EventListener<Event>
 		}
 	}
 
-	private void cmd_newRecord() {
+	protected void cmd_newRecord() {
 		cbNewEdit.setSelected(false);
 		cbNewEdit.setEnabled(false);
 		bNewRecord.setEnabled(false);
@@ -883,7 +883,7 @@ public class WPAttributeDialog extends Window implements EventListener<Event>
 		fieldDescription.setText("");
 	}
 
-	private void cmd_edit() {
+	protected void cmd_edit() {
 		boolean check = cbNewEdit.isSelected();
 		for (int i = 0; i < m_editors.size(); i++)
 		{
@@ -896,7 +896,7 @@ public class WPAttributeDialog extends Window implements EventListener<Event>
 	 * 	Instance Selection Button
 	 * 	@return true if selected
 	 */
-	private void cmd_select()
+	protected void cmd_select()
 	{
 		log.config("");
 		
@@ -965,7 +965,7 @@ public class WPAttributeDialog extends Window implements EventListener<Event>
 	/**
 	 * 	Instance New/Edit
 	 */
-	private void cmd_newEdit()
+	protected void cmd_newEdit()
 	{
 		boolean rw = cbNewEdit.isChecked();
 		if (log.isLoggable(Level.CONFIG)) log.config("R/W=" + rw + " " + m_masi);
@@ -1005,7 +1005,7 @@ public class WPAttributeDialog extends Window implements EventListener<Event>
 	 *	Save Selection
 	 *	@return true if saved
 	 */
-	private boolean saveSelection()
+	protected boolean saveSelection()
 	{
 		log.info("");
 		


### PR DESCRIPTION
…nsible

https://idempiere.atlassian.net/browse/IDEMPIERE-5690

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

