### PR TITLE
IDEMPIERE-5275 Tabular Report Re-Run button/close parameter window

### DIFF
--- a/org.adempiere.base/src/org/compiere/print/ReportEngine.java
+++ b/org.adempiere.base/src/org/compiere/print/ReportEngine.java
@@ -2855,4 +2855,20 @@ queued-job-count = 0  (class javax.print.attribute.standard.QueuedJobCount)
 			element.setStyle(styleBuilder.toString());
 		//
 	}
+
+	private ProcessInfo m_pi = null;
+	
+	/**
+	 * @param pi
+	 */
+	public void setProcessInfo(ProcessInfo pi) {
+		m_pi = pi;
+	}
+	
+	/**
+	 * @return ProcessInfo
+	 */
+	public ProcessInfo getProcessInfo() {
+		return m_pi;
+	}
 }	//	ReportEngine

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/ProcessDialog.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/ProcessDialog.java
@@ -93,6 +93,8 @@ import com.lowagie.text.pdf.PdfWriter;
  */
 public class ProcessDialog extends AbstractProcessDialog implements EventListener<Event>, IHelpContext, ITabOnCloseHandler
 {
+	public static final String SAVED_PREDEFINED_CONTEXT_VARIABLES = "__PredefinedContextVariables__";
+
 	/**
 	 * generated serial id
 	 */
@@ -152,6 +154,11 @@ public class ProcessDialog extends AbstractProcessDialog implements EventListene
 		m_WindowNo = SessionManager.getAppDesktop().registerWindow(this);
 		this.setAttribute(IDesktop.WINDOWNO_ATTRIBUTE, m_WindowNo);
 		Env.setContext(Env.getCtx(), m_WindowNo, "IsSOTrx", isSOTrx ? "Y" : "N");
+		//save for rerun of report
+		if (predefinedContextVariables != null && MProcess.get(AD_Process_ID).isReport())
+		{
+			Env.setContext(Env.getCtx(), m_WindowNo, SAVED_PREDEFINED_CONTEXT_VARIABLES, predefinedContextVariables);
+		}
 		Env.setPredefinedVariables(Env.getCtx(), m_WindowNo, predefinedContextVariables);
 		try
 		{

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/ZkReportViewer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/ZkReportViewer.java
@@ -1054,7 +1054,7 @@ public class ZkReportViewer extends Window implements EventListener<Event>, IRep
 		ProcessInfoUtil.setLogFromDB(pi);
 		if (pi.isError() || (pi.getLogs() != null && pi.getLogs().length > 0)) {
 			ProcessInfoDialog dialog = new ProcessInfoDialog(pi, false);
-			dialog.setAutoCloseAfterZoom(true);
+			dialog.setAutoCloseAfterZoom(false);
 			dialog.setPage(this.getPage());
 			dialog.doHighlighted();
 		}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/ZkReportViewerProvider.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/ZkReportViewerProvider.java
@@ -17,11 +17,14 @@
 package org.adempiere.webui.window;
 
 import org.adempiere.webui.apps.AEnv;
+import org.adempiere.webui.apps.ProcessDialog;
 import org.adempiere.webui.component.Window;
 import org.adempiere.webui.part.WindowContainer;
 import org.adempiere.webui.session.SessionManager;
 import org.compiere.print.ReportEngine;
 import org.compiere.print.ReportViewerProvider;
+import org.compiere.util.Env;
+import org.compiere.util.Util;
 import org.zkoss.zk.ui.Executions;
 
 /**
@@ -55,6 +58,11 @@ public class ZkReportViewerProvider implements ReportViewerProvider {
 		if(report.isReplaceTabContent()) {
 			viewer.setAttribute(Window.INSERT_POSITION_KEY, Window.REPLACE);
 			viewer.setAttribute(WindowContainer.REPLACE_WINDOW_NO, report.getWindowNo());
+			String predefined = Env.getContext(Env.getCtx(), report.getWindowNo(), ProcessDialog.SAVED_PREDEFINED_CONTEXT_VARIABLES);
+			if (!Util.isEmpty(predefined, true)) {
+				viewer.setAttribute(ProcessDialog.SAVED_PREDEFINED_CONTEXT_VARIABLES, predefined);
+			}
+			viewer.setAttribute("IsSOTrx", Env.getContext(Env.getCtx(), report.getWindowNo(), "IsSOTrx"));
 		}
 		viewer.setAttribute(WindowContainer.DEFER_SET_SELECTED_TAB, Boolean.TRUE);
 		SessionManager.getAppDesktop().showWindow(viewer);

--- a/org.adempiere.ui/src/org/compiere/print/ReportCtl.java
+++ b/org.adempiere.ui/src/org/compiere/print/ReportCtl.java
@@ -312,6 +312,7 @@ public class ReportCtl
 		}
 		re.setLanguageID(pi.getLanguageID());
 		re.setIsReplaceTabContent(pi.isReplaceTabContent());
+		re.setProcessInfo(pi);
 		createOutput(re, pi.isPrintPreview(), null);
 		return true;
 	}	//	startStandardReport


### PR DESCRIPTION
- Fix process info log & error not shown
- Fix re-run missing context variable from menu

https://idempiere.atlassian.net/browse/IDEMPIERE-5275
# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

