### PR TITLE
Idempiere 5804 - Info Window mandatory parameters are not beeing display correctly.

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
@@ -52,8 +52,10 @@ import org.adempiere.webui.component.Borderlayout;
 import org.adempiere.webui.component.Button;
 import org.adempiere.webui.component.Column;
 import org.adempiere.webui.component.Columns;
+import org.adempiere.webui.component.ComboEditorBox;
 import org.adempiere.webui.component.Combobox;
 import org.adempiere.webui.component.ConfirmPanel;
+import org.adempiere.webui.component.DatetimeBox;
 import org.adempiere.webui.component.EditorBox;
 import org.adempiere.webui.component.Grid;
 import org.adempiere.webui.component.GridFactory;
@@ -137,6 +139,7 @@ import org.zkoss.zul.Center;
 import org.zkoss.zul.Checkbox;
 import org.zkoss.zul.Comboitem;
 import org.zkoss.zul.ComboitemRenderer;
+import org.zkoss.zul.Constraint;
 import org.zkoss.zul.Div;
 import org.zkoss.zul.Filedownload;
 import org.zkoss.zul.ListModelList;
@@ -145,6 +148,7 @@ import org.zkoss.zul.Menuitem;
 import org.zkoss.zul.North;
 import org.zkoss.zul.Paging;
 import org.zkoss.zul.Separator;
+import org.zkoss.zul.SimpleConstraint;
 import org.zkoss.zul.South;
 import org.zkoss.zul.Space;
 import org.zkoss.zul.Vbox;
@@ -165,6 +169,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 	private static final long serialVersionUID = 4004251745919433247L;
 
 	private static final String ON_QUERY_AFTER_CHANGE = "onQueryAfterChange";
+	private static final Constraint ZK_INPUT_NOT_EMPTY_CONSTRAINT = new SimpleConstraint(SimpleConstraint.NO_EMPTY, Msg.getMsg(Env.getCtx(), "Missing required parameters"));
 	
 	protected Grid parameterGrid;
 	private Borderlayout layout;
@@ -2345,6 +2350,9 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
     			super.onEvent(event);
     		}
     		
+    	} else if (event.getTarget().equals(confirmPanel.getButton(ConfirmPanel.A_REFRESH))) {
+    		setMandatoryFieldsConstraint();
+    		super.onEvent(event);
     	}
     	else
     	{
@@ -3388,5 +3396,54 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 		{
 			return true;
 		}	
-	}	
+	}
+
+	/**
+	 * That method will search at all Editors to set a
+	 * {@link InputElement#setConstraint(org.zkoss.zul.Constraint)} (equivalent to
+	 * "required" HTML attribute) for mandatory parameters.
+	 */
+	private void setMandatoryFieldsConstraint() {
+
+		InputElement inputFrom = null;
+		InputElement inputTo = null;
+		Constraint constraint = null;
+
+		int index = 0;
+		for (WEditor editorFrom : editors) {
+			WEditor editorTo = editors2.get(index++);
+
+			if (editorFrom.getComponent() instanceof InputElement) {
+				inputFrom = (InputElement) editorFrom.getComponent();
+				if (editorTo != null)
+					inputTo = (InputElement) editorTo.getComponent();
+
+			} else if (editorFrom.getComponent() instanceof NumberBox) {
+				inputFrom = ((NumberBox) editorFrom.getComponent()).getDecimalbox();
+				if (editorTo != null)
+					inputTo = ((NumberBox) editorTo.getComponent()).getDecimalbox();
+
+			} else if (editorFrom.getComponent() instanceof ComboEditorBox) {
+				inputFrom = ((ComboEditorBox) editorFrom.getComponent()).getCombobox();
+				if (editorTo != null)
+					inputTo = ((ComboEditorBox) editorTo.getComponent()).getCombobox();
+
+			} else if (editorFrom.getComponent() instanceof DatetimeBox) {
+				inputFrom = ((DatetimeBox) editorFrom.getComponent()).getDatebox();
+				if (editorTo != null)
+					inputTo = ((DatetimeBox) editorTo.getComponent()).getDatebox();
+
+			} 
+
+			if (editorFrom.isMandatory())
+				constraint = ZK_INPUT_NOT_EMPTY_CONSTRAINT;
+
+			if (inputFrom != null)
+				inputFrom.setConstraint(constraint);
+			if (inputTo != null)
+				inputTo.setConstraint(constraint);
+				
+		}
+	}
+
 }

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
@@ -52,10 +52,8 @@ import org.adempiere.webui.component.Borderlayout;
 import org.adempiere.webui.component.Button;
 import org.adempiere.webui.component.Column;
 import org.adempiere.webui.component.Columns;
-import org.adempiere.webui.component.ComboEditorBox;
 import org.adempiere.webui.component.Combobox;
 import org.adempiere.webui.component.ConfirmPanel;
-import org.adempiere.webui.component.DatetimeBox;
 import org.adempiere.webui.component.EditorBox;
 import org.adempiere.webui.component.Grid;
 import org.adempiere.webui.component.GridFactory;
@@ -130,6 +128,7 @@ import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.HtmlBasedComponent;
 import org.zkoss.zk.ui.Page;
+import org.zkoss.zk.ui.WrongValueException;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
 import org.zkoss.zk.ui.event.Events;
