### PR TITLE
IDEMPIERE-5760: Manage mail.smtp.timeout using SysConfig

### DIFF
--- a/migration/iD10/oracle/202308280920_IDEMPIERE-5760.sql
+++ b/migration/iD10/oracle/202308280920_IDEMPIERE-5760.sql
@@ -1,0 +1,10 @@
+-- IDEMPIERE-5760
+SELECT register_migration_script('202308280920_IDEMPIERE-5760.sql') FROM dual;
+
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Aug 28, 2023, 9:20:09 AM CEST
+INSERT INTO AD_SysConfig (AD_SysConfig_ID,AD_Client_ID,AD_Org_ID,Created,Updated,CreatedBy,UpdatedBy,IsActive,Name,Value,Description,EntityType,ConfigurationLevel,AD_SysConfig_UU) VALUES (200233,0,0,TO_TIMESTAMP('2023-08-28 09:20:09','YYYY-MM-DD HH24:MI:SS'),TO_TIMESTAMP('2023-08-28 09:20:09','YYYY-MM-DD HH24:MI:SS'),10,10,'Y','MAIL_SMTP_TIMEOUT','20000','Timeout in milliseconds to send an email','D','C','66c84808-15eb-4f26-ad23-25d9ea0d96fc')
+;
+

--- a/migration/iD10/postgresql/202308280920_IDEMPIERE-5760.sql
+++ b/migration/iD10/postgresql/202308280920_IDEMPIERE-5760.sql
@@ -1,0 +1,7 @@
+-- IDEMPIERE-5760
+SELECT register_migration_script('202308280920_IDEMPIERE-5760.sql') FROM dual;
+
+-- Aug 28, 2023, 9:20:09 AM CEST
+INSERT INTO AD_SysConfig (AD_SysConfig_ID,AD_Client_ID,AD_Org_ID,Created,Updated,CreatedBy,UpdatedBy,IsActive,Name,Value,Description,EntityType,ConfigurationLevel,AD_SysConfig_UU) VALUES (200233,0,0,TO_TIMESTAMP('2023-08-28 09:20:09','YYYY-MM-DD HH24:MI:SS'),TO_TIMESTAMP('2023-08-28 09:20:09','YYYY-MM-DD HH24:MI:SS'),10,10,'Y','MAIL_SMTP_TIMEOUT','20000','Timeout in milliseconds to send an email','D','C','66c84808-15eb-4f26-ad23-25d9ea0d96fc')
+;
+

--- a/org.adempiere.base/src/org/compiere/model/MSysConfig.java
+++ b/org.adempiere.base/src/org/compiere/model/MSysConfig.java
@@ -44,7 +44,7 @@ public class MSysConfig extends X_AD_SysConfig
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = 4924291305767860669L;
+	private static final long serialVersionUID = -2055659961699848343L;
 
     public static final String AD_CHANGELOG_SAVE_UUID = "AD_CHANGELOG_SAVE_UUID";
     public static final String ADDRESS_VALIDATION = "ADDRESS_VALIDATION";
@@ -137,6 +137,7 @@ public class MSysConfig extends X_AD_SysConfig
     public static final String MAIL_SEND_BCC_TO_ADDRESS = "MAIL_SEND_BCC_TO_ADDRESS";
     public static final String MAIL_SEND_BCC_TO_FROM = "MAIL_SEND_BCC_TO_FROM";
     public static final String MAIL_SEND_CREDENTIALS = "MAIL_SEND_CREDENTIALS";
+    public static final String MAIL_SMTP_TIMEOUT = "MAIL_SMTP_TIMEOUT";
     public static final String MAX_ACTIVITIES_IN_LIST = "MAX_ACTIVITIES_IN_LIST";
     public static final String MAX_RESULTS_PER_SEARCH_IN_DOCUMENT_CONTROLLER = "MAX_RESULTS_PER_SEARCH_IN_DOCUMENT_CONTROLLER";
     public static final String MAX_ROWS_IN_TABLE_COMBOLIST = "MAX_ROWS_IN_TABLE_COMBOLIST";

--- a/org.adempiere.base/src/org/compiere/util/EMail.java
+++ b/org.adempiere.base/src/org/compiere/util/EMail.java
@@ -74,7 +74,7 @@ public final class EMail implements Serializable
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = 5355436165040508855L;
+	private static final long serialVersionUID = -8982983766981221312L;
 
 	//use in server bean
 	public final static String HTML_MAIL_MARKER = "ContentType=text/html;";
@@ -305,8 +305,8 @@ public final class EMail implements Serializable
 		props.put("mail.store.protocol", "smtp");
 		props.put("mail.transport.protocol", "smtp");
 		props.put("mail.host", m_smtpHost);
-		//Timeout for sending the email defaulted to 20 seconds
-		props.put("mail.smtp.timeout", 20000);
+		//Timeout for sending the email defaulted to 20 seconds if not defined in a SysConfig Key
+		props.put("mail.smtp.timeout", MSysConfig.getIntValue(MSysConfig.MAIL_SMTP_TIMEOUT, 20000, Env.getAD_Client_ID(m_ctx)));
 
 		if (CLogMgt.isLevelFinest())
 			props.put("mail.debug", "true");


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5760

https://github.com/idempiere/idempiere/pull/1883 + changes requested by Carlos (migration script)

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [x] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

