### PR TITLE
IDEMPIERE-5831 - Fix onZoom events to be executed once a click for Broadcast Messages

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/BroadcastMessageWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/BroadcastMessageWindow.java
@@ -22,15 +22,12 @@ import java.util.logging.Level;
 import org.adempiere.exceptions.DBException;
 import org.adempiere.model.MBroadcastMessage;
 import org.adempiere.webui.ClientInfo;
-import org.adempiere.webui.apps.AEnv;
 import org.adempiere.webui.component.Button;
 import org.adempiere.webui.component.Checkbox;
 import org.adempiere.webui.component.Label;
 import org.adempiere.webui.component.Window;
-import org.adempiere.webui.event.ZoomEvent;
 import org.adempiere.webui.util.ZKUpdateUtil;
 import org.compiere.model.MNote;
-import org.compiere.model.MQuery;
 import org.compiere.util.CLogger;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
@@ -41,7 +38,6 @@ import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
 import org.zkoss.zk.ui.event.Events;
-import org.zkoss.zk.ui.util.Clients;
 import org.zkoss.zul.Borderlayout;
 import org.zkoss.zul.Cell;
 import org.zkoss.zul.Center;
@@ -124,7 +120,6 @@ public class BroadcastMessageWindow extends Window implements IBroadcastMsgPopup
 		Env.setContext(Env.getCtx(), MBroadcastMessage.CLIENTINFO_BROADCAST_COMPONENT_ID, pnlHead.getUuid());
 		setTitle(mbMessages.get(0));
 		textMsgContent.setContent(mbMessages.get(0).get_Translation(MBroadcastMessage.COLUMNNAME_BroadcastMessage));
-		pnlHead.addEventListener(ZoomEvent.EVENT_NAME, this);
 		htmlDiv.setFocus(true);
 		htmlDiv.setStyle("display: table-cell; vertical-align: middle; text-align: center;");
 		Div divAlign = new Div();
@@ -243,13 +238,6 @@ public class BroadcastMessageWindow extends Window implements IBroadcastMsgPopup
         	}else if(comp == acknowledged){
        			hashMessages.put(mbMessages.get(currMsg).get_ID(), acknowledged.isChecked());
         	}
-		}
-		else if(event.getName().equals(ZoomEvent.EVENT_NAME)) {
-			Clients.clearBusy();
-			ZoomEvent ze = (ZoomEvent) event;
-			if (ze.getData() != null && ze.getData() instanceof MQuery) {
-				AEnv.zoom((MQuery) ze.getData());
-			}
 		}
 	}
 	

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/HeaderPanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/HeaderPanel.java
@@ -19,13 +19,16 @@ package org.adempiere.webui.panel;
 
 import org.adempiere.webui.ClientInfo;
 import org.adempiere.webui.LayoutUtils;
+import org.adempiere.webui.apps.AEnv;
 import org.adempiere.webui.apps.GlobalSearch;
 import org.adempiere.webui.apps.MenuSearchController;
 import org.adempiere.webui.component.Panel;
+import org.adempiere.webui.event.ZoomEvent;
 import org.adempiere.webui.session.SessionManager;
 import org.adempiere.webui.theme.ThemeManager;
 import org.adempiere.webui.util.ZKUpdateUtil;
 import org.adempiere.webui.window.AboutWindow;
+import org.compiere.model.MQuery;
 import org.compiere.util.Env;
 import org.compiere.util.Msg;
 import org.compiere.util.Util;
@@ -36,6 +39,7 @@ import org.zkoss.zk.ui.event.EventListener;
 import org.zkoss.zk.ui.event.Events;
 import org.zkoss.zk.ui.event.KeyEvent;
 import org.zkoss.zk.ui.event.OpenEvent;
+import org.zkoss.zk.ui.util.Clients;
 import org.zkoss.zul.Image;
 import org.zkoss.zul.Popup;
 import org.zkoss.zul.impl.LabelImageElement;
@@ -62,7 +66,8 @@ public class HeaderPanel extends Panel implements EventListener<Event>
     public HeaderPanel()
     {
         super();
-        addEventListener(Events.ON_CREATE, this);              
+        addEventListener(Events.ON_CREATE, this);
+        addEventListener(ZoomEvent.EVENT_NAME, this);
     }
 
     protected void onCreate()
@@ -140,6 +145,12 @@ public class HeaderPanel extends Panel implements EventListener<Event>
 			}else if (ke.getKeyCode() == 27) {
 				popMenu.close();
 			} 
+		} else if(event.getName().equals(ZoomEvent.EVENT_NAME)) {
+			Clients.clearBusy();
+			ZoomEvent ze = (ZoomEvent) event;
+			if (ze.getData() != null && ze.getData() instanceof MQuery) {
+				AEnv.zoom((MQuery) ze.getData());
+			}
 		}
 	}
 


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5831

After adjusts, the window was oppened just once.
![image](https://github.com/idempiere/idempiere/assets/71560285/e38d59b1-f3ff-4cbe-91dd-f4f52fd29b4e)

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

