### PR TITLE
IDEMPIERE-5529 StackOverflowError at Quick Entry using WDateEditor

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WDateEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WDateEditor.java
@@ -18,8 +18,10 @@
 package org.adempiere.webui.editor;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.Objects;
 
 import org.adempiere.webui.ValuePreference;
 import org.adempiere.webui.component.Datebox;
@@ -171,30 +173,43 @@ public class WDateEditor extends WEditor implements ContextMenuListener
     {
     	if (value == null || value.toString().trim().length() == 0)
     	{
+    		Timestamp currentValue = oldValue;
     		oldValue = null;
     		getComponent().setValue(null);
-    		ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), oldValue, value);
-            super.fireValueChange(changeEvent);
+    		if (currentValue != null)
+    		{
+    			ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, null);
+    			super.fireValueChange(changeEvent);
+    		}
     	}
     	else if (value instanceof Timestamp)
         {
-            getComponent().setValueInLocalDateTime(((Timestamp)value).toLocalDateTime());
-            ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), oldValue, value);
-            super.fireValueChange(changeEvent);
-            oldValue = (Timestamp)value;
+    		Timestamp currentValue = oldValue;
+    		LocalDateTime localDateTime = ((Timestamp)value).toLocalDateTime();
+            getComponent().setValueInLocalDateTime(localDateTime);            
+            oldValue = Timestamp.valueOf(localDateTime);
+            if (!Objects.equals(currentValue, oldValue)) 
+            {
+            	ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, oldValue);
+            	super.fireValueChange(changeEvent);
+            }
         }
     	else
     	{
     		try
     		{
+    			Timestamp currentValue = oldValue;
     			getComponent().setText(value.toString());
-    			ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), oldValue, value);
-                super.fireValueChange(changeEvent);
-    		} catch (Exception e) {}
-    		if (getComponent().getValue() != null)
-    			oldValue = Timestamp.valueOf(getComponent().getValue().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
-    		else
-    			oldValue = null;
+    			if (getComponent().getValue() != null)
+        			oldValue = Timestamp.valueOf(getComponent().getValue().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
+        		else
+        			oldValue = null;
+    			if (!Objects.equals(currentValue, oldValue))
+    			{
+	    			ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, oldValue);
+	                super.fireValueChange(changeEvent);
+    			}
+    		} catch (Exception e) {}    		
     	}
     }
 

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WDatetimeEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WDatetimeEditor.java
@@ -36,6 +36,8 @@ import org.compiere.util.Util;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.Events;
 
+import com.google.common.base.Objects;
+
 /**
  * Default editor for {@link DisplayType#DateTime} and {@link DisplayType#TimestampWithTimeZone}.
  * Implemented with {@link DatetimeBox} component.
@@ -215,30 +217,46 @@ public class WDatetimeEditor extends WEditor implements ContextMenuListener
     {
     	if (value == null || value.toString().trim().length() == 0)
     	{
+    		Timestamp currentValue = oldValue;
     		oldValue = null;
     		getComponent().setValue(null);
+    		if (currentValue != null)
+    		{
+    			ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, null);
+    			super.fireValueChange(changeEvent);
+    		}
     	}
     	else if (value instanceof Timestamp)
         {
     		Timestamp ts = (Timestamp) value;
     		if (isTimestampWithTimeZone())
     		{
+    			Timestamp currentValue = oldValue;
     			ZonedDateTime zdt = ts.toInstant().atZone(getComponent().getDatebox().getTimeZone().toZoneId());
     			getComponent().setValueInZonedDateTime(zdt);
-    			ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), oldValue, value);
-                super.fireValueChange(changeEvent);
+    			oldValue = Timestamp.from(zdt.toInstant());
+    			if (!Objects.equal(currentValue, oldValue))
+    			{
+    				ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, oldValue);
+    				super.fireValueChange(changeEvent);
+    			}
     		}
     		else
     		{
+    			Timestamp currentValue = oldValue;
 	    		LocalDateTime localTime = ts.toLocalDateTime();
 	    		getComponent().setValueInLocalDateTime(localTime);
-	    		ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), oldValue, value);
-	            super.fireValueChange(changeEvent);
+	    		oldValue = Timestamp.valueOf(localTime);
+    			if (!Objects.equal(currentValue, oldValue))
+    			{
+    				ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, oldValue);
+    				super.fireValueChange(changeEvent);
+    			}
     		}
-            oldValue = ts;
         }
     	else
     	{
+    		Timestamp currentValue = oldValue;
     		try
     		{
     			getComponent().setText(value.toString());
@@ -249,10 +267,20 @@ public class WDatetimeEditor extends WEditor implements ContextMenuListener
     				oldValue = Timestamp.from(getComponent().getDatebox().getValue().toInstant());
     			else
     				oldValue = Timestamp.valueOf(getComponent().getDatebox().getValue().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
+    			if (!Objects.equal(currentValue, oldValue))
+    			{
+    				ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, oldValue);
+    				super.fireValueChange(changeEvent);
+    			}
     		}
     		else
     		{
     			oldValue = null;
+    			if (currentValue != null)
+        		{
+        			ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, null);
+        			super.fireValueChange(changeEvent);
+        		}
     		}
     	}
     }


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5529

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

