### PR TITLE
IDEMPIERE-5843 System support users (like SuperUser) cannot see (fix) preferences on tenants

### DIFF
--- a/org.adempiere.base/src/org/adempiere/model/MTabCustomization.java
+++ b/org.adempiere.base/src/org/adempiere/model/MTabCustomization.java
@@ -4,17 +4,16 @@ import java.sql.ResultSet;
 import java.util.Properties;
 
 import org.compiere.model.Query;
-import org.compiere.model.SystemIDs;
 import org.compiere.model.X_AD_Tab_Customization;
 import org.compiere.util.Util;
 
 public class MTabCustomization extends X_AD_Tab_Customization {
-	/**
+    /**
 	 * 
 	 */
-	private static final long serialVersionUID = -4986336833193761507L;
+	private static final long serialVersionUID = 7401493734354775112L;
 
-    /**
+	/**
     * UUID based Constructor
     * @param ctx  Context
     * @param AD_Tab_Customization_UU  UUID key
@@ -109,19 +108,5 @@ public class MTabCustomization extends X_AD_Tab_Customization {
 			return tabCust.delete(true);
 		return tabCust.save();
 	} // saveTabCustomization
-
-	/** Set User/Contact.
-        @param AD_User_ID
-        User within the system - Internal or Business Partner Contact
-        Overridden to allow saving System record (zero ID)
-	 */
-	@Override
-	public void setAD_User_ID (int AD_User_ID)
-	{
-		if (AD_User_ID == SystemIDs.USER_SYSTEM_DEPRECATED) 
-			set_ValueNoCheck (COLUMNNAME_AD_User_ID, AD_User_ID);
-		else 
-			super.setAD_User_ID(AD_User_ID);
-	} //setAD_User_ID
 
 }

--- a/org.adempiere.base/src/org/compiere/model/MDashboardPreference.java
+++ b/org.adempiere.base/src/org/compiere/model/MDashboardPreference.java
@@ -31,7 +31,7 @@ public class MDashboardPreference extends X_PA_DashboardPreference
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = -3887344231734476767L;
+	private static final long serialVersionUID = -8779298936108629638L;
 
 	/**
 	 *
@@ -182,19 +182,5 @@ public class MDashboardPreference extends X_PA_DashboardPreference
     {
       super (ctx, rs, trxName);
     }
-
-	/** Set User/Contact.
-        @param AD_User_ID
-        User within the system - Internal or Business Partner Contact
-        Overridden to allow saving System record (zero ID)
-	 */
-	@Override
-	public void setAD_User_ID (int AD_User_ID)
-	{
-		if (AD_User_ID == SystemIDs.USER_SYSTEM_DEPRECATED) 
-			set_ValueNoCheck (COLUMNNAME_AD_User_ID, AD_User_ID);
-		else 
-			super.setAD_User_ID(AD_User_ID);
-	} //setAD_User_ID
 
 }

--- a/org.adempiere.base/src/org/compiere/model/MMFARegistration.java
+++ b/org.adempiere.base/src/org/compiere/model/MMFARegistration.java
@@ -37,12 +37,12 @@ import org.compiere.util.Env;
  * Multi-factor Authentication Registration
  */
 public class MMFARegistration extends X_MFA_Registration {
-	/**
+    /**
 	 * 
 	 */
-	private static final long serialVersionUID = -2032862057961778934L;
+	private static final long serialVersionUID = -1441495978065471474L;
 
-    /**
+	/**
     * UUID based Constructor
     * @param ctx  Context
     * @param MFA_Registration_UU  UUID key
@@ -199,20 +199,5 @@ public class MMFARegistration extends X_MFA_Registration {
 		String msg = mechanism.validateCode(reg, code, setPreferred);
 		return msg;
 	}
-
-	/**
-	 * 	Set User/Contact.
-     * @param AD_User_ID
-     * User within the system - Internal or Business Partner Contact
-     * Overridden to allow saving System record (zero ID)
-	 */
-	@Override
-	public void setAD_User_ID (int AD_User_ID)
-	{
-		if (AD_User_ID == SystemIDs.USER_SYSTEM_DEPRECATED) 
-			set_ValueNoCheck (COLUMNNAME_AD_User_ID, AD_User_ID);
-		else 
-			super.setAD_User_ID(AD_User_ID);
-	} //setAD_User_ID
 
 } // MMFARegistration

