### PR TITLE
IDEMPIERE-5816 Upgrade Hazelcast version (FHCA-4436)

### DIFF
--- a/org.idempiere.hazelcast.service/build.properties
+++ b/org.idempiere.hazelcast.service/build.properties
@@ -5,7 +5,6 @@ bin.includes = META-INF/,\
                OSGI-INF/cacheservice.xml,\
                OSGI-INF/messageservice.xml,\
                OSGI-INF/,\
-               lib/hazelcast-aws.jar,\
                lib/hazelcast.jar
 source.. = src/
 jre.compilation.profile = JavaSE-17

--- a/org.idempiere.hazelcast.service/pom.xml
+++ b/org.idempiere.hazelcast.service/pom.xml
@@ -28,11 +28,6 @@
 									<artifactId>hazelcast</artifactId>
 									<version>5.3.1</version>
 								</artifactItem>
-								<artifactItem>
-									<groupId>com.hazelcast</groupId>
-									<artifactId>hazelcast-aws</artifactId>
-									<version>3.4</version>
-								</artifactItem>
 							</artifactItems>
 							<outputDirectory>lib</outputDirectory>
 							<stripVersion>true</stripVersion>

--- a/org.idempiere.hazelcast.service/src/org/idempiere/hazelcast/service/Activator.java
+++ b/org.idempiere.hazelcast.service/src/org/idempiere/hazelcast/service/Activator.java
@@ -133,7 +133,7 @@ public class Activator implements BundleActivator {
 			}
 			
 			Enumeration<URL> entries = getContext().getBundle().findEntries("/", "hazelcast.xml", false);
-			URL url = entries.hasMoreElements() ? entries.nextElement() : null;
+			URL url = (entries != null && entries.hasMoreElements()) ? entries.nextElement() : null;
 			if (url != null) {
 				try {
 					Config config = new UrlXmlConfig(url);


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5816

- fix NPE when no hazelcast.xml file is in path or in bundle
- remove the library hazelcast-aws.jar - not needed anymore

I conducted tests with two amazon instances and it worked fine without the library as those classes are now included in hazelcast.jar