@@ -139,7 +138,6 @@ import org.zkoss.zul.Center;
 import org.zkoss.zul.Checkbox;
 import org.zkoss.zul.Comboitem;
 import org.zkoss.zul.ComboitemRenderer;
-import org.zkoss.zul.Constraint;
 import org.zkoss.zul.Div;
 import org.zkoss.zul.Filedownload;
 import org.zkoss.zul.ListModelList;
@@ -148,7 +146,6 @@ import org.zkoss.zul.Menuitem;
 import org.zkoss.zul.North;
 import org.zkoss.zul.Paging;
 import org.zkoss.zul.Separator;
-import org.zkoss.zul.SimpleConstraint;
 import org.zkoss.zul.South;
 import org.zkoss.zul.Space;
 import org.zkoss.zul.Vbox;
@@ -169,7 +166,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 	private static final long serialVersionUID = 4004251745919433247L;
 
 	private static final String ON_QUERY_AFTER_CHANGE = "onQueryAfterChange";
-	private static final Constraint ZK_INPUT_NOT_EMPTY_CONSTRAINT = new SimpleConstraint(SimpleConstraint.NO_EMPTY, Msg.getMsg(Env.getCtx(), "Missing required parameters"));
+//	private static final Constraint ZK_INPUT_NOT_EMPTY_CONSTRAINT = new SimpleConstraint(SimpleConstraint.NO_EMPTY, );
 	
 	protected Grid parameterGrid;
 	private Borderlayout layout;
@@ -3405,43 +3402,15 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 	 */
 	private void setMandatoryFieldsConstraint() {
 
-		InputElement inputFrom = null;
-		InputElement inputTo = null;
-		Constraint constraint = null;
-
 		int index = 0;
 		for (WEditor editorFrom : editors) {
 			WEditor editorTo = editors2.get(index++);
 
-			if (editorFrom.getComponent() instanceof InputElement) {
-				inputFrom = (InputElement) editorFrom.getComponent();
-				if (editorTo != null)
-					inputTo = (InputElement) editorTo.getComponent();
+			if (editorFrom.isMandatory() && editorFrom.getValue() == null)
+				throw new WrongValueException(editorFrom.getComponent(), Msg.getMsg(Env.getCtx(), "Missing required parameters"));
 
-			} else if (editorFrom.getComponent() instanceof NumberBox) {
-				inputFrom = ((NumberBox) editorFrom.getComponent()).getDecimalbox();
-				if (editorTo != null)
-					inputTo = ((NumberBox) editorTo.getComponent()).getDecimalbox();
-
-			} else if (editorFrom.getComponent() instanceof ComboEditorBox) {
-				inputFrom = ((ComboEditorBox) editorFrom.getComponent()).getCombobox();
-				if (editorTo != null)
-					inputTo = ((ComboEditorBox) editorTo.getComponent()).getCombobox();
-
-			} else if (editorFrom.getComponent() instanceof DatetimeBox) {
-				inputFrom = ((DatetimeBox) editorFrom.getComponent()).getDatebox();
-				if (editorTo != null)
-					inputTo = ((DatetimeBox) editorTo.getComponent()).getDatebox();
-
-			} 
-
-			if (editorFrom.isMandatory())
-				constraint = ZK_INPUT_NOT_EMPTY_CONSTRAINT;
-
-			if (inputFrom != null)
-				inputFrom.setConstraint(constraint);
-			if (inputTo != null)
-				inputTo.setConstraint(constraint);
+			if (editorTo != null && editorTo.isMandatory() && editorTo.getValue() == null)
+				throw new WrongValueException(editorTo.getComponent(), Msg.getMsg(Env.getCtx(), "Missing required parameters"));
 				
 		}
 	}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
@@ -2274,7 +2274,10 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 			// reset value of WInfoPAttributeEditor to null when change M_AttributeSet_ID
 			if (asiChanged && otherEditor instanceof WInfoPAttributeEditor)
 				((WInfoPAttributeEditor)otherEditor).clearWhereClause();
-			
+
+			if (otherEditor.getGridField() != null)
+				otherEditor.setMandatory(otherEditor.getGridField().isMandatory(true));
+
 			otherEditor.dynamicDisplay();
 		}
 	}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
@@ -166,7 +166,6 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 	private static final long serialVersionUID = 4004251745919433247L;
 
 	private static final String ON_QUERY_AFTER_CHANGE = "onQueryAfterChange";
-//	private static final Constraint ZK_INPUT_NOT_EMPTY_CONSTRAINT = new SimpleConstraint(SimpleConstraint.NO_EMPTY, );
 	
 	protected Grid parameterGrid;
 	private Borderlayout layout;
@@ -3396,9 +3395,8 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 	}
 
 	/**
-	 * That method will search at all Editors to set a
-	 * {@link InputElement#setConstraint(org.zkoss.zul.Constraint)} (equivalent to
-	 * "required" HTML attribute) for mandatory parameters.
+	 * That method will search at all Editors to validate if it is mandatory and has
+	 * to be provided by user.
 	 */
 	private void setMandatoryFieldsConstraint() {
 


### PR DESCRIPTION
Fix the display bug for mandatory parameters and implements the ZK WrongValueException for mandatory parameters on ON_REFRESH time.

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