--- a/org.adempiere.base/src/org/compiere/model/MPasswordHistory.java
+++ b/org.adempiere.base/src/org/compiere/model/MPasswordHistory.java
@@ -11,9 +11,9 @@ public class MPasswordHistory extends X_AD_Password_History {
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = -571685945938727000L;
+    private static final long serialVersionUID = -5199700193821111847L;
 
-    /**
+	/**
     * UUID based Constructor
     * @param ctx  Context
     * @param AD_Password_History_UU  UUID key
@@ -58,20 +58,5 @@ public class MPasswordHistory extends X_AD_Password_History {
 		
 		return query.list();
 	}
-
-	/** Set User/Contact.
-        @param AD_User_ID
-        User within the system - Internal or Business Partner Contact
-        Overridden to allow saving System record (zero ID)
-        http://wiki.idempiere.org/en/System_user
-	 */
-	@Override
-	public void setAD_User_ID (int AD_User_ID)
-	{
-		if (AD_User_ID == 0) 
-			set_ValueNoCheck (COLUMNNAME_AD_User_ID, AD_User_ID);
-		else 
-			super.setAD_User_ID(AD_User_ID);
-	} //setAD_User_ID
 
 }

--- a/org.adempiere.base/src/org/compiere/model/MPreference.java
+++ b/org.adempiere.base/src/org/compiere/model/MPreference.java
@@ -30,7 +30,7 @@ public class MPreference extends X_AD_Preference
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = -8935876328996934527L;
+	private static final long serialVersionUID = -3831004323199130018L;
 
 	/**	Null Indicator				*/
 	public static String		NULL = "null";
@@ -108,19 +108,5 @@ public class MPreference extends X_AD_Preference
 			.append ("]");
 		return sb.toString ();
 	}	//	toString
-
-	/** Set User/Contact.
-        @param AD_User_ID
-        User within the system - Internal or Business Partner Contact
-        Overridden to allow saving System record (zero ID)
-	 */
-	@Override
-	public void setAD_User_ID (int AD_User_ID)
-	{
-		if (AD_User_ID == SystemIDs.USER_SYSTEM_DEPRECATED) 
-			set_ValueNoCheck (COLUMNNAME_AD_User_ID, AD_User_ID);
-		else 
-			super.setAD_User_ID(AD_User_ID);
-	} //setAD_User_ID
 
 }	//	MPreference

