### PR TITLE
IDEMPIERE-5567 Support of UUID as Key (FHCA-4195)

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/GridTable.java
+++ b/org.adempiere.base/src/org/compiere/model/GridTable.java
@@ -1632,7 +1632,7 @@ public class GridTable extends AbstractTableModel
 			m_trxName = null;
 		if (Record_ID != -1)
 		{
-			if (Record_ID == 0 && MTable.isZeroIDTable(table.getTableName())) {
+			if (Record_ID == 0 && !m_inserting && MTable.isZeroIDTable(table.getTableName())) {
 				String uuidFromZeroID = table.getUUIDFromZeroID();
 				po = table.getPOByUU(uuidFromZeroID, m_trxName);
 			} else {


### PR DESCRIPTION
- Fix issues created with latest change - not able to create new records in Zero ID tables (C_DocType, AD_User, etc)

Example of test case failing:
- Try to create a new document type
- Check the ID when saved - is changing the record Zero instead of creating a new one