### PR TITLE
IDEMPIERE-5756 2PackActivator: should check Adempiere.isStarted instead of getThreadPoolExecutor

### DIFF
--- a/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/AbstractActivator.java
+++ b/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/AbstractActivator.java
@@ -263,7 +263,7 @@ public abstract class AbstractActivator implements BundleActivator, ServiceTrack
 			if (isFrameworkStarted())
 				frameworkStarted ();
 		};
-		if (Adempiere.getThreadPoolExecutor() != null) {
+		if (Adempiere.isStarted()) {
 			Adempiere.getThreadPoolExecutor().submit(runnable);
 		} else {
 			MyServerStateChangeListener l = new MyServerStateChangeListener(runnable);


### PR DESCRIPTION
# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x]  My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [ ] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
