### PR TITLE
IDEMPIERE-5769: WRadioGroupEditor : make RadioGroupEditor class public

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WRadioGroupEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WRadioGroupEditor.java
@@ -508,7 +508,7 @@ public class WRadioGroupEditor extends WEditor implements ContextMenuListener, L
 		/**
 		 * generated serial id
 		 */
-		private static final long serialVersionUID = -8814498538711459900L;
+		private static final long serialVersionUID = 6356574816984519621L;
 		private Radiogroup radioGroup;
 		private boolean enabled;
 		

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WRadioGroupEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WRadioGroupEditor.java
@@ -504,7 +504,7 @@ public class WRadioGroupEditor extends WEditor implements ContextMenuListener, L
 	/**
 	 * Container for {@link Radiogroup}  and {@link Radio} component.
 	 */
-	private static class RadioGroupEditor extends Hlayout {
+	public static class RadioGroupEditor extends Hlayout {
 		/**
 		 * generated serial id
 		 */


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5769

# Pull Request Checklist

- [X] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [X] My code follows the best practices of this project
- [X] I have performed a self-review of my own code
- [X] My code is easy to understand and review. 
- [] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [X] My changes generate no new warnings
### Tests
- [X] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