--- a/org.adempiere.base/src/org/compiere/model/MUserPreference.java
+++ b/org.adempiere.base/src/org/compiere/model/MUserPreference.java
@@ -31,12 +31,12 @@ import java.util.Properties;
 import org.compiere.util.Env;
 
 public class MUserPreference extends X_AD_UserPreference {
-	/**
+    /**
 	 * 
 	 */
-	private static final long serialVersionUID = -5816348717625872665L;
+	private static final long serialVersionUID = 4313636387666521703L;
 
-    /**
+	/**
     * UUID based Constructor
     * @param ctx  Context
     * @param AD_UserPreference_UU  UUID key
@@ -55,20 +55,6 @@ public class MUserPreference extends X_AD_UserPreference {
 	{
 		super(ctx, rs, trxName);
 	} //MUserPreference
-
-	/** Set User/Contact.
-	    @param AD_User_ID
-	    User within the system - Internal or Business Partner Contact
-	    Overridden to allow saving System record (zero ID)
-	 */
-	@Override
-	public void setAD_User_ID (int AD_User_ID)
-	{
-		if (AD_User_ID == SystemIDs.USER_SYSTEM_DEPRECATED) 
-			set_ValueNoCheck (COLUMNNAME_AD_User_ID, AD_User_ID);
-		else 
-			super.setAD_User_ID(AD_User_ID);
-	} //setAD_User_ID
 
 	private static MUserPreference createUserPreferences(int AD_User_ID, int AD_Client_ID, String trxName){
 		MUserPreference preferences = new MUserPreference(Env.getCtx(), 0, trxName);

--- a/org.adempiere.base/src/org/compiere/model/MUserQuery.java
+++ b/org.adempiere.base/src/org/compiere/model/MUserQuery.java
@@ -40,7 +40,7 @@ public class MUserQuery extends X_AD_UserQuery
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = 488522350853249825L;
+	private static final long serialVersionUID = -7615897105314639570L;
 
 	/**
 	 * 	Get all active queries of client for Tab
@@ -355,19 +355,5 @@ public class MUserQuery extends X_AD_UserQuery
 
 		return !getCode().startsWith("@SQL=");
 	}
-
-	/** Set User/Contact.
-        @param AD_User_ID
-        User within the system - Internal or Business Partner Contact
-        Overridden to allow saving System record (zero ID)
-	 */
-	@Override
-	public void setAD_User_ID (int AD_User_ID)
-	{
-		if (AD_User_ID == SystemIDs.USER_SYSTEM_DEPRECATED) 
-			set_ValueNoCheck (COLUMNNAME_AD_User_ID, AD_User_ID);
-		else 
-			super.setAD_User_ID(AD_User_ID);
-	} //setAD_User_ID
 
 }	//	MUserQuery

--- a/org.adempiere.base/src/org/compiere/model/MUserRoles.java
+++ b/org.adempiere.base/src/org/compiere/model/MUserRoles.java
@@ -35,7 +35,7 @@ public class MUserRoles extends X_AD_User_Roles
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = 5850010835736994376L;
+	private static final long serialVersionUID = 2957269818448823135L;
 
 	/**
 	 * 	Get User Roles Of Role
@@ -123,20 +123,6 @@ public class MUserRoles extends X_AD_User_Roles
 		setAD_User_ID(AD_User_ID);
 		setAD_Role_ID(AD_Role_ID);
 	}	//	MUserRoles
-
-	/** Set User/Contact.
-        @param AD_User_ID
-        User within the system - Internal or Business Partner Contact
-        Overridden to allow saving System record (zero ID)
-	 */
-	@Override
-	public void setAD_User_ID (int AD_User_ID)
-	{
-		if (AD_User_ID == SystemIDs.USER_SYSTEM_DEPRECATED) 
-			set_ValueNoCheck (COLUMNNAME_AD_User_ID, AD_User_ID);
-		else 
-			super.setAD_User_ID(AD_User_ID);
-	} //setAD_User_ID
 
 	/** 
 	 * 	Set Role.

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/ADTabpanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/ADTabpanel.java
@@ -1577,7 +1577,7 @@ DataStatusListener, IADTabpanel, IdSpace, IFieldEditorContainer
     			if (preference == null || preference.getAD_Preference_ID() <= 0) {
     				preference = new MPreference(Env.getCtx(), 0, null);
     				preference.setAD_Window_ID(windowId);
-    				preference.setAD_User_ID(userId); // allow System
+    				preference.setAD_User_ID(userId);
     				preference.setAttribute(adTabId+"|DetailPane.IsOpen");
     			}
 				preference.setValue(value ? "Y" : "N");

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/desktop/DashboardController.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/desktop/DashboardController.java
@@ -1283,7 +1283,7 @@ public class DashboardController implements EventListener<Event> {
 			MDashboardPreference preference = new MDashboardPreference(Env.getCtx(), 0, null);
 			preference.setAD_Org_ID(0);
 			preference.setAD_Role_ID(AD_Role_ID);
-			preference.setAD_User_ID(AD_User_ID); // allow System
+			preference.setAD_User_ID(AD_User_ID);
 			preference.setColumnNo(dc.getColumnNo());
 			preference.setIsCollapsedByDefault(dc.isCollapsedByDefault());
 			preference.setIsShowInDashboard(dc.isShowInDashboard());
@@ -1316,7 +1316,7 @@ public class DashboardController implements EventListener<Event> {
 				MDashboardPreference preference = new MDashboardPreference(ctx,0, null);
 				preference.setAD_Org_ID(0);
 				preference.setAD_Role_ID(Env.getAD_Role_ID(ctx));
-				preference.setAD_User_ID(Env.getAD_User_ID(ctx));  // allow System
+				preference.setAD_User_ID(Env.getAD_User_ID(ctx));
 				preference.setColumnNo(dcs[i].getColumnNo());
 				preference.setIsCollapsedByDefault(dcs[i].isCollapsedByDefault());
 				preference.setIsShowInDashboard(dcs[i].isShowInDashboard());

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/desktop/DefaultDesktop.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/desktop/DefaultDesktop.java
@@ -510,7 +510,7 @@ public class DefaultDesktop extends TabbedDesktop implements MenuListener, Seria
         	
         	if ( preference == null || preference.getAD_Preference_ID() <= 0 ) {        		
         		preference = new MPreference(Env.getCtx(), 0, null);
-        		preference.setAD_User_ID(userId); // allow System
+        		preference.setAD_User_ID(userId);
         		preference.setAttribute(SIDE_CONTROLLER_WIDTH_PREFERENCE);
         	}
         	preference.setValue(width);
@@ -558,7 +558,7 @@ public class DefaultDesktop extends TabbedDesktop implements MenuListener, Seria
         	
         	if ( preference == null || preference.getAD_Preference_ID() <= 0 ) {        		
         		preference = new MPreference(Env.getCtx(), 0, null);
-        		preference.setAD_User_ID(userId); // allow System
+        		preference.setAD_User_ID(userId);
         		preference.setAttribute(HELP_CONTROLLER_WIDTH_PREFERENCE);
         	}
         	preference.setValue(width);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/util/UserPreference.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/util/UserPreference.java
@@ -105,7 +105,7 @@ public final class UserPreference implements Serializable {
 	 * save user preference
 	 */
 	public void savePreference() {
-		if (m_AD_User_ID >= 0) {
+		if (m_AD_User_ID > 0) {
 			Query query = new Query(Env.getCtx(), I_AD_Preference.Table_Name, "NVL(AD_User_ID,0) = ? AND Attribute = ? AND AD_Window_ID Is NULL AND AD_Process_ID IS NULL AND PreferenceFor = 'W'", null);
 			for (int i = 0; i < PROPERTIES.length; i++) {
 				String attribute = PROPERTIES[i];

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/FindWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/FindWindow.java
@@ -2555,7 +2555,7 @@ public class FindWindow extends Window implements EventListener<Event>, ValueCha
 						uq = new MUserQuery (Env.getCtx(), 0, null);
 						uq.setName (name);
 						uq.setAD_Tab_ID(m_AD_Tab_ID); //red1 UserQuery [ 1798539 ] taking in new field from Compiere
-						uq.setAD_User_ID(Env.getAD_User_ID(Env.getCtx())); // allow System
+						uq.setAD_User_ID(Env.getAD_User_ID(Env.getCtx()));
 					}
 					if (shareAllUsers)
 						uq.setAD_User_ID(-1); // set to null

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WGadgets.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WGadgets.java
@@ -427,7 +427,7 @@ public class WGadgets extends Window implements  EventListener<Event>{
 					pre = new MDashboardPreference(Env.getCtx(), 0, null);
 					pre.setAD_Org_ID(0);
 					pre.setAD_Role_ID(AD_Role_ID);
-					pre.setAD_User_ID(AD_User_ID); // allow System
+					pre.setAD_User_ID(AD_User_ID);
 					pre.setColumnNo(content.getColumnNo());
 					pre.setIsCollapsedByDefault(content.isCollapsedByDefault());
 					pre.setIsShowInDashboard(content.isShowInDashboard());
@@ -442,7 +442,7 @@ public class WGadgets extends Window implements  EventListener<Event>{
 					pre = new MDashboardPreference(Env.getCtx(), 0, null);
 					pre.setAD_Org_ID(0);
 					pre.setAD_Role_ID(AD_Role_ID);
-					pre.setAD_User_ID(AD_User_ID); // allow System
+					pre.setAD_User_ID(AD_User_ID);
 					pre.setColumnNo(content.getColumnNo());
 					pre.setIsCollapsedByDefault(content.isCollapsedByDefault());
 					pre.setIsShowInDashboard(content.isShowInDashboard());


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5843

Noticed there are still records being created wrongly with AD_Preference.AD_User_ID=0, that lead to the window not being editable.

IDEMPIERE-5174 / Revert changes from IDEMPIERE-4386

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
