### PR TITLE
IDEMPIERE-5560 Cannot save Material Receipt after filling Order if the User1_ID field is not displayed

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/GridTab.java
+++ b/org.adempiere.base/src/org/compiere/model/GridTab.java
@@ -2769,8 +2769,15 @@ public class GridTab implements DataStatusListener, Evaluatee, Serializable
 
 		if (log.isLoggable(Level.FINE)) log.fine(field.getColumnName() + "=" + value + " - Row=" + m_currentRow);
 
-		if (DisplayType.isID(field.getDisplayType()) && value instanceof Integer && ((Integer)value).intValue() < 0)
-			value = null;
+		if (value instanceof Integer) {
+			if (((Integer)value).intValue() < 0 && DisplayType.isID(field.getDisplayType())) {
+				value = null;
+			} else if (((Integer)value).intValue() == 0 && field.isLookup()) {
+				MColumn column = MColumn.get(field.getAD_Column_ID());
+				if (! MTable.isZeroIDTable(column.getReferenceTableName()))
+					value = null;
+			}
+		}
 
 		int col = m_mTable.findColumn(field.getColumnName());
 		m_mTable.setValueAt(value, m_currentRow, col, false);


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5560?focusedCommentId=49477

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
