### PR TITLE
IDEMPIERE-5780 NPE on StatusBarPanel

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/StatusBarPanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/StatusBarPanel.java
@@ -75,7 +75,7 @@ public class StatusBarPanel extends Panel implements EventListener<Event>, IStat
 
 	private String m_text;
 
-	private Div east;
+	private East east;
 
 	private Div popup;
 
@@ -109,7 +109,7 @@ public class StatusBarPanel extends Panel implements EventListener<Event>, IStat
         Center center = new Center();
         statusBar.appendChild(center);
 
-        East east = new East();
+        east = new East();
         statusBar.appendChild(east);
 
         LayoutUtils.addSclass("status-selected", selectedLine);


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5780

It seems the InfoProductPanel (deprecated) is unusable, and this ticket doesn't solve this problem, but at least doesn't throw NPE and allows to select a product entering the value or name.

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
