### PR TITLE
IDEMPIERE-5756 2PackActivator: should check Adempiere.isStarted inste…

### DIFF
--- a/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/AdempiereActivator.java
+++ b/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/AdempiereActivator.java
@@ -162,7 +162,7 @@ public class AdempiereActivator extends AbstractActivator {
 
 	protected void frameworkStarted() {
 		if (service != null) {
-			if (Adempiere.getThreadPoolExecutor() != null) {
+			if (Adempiere.isStarted()) {
 				Adempiere.getThreadPoolExecutor().execute(new Runnable() {			
 					@Override
 					public void run() {

--- a/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/Incremental2PackActivator.java
+++ b/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/Incremental2PackActivator.java
@@ -281,7 +281,7 @@ public class Incremental2PackActivator extends AbstractActivator {
 	@Override
 	protected void frameworkStarted() {
 		if (service != null) {
-			if (Adempiere.getThreadPoolExecutor() != null) {
+			if (Adempiere.isStarted()) {
 				Adempiere.getThreadPoolExecutor().execute(new Runnable() {			
 					@Override
 					public void run() {

--- a/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/PackInApplicationActivator.java
+++ b/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/PackInApplicationActivator.java
@@ -355,7 +355,7 @@ public class PackInApplicationActivator extends AbstractActivator{
 	@Override
 	protected void frameworkStarted() {
 		if (service != null) {
-			if (Adempiere.getThreadPoolExecutor() != null) {
+			if (Adempiere.isStarted()) {
 				Adempiere.getThreadPoolExecutor().execute(new Runnable() {			
 					@Override
 					public void run() {

--- a/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/Version2PackActivator.java
+++ b/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/Version2PackActivator.java
@@ -248,7 +248,7 @@ public class Version2PackActivator extends AbstractActivator{
 	@Override
 	protected void frameworkStarted() {
 		if (service != null) {
-			if (Adempiere.getThreadPoolExecutor() != null) {
+			if (Adempiere.isStarted()) {
 				Adempiere.getThreadPoolExecutor().execute(new Runnable() {			
 					@Override
 					public void run() {


### PR DESCRIPTION
…ad of getThreadPoolExecutor

https://idempiere.atlassian.net/browse/IDEMPIERE-5756
# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

