### PR TITLE
IDEMPIERE-5751 - Displayed Linked Order field in Purchase and Sales O…

### DIFF
--- a/migration/iD11/oracle/202306051322_IDEMPIERE-5751.sql
+++ b/migration/iD11/oracle/202306051322_IDEMPIERE-5751.sql
@@ -1,0 +1,19 @@
+-- IDEMPIERE-5751- Display the Link Order field when it is populated in Sales Order and Purchase Order
+SELECT register_migration_script('202306051322_IDEMPIERE-5751.sql') FROM dual;
+
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Jun 5, 2023, 1:22:15 PM CEST
+UPDATE AD_Field SET IsDisplayed='Y', DisplayLogic='@Link_Order_ID:0@>0', IsReadOnly='Y',Updated=TO_TIMESTAMP('2023-06-05 13:22:15','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=201611
+;
+
+-- Jun 5, 2023, 1:23:07 PM CEST
+UPDATE AD_Field SET SeqNo=610, ColumnSpan=2,Updated=TO_TIMESTAMP('2023-06-05 13:23:07','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=201611
+;
+
+-- Jun 5, 2023, 1:25:14 PM CEST
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLogic,DisplayLength,SeqNo,SortNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan,NumLines,IsQuickEntry,IsDefaultFocus,IsAdvancedField,IsQuickForm) VALUES (207632,'Linked Order','This field links a sales order to the purchase order that is generated from it.',294,55322,'Y','@Link_Order_ID:0@>0
+',0,490,0,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-06-05 13:25:13','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-06-05 13:25:13','YYYY-MM-DD HH24:MI:SS'),100,'Y','Y','D','e72aa65f-6623-43e9-9716-ed76f569a7a0','N',490,1,2,1,'N','N','N','N')
+;
+

--- a/migration/iD11/postgresql/202306051322_IDEMPIERE-5751.sql
+++ b/migration/iD11/postgresql/202306051322_IDEMPIERE-5751.sql
@@ -1,0 +1,16 @@
+-- IDEMPIERE-5751- Display the Link Order field when it is populated in Sales Order and Purchase Order
+SELECT register_migration_script('202306051322_IDEMPIERE-5751.sql') FROM dual;
+
+-- Jun 5, 2023, 1:22:15 PM CEST
+UPDATE AD_Field SET IsDisplayed='Y', DisplayLogic='@Link_Order_ID:0@>0', IsReadOnly='Y',Updated=TO_TIMESTAMP('2023-06-05 13:22:15','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=201611
+;
+
+-- Jun 5, 2023, 1:23:07 PM CEST
+UPDATE AD_Field SET SeqNo=610, ColumnSpan=2,Updated=TO_TIMESTAMP('2023-06-05 13:23:07','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=201611
+;
+
+-- Jun 5, 2023, 1:25:14 PM CEST
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLogic,DisplayLength,SeqNo,SortNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan,NumLines,IsQuickEntry,IsDefaultFocus,IsAdvancedField,IsQuickForm) VALUES (207632,'Linked Order','This field links a sales order to the purchase order that is generated from it.',294,55322,'Y','@Link_Order_ID:0@>0
+',0,490,0,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-06-05 13:25:13','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-06-05 13:25:13','YYYY-MM-DD HH24:MI:SS'),100,'Y','Y','D','e72aa65f-6623-43e9-9716-ed76f569a7a0','N',490,1,2,1,'N','N','N','N')
+;
+


### PR DESCRIPTION
…rder windows when the field is not null

https://idempiere.atlassian.net/browse/IDEMPIERE-5751

# Pull Request Checklist

- [ ] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [ ] My code follows the best practices of this project
- [ ] I have performed a self-review of my own code
- [ ] My code is easy to understand and review. 
- [ ] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [ ] My changes generate no new warnings
### Tests
- [ ] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

