### PR TITLE
IDEMPIERE-5696: Width of last column of reports exported as Xlsx is n…

### DIFF
--- a/org.adempiere.base/src/org/adempiere/impexp/AbstractXLSXExporter.java
+++ b/org.adempiere.base/src/org/adempiere/impexp/AbstractXLSXExporter.java
@@ -321,9 +321,9 @@ public abstract class AbstractXLSXExporter
 		return cs_header;
 	}
 
-	private void fixColumnWidth(XSSFSheet sheet, int lastColumnIndex)
+	private void fixColumnWidth(XSSFSheet sheet, int colCount)
 	{
-		for (short colnum = 0; colnum < lastColumnIndex; colnum++)
+		for (short colnum = 0; colnum < colCount; colnum++)
 		{
 			sheet.autoSizeColumn(colnum);
 		}
@@ -488,9 +488,7 @@ public abstract class AbstractXLSXExporter
 			// for all columns
 			int colnum = 0;
 			for (int col = 0; col < getColumnCount(); col++)
-			{
-				if (colnum > colnumMax)
-					colnumMax = colnum;
+			{				
 				//
 				if (isColumnPrinted(col))
 				{
@@ -589,6 +587,8 @@ public abstract class AbstractXLSXExporter
 					}
 					//
 					colnum++;
+					if (colnum > colnumMax)
+						colnumMax = colnum;
 					if (colSuppressRepeats != null)
 						preValues[printColIndex] = obj;
 				} // printed
@@ -606,7 +606,7 @@ public abstract class AbstractXLSXExporter
 		if (out == null)
 			fixColumnWidth(sheet, colnumMax);
 		else
-			closeTableSheet(sheet, sheetName, colnumMax + 1);
+			closeTableSheet(sheet, sheetName, colnumMax);
 		//
 
 		if (out != null)

--- a/org.adempiere.base/src/org/adempiere/impexp/AbstractXLSXExporter.java
+++ b/org.adempiere.base/src/org/adempiere/impexp/AbstractXLSXExporter.java
@@ -606,7 +606,7 @@ public abstract class AbstractXLSXExporter
 		if (out == null)
 			fixColumnWidth(sheet, colnumMax);
 		else
-			closeTableSheet(sheet, sheetName, colnumMax);
+			closeTableSheet(sheet, sheetName, colnumMax + 1);
 		//
 
 		if (out != null)


### PR DESCRIPTION
…ot correct

https://idempiere.atlassian.net/browse/IDEMPIERE-5696

# Pull Request Checklist

- [X] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [X] My code follows the best practices of this project
- [X] I have performed a self-review of my own code
- [X] My code is easy to understand and review. 
- [X] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [X] My changes generate no new warnings
### Tests
- [X] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

