### PR TITLE
IDEMPIERE-5567 Support of UUID as Key (FHCA-4195) - AD_PInstance

### DIFF
--- a/migration/iD11/oracle/202309111733_IDEMPIERE-5567_TestProcess.sql
+++ b/migration/iD11/oracle/202309111733_IDEMPIERE-5567_TestProcess.sql
@@ -1,0 +1,18 @@
+-- IDEMPIERE-5567 Support of UUID as Key (FHCA-4195)
+SELECT register_migration_script('202309111733_IDEMPIERE-5567_TestProcess.sql') FROM dual;
+
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Sep 11, 2023, 5:33:43 PM CEST
+INSERT INTO AD_Process (AD_Process_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Name,IsReport,Value,IsDirectPrint,Classname,AccessLevel,EntityType,Statistic_Count,Statistic_Seconds,IsBetaFunctionality,ShowHelp,CopyFromProcess,AD_Process_UU,AllowMultipleExecution) VALUES (200155,0,0,'Y',TO_TIMESTAMP('2023-09-11 17:33:43','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-09-11 17:33:43','YYYY-MM-DD HH24:MI:SS'),100,'Switch Active Flag on this Test UU and its Details','N','TestUUChangeActive','N','org.idempiere.process.TestUUChangeActive','7','D',0,0,'N','Y','N','eb8d0521-c103-433d-9cad-071968a4d923','P')
+;
+
+-- Sep 11, 2023, 5:34:00 PM CEST
+INSERT INTO AD_ToolBarButton (AD_Client_ID,AD_Org_ID,Created,CreatedBy,ComponentName,IsActive,AD_ToolBarButton_ID,Name,Updated,UpdatedBy,IsCustomization,AD_ToolBarButton_UU,Action,AD_Tab_ID,AD_Process_ID,SeqNo,EntityType) VALUES (0,0,TO_TIMESTAMP('2023-09-11 17:34:00','YYYY-MM-DD HH24:MI:SS'),100,'TestUUChangeActive','Y',200132,'TestUUChangeActive',TO_TIMESTAMP('2023-09-11 17:34:00','YYYY-MM-DD HH24:MI:SS'),100,'N','89679ad7-dead-4697-b7be-5f1080071fd3','W',200348,200155,10,'D')
+;
+
+-- Sep 11, 2023, 6:03:39 PM CEST
+UPDATE AD_Process SET ShowHelp='S',Updated=TO_TIMESTAMP('2023-09-11 18:03:39','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Process_ID=200155
+;
+

--- a/migration/iD11/oracle/202309111844_IDEMPIERE-5567_ADPInstance.sql
+++ b/migration/iD11/oracle/202309111844_IDEMPIERE-5567_ADPInstance.sql
@@ -1,0 +1,179 @@
+-- IDEMPIERE-5567 Support of UUID as Key (FHCA-4195)
+SELECT register_migration_script('202309111844_IDEMPIERE-5567_ADPInstance.sql') FROM dual;
+
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Sep 11, 2023, 6:44:35 PM CEST
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,FKConstraintType,IsHtml) VALUES (215912,0,'Table','Database Table information','The Database Table provides the information of the table definition',282,'AD_Table_ID',10,'N','N','N','N','N',0,'N',19,0,0,'Y',TO_TIMESTAMP('2023-09-11 18:44:34','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-09-11 18:44:34','YYYY-MM-DD HH24:MI:SS'),100,126,'Y','N','D','N','N','N','Y','2f7ad2ed-750c-40b9-b12a-8c47b58d3b42','Y',0,'N','N','N','N')
+;
+
+-- Sep 11, 2023, 6:45:53 PM CEST
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,FKConstraintType,IsHtml) VALUES (215913,0,'Record UUID',282,'Record_UU',36,'N','N','N','N','N',0,'N',200240,0,0,'Y',TO_TIMESTAMP('2023-09-11 18:45:52','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-09-11 18:45:52','YYYY-MM-DD HH24:MI:SS'),100,203804,'N','N','D','N','N','N','Y','a6104789-a5da-42e5-bfab-0c188630bbf1','Y',0,'N','N','D','N')
+;
+
+-- Sep 11, 2023, 6:46:17 PM CEST
+UPDATE AD_Column SET AD_Reference_ID=200202, FKConstraintType='D',Updated=TO_TIMESTAMP('2023-09-11 18:46:17','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=2782
+;
+
+-- Sep 11, 2023, 6:46:29 PM CEST
+UPDATE AD_Column SET IsUpdateable='N',Updated=TO_TIMESTAMP('2023-09-11 18:46:29','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=215912
+;
+
+-- Sep 11, 2023, 6:48:04 PM CEST
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (207720,'Name','Alphanumeric identifier of the entity','The name of an entity (record) is used as an default search option in addition to the search key. The name is up to 60 characters in length.',663,210890,'Y',60,170,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-09-11 18:48:04','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-09-11 18:48:04','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','bfef1933-138a-4c2e-a0f0-9b4e2f722939','Y',170,5)
+;
+
+-- Sep 11, 2023, 6:48:04 PM CEST
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (207721,'Table','Database Table information','The Database Table provides the information of the table definition',663,215912,'Y',10,180,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-09-11 18:48:04','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-09-11 18:48:04','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','f271284f-7b1d-4e78-86b3-0433b4d4b5f4','Y',180,2)
+;
+
+-- Sep 11, 2023, 6:48:05 PM CEST
+INSERT INTO AD_Field (AD_Field_ID,Name,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (207722,'Record UUID',663,215913,'Y',36,190,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-09-11 18:48:04','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-09-11 18:48:04','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','16d8bd0a-2133-4a94-99c9-c8f16bca5ced','Y',190,2)
+;
+
+-- Sep 11, 2023, 6:49:24 PM CEST
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=60, XPosition=1,Updated=TO_TIMESTAMP('2023-09-11 18:49:24','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207721
+;
+
+-- Sep 11, 2023, 6:49:24 PM CEST
+UPDATE AD_Field SET IsDisplayed='Y', DisplayLogic='@Record_UU@=''''', SeqNo=70, XPosition=4,Updated=TO_TIMESTAMP('2023-09-11 18:49:24','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=10494
+;
+
+-- Sep 11, 2023, 6:49:24 PM CEST
+UPDATE AD_Field SET IsDisplayed='Y', DisplayLogic='@Record_UU@!''''', SeqNo=80, XPosition=4,Updated=TO_TIMESTAMP('2023-09-11 18:49:24','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207722
+;
+
+-- Sep 11, 2023, 6:49:24 PM CEST
+UPDATE AD_Field SET SeqNo=90,Updated=TO_TIMESTAMP('2023-09-11 18:49:24','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=10497
+;
+
+-- Sep 11, 2023, 6:49:25 PM CEST
+UPDATE AD_Field SET SeqNo=100,Updated=TO_TIMESTAMP('2023-09-11 18:49:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=10500
+;
+
+-- Sep 11, 2023, 6:49:25 PM CEST
+UPDATE AD_Field SET SeqNo=110,Updated=TO_TIMESTAMP('2023-09-11 18:49:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=10501
+;
+
+-- Sep 11, 2023, 6:49:25 PM CEST
+UPDATE AD_Field SET SeqNo=120,Updated=TO_TIMESTAMP('2023-09-11 18:49:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207416
+;
+
+-- Sep 11, 2023, 6:49:25 PM CEST
+UPDATE AD_Field SET SeqNo=130,Updated=TO_TIMESTAMP('2023-09-11 18:49:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=10495
+;
+
+-- Sep 11, 2023, 6:49:25 PM CEST
+UPDATE AD_Field SET SeqNo=140,Updated=TO_TIMESTAMP('2023-09-11 18:49:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=202845
+;
+
+-- Sep 11, 2023, 6:49:25 PM CEST
+UPDATE AD_Field SET SeqNo=150,Updated=TO_TIMESTAMP('2023-09-11 18:49:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=202847
+;
+
+-- Sep 11, 2023, 6:49:25 PM CEST
+UPDATE AD_Field SET SeqNo=160,Updated=TO_TIMESTAMP('2023-09-11 18:49:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207405
+;
+
+-- Sep 11, 2023, 6:49:25 PM CEST
+UPDATE AD_Field SET SeqNo=170,Updated=TO_TIMESTAMP('2023-09-11 18:49:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207407
+;
+
+-- Sep 11, 2023, 6:49:25 PM CEST
+UPDATE AD_Field SET SeqNo=180,Updated=TO_TIMESTAMP('2023-09-11 18:49:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207406
+;
+
+-- Sep 11, 2023, 6:49:25 PM CEST
+UPDATE AD_Field SET SeqNo=190,Updated=TO_TIMESTAMP('2023-09-11 18:49:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207408
+;
+
+-- Sep 11, 2023, 6:49:25 PM CEST
+UPDATE AD_Field SET DisplayLogic='@Name@!''''', SeqNo=200,Updated=TO_TIMESTAMP('2023-09-11 18:49:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207720
+;
+
+-- Sep 12, 2023, 12:15:31 PM CEST
+UPDATE AD_Column SET FKConstraintName='ADTable_ADPInstance', FKConstraintType='N',Updated=TO_TIMESTAMP('2023-09-12 12:15:31','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=215912
+;
+
+-- Sep 12, 2023, 12:15:31 PM CEST
+ALTER TABLE AD_PInstance ADD AD_Table_ID NUMBER(10) DEFAULT NULL 
+;
+
+-- Sep 12, 2023, 12:15:31 PM CEST
+ALTER TABLE AD_PInstance ADD CONSTRAINT ADTable_ADPInstance FOREIGN KEY (AD_Table_ID) REFERENCES ad_table(ad_table_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Sep 12, 2023, 12:15:56 PM CEST
+ALTER TABLE AD_PInstance ADD Record_UU VARCHAR2(36 CHAR) DEFAULT NULL 
+;
+
+-- Sep 12, 2023, 12:29:54 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Table_ID:0@>0',Updated=TO_TIMESTAMP('2023-09-12 12:29:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207721
+;
+
+-- Sep 12, 2023, 3:40:47 PM CEST
+UPDATE AD_Field SET DisplayLogic='(@Record_UU@='''' & @Record_ID@>0) | (@Record_UU@='''' & @AD_Table_ID@>0)',Updated=TO_TIMESTAMP('2023-09-12 15:40:47','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=10494
+;
+
+-- set AD_Table_ID from related column
+CREATE INDEX tmp_deleteme20230912 ON AD_Column (AD_Process_ID);
+
+UPDATE AD_PInstance
+SET AD_Table_ID = (SELECT DISTINCT AD_Table_ID FROM AD_Column WHERE AD_Column.AD_Process_ID=AD_PInstance.AD_Process_ID)
+WHERE Record_ID > 0 AND AD_Table_ID IS NULL
+AND (SELECT COUNT(DISTINCT AD_Table_ID) FROM AD_Column WHERE AD_Column.AD_Process_ID=AD_PInstance.AD_Process_ID) = 1;
+
+DROP INDEX tmp_deleteme20230912;
+
+-- set AD_Table_ID from related toolbar button
+UPDATE AD_PInstance
+SET AD_Table_ID = (SELECT DISTINCT AD_Tab.AD_Table_ID FROM AD_ToolbarButton JOIN AD_Tab ON (AD_Tab.AD_Tab_ID=AD_ToolbarButton.AD_Tab_ID) WHERE AD_ToolbarButton.AD_Process_ID=AD_PInstance.AD_Process_ID)
+WHERE Record_ID > 0 AND AD_Table_ID IS NULL
+AND (SELECT COUNT(DISTINCT AD_Tab.AD_Table_ID) FROM AD_ToolbarButton JOIN AD_Tab ON (AD_Tab.AD_Tab_ID=AD_ToolbarButton.AD_Tab_ID) WHERE AD_ToolbarButton.AD_Process_ID=AD_PInstance.AD_Process_ID) = 1;
+
+-- set AD_Table_ID from hardcoded reports
+UPDATE AD_PInstance SET AD_Table_ID = 259 /* C_Order */ WHERE Record_ID > 0 AND AD_Table_ID IS NULL AND AD_Process_ID = 110 /* Rpt C_Order */;
+
+UPDATE AD_PInstance SET AD_Table_ID = 318 /* C_Invoice */ WHERE Record_ID > 0 AND AD_Table_ID IS NULL AND AD_Process_ID = 116 /* Rpt C_Invoice */;
+
+UPDATE AD_PInstance SET AD_Table_ID = 319 /* M_InOut */ WHERE Record_ID > 0 AND AD_Table_ID IS NULL AND AD_Process_ID = 117 /* Rpt M_InOut */;
+
+UPDATE AD_PInstance SET AD_Table_ID = 301 /* C_Dunning */ WHERE Record_ID > 0 AND AD_Table_ID IS NULL AND AD_Process_ID = 159 /* Rpt C_Dunning */;
+
+UPDATE AD_PInstance SET AD_Table_ID = 203 /* C_Project */ WHERE Record_ID > 0 AND AD_Table_ID IS NULL AND AD_Process_ID = 217 /* Rpt C_Project */;
+
+UPDATE AD_PInstance SET AD_Table_ID = 674 /* C_RfQResponse */ WHERE Record_ID > 0 AND AD_Table_ID IS NULL AND AD_Process_ID = 276 /* Rpt C_RfQResponse */;
+
+UPDATE AD_PInstance SET AD_Table_ID = 727 /* M_InOutConfirm */ WHERE Record_ID > 0 AND AD_Table_ID IS NULL AND AD_Process_ID = 292 /* Rpt M_InOutConfirm */;
+
+UPDATE AD_PInstance SET AD_Table_ID = 335 /* C_Payment */ WHERE Record_ID > 0 AND AD_Table_ID IS NULL AND AD_Process_ID = 313 /* Rpt C_Payment */;
+
+UPDATE AD_PInstance SET AD_Table_ID = 53027 /* PP_Order */ WHERE Record_ID > 0 AND AD_Table_ID IS NULL AND AD_Process_ID = 53028 /* Rpt PP_Order */;
+
+UPDATE AD_PInstance SET AD_Table_ID = 53037 /* DD_Order */ WHERE Record_ID > 0 AND AD_Table_ID IS NULL AND AD_Process_ID = 53044 /* Rpt DD_Order */;
+
+-- set AD_Table_ID from report view
+UPDATE AD_PInstance
+SET AD_Table_ID = (SELECT AD_ReportView.AD_Table_ID FROM AD_ReportView JOIN AD_Process ON (AD_Process.AD_ReportView_ID=AD_ReportView.AD_ReportView_ID) WHERE AD_Process.AD_Process_ID=AD_PInstance.AD_Process_ID)
+WHERE Record_ID > 0 AND AD_Table_ID IS NULL
+AND EXISTS (SELECT AD_ReportView.AD_Table_ID FROM AD_ReportView JOIN AD_Process ON (AD_Process.AD_ReportView_ID=AD_ReportView.AD_ReportView_ID) WHERE AD_Process.AD_Process_ID=AD_PInstance.AD_Process_ID);
+
+-- set AD_Table_ID from table of print format
+UPDATE AD_PInstance
+SET AD_Table_ID = (SELECT AD_PrintFormat.AD_Table_ID FROM AD_PrintFormat JOIN AD_Process ON (AD_Process.AD_PrintFormat_ID=AD_PrintFormat.AD_PrintFormat_ID) WHERE AD_Process.AD_Process_ID=AD_PInstance.AD_Process_ID AND AD_PrintFormat.AD_Table_ID > 0)
+WHERE Record_ID > 0 AND AD_Table_ID IS NULL
+AND EXISTS (SELECT AD_PrintFormat.AD_Table_ID FROM AD_PrintFormat JOIN AD_Process ON (AD_Process.AD_PrintFormat_ID=AD_PrintFormat.AD_PrintFormat_ID) WHERE AD_Process.AD_Process_ID=AD_PInstance.AD_Process_ID AND AD_PrintFormat.AD_Table_ID > 0);
+
+-- set AD_Table_ID from table of jasper print format
+UPDATE AD_PInstance
+SET AD_Table_ID = (SELECT DISTINCT AD_PrintFormat.AD_Table_ID FROM AD_PrintFormat JOIN AD_Process ON (AD_PrintFormat.JasperProcess_ID=AD_Process.AD_Process_ID) WHERE AD_Process.AD_Process_ID=AD_PInstance.AD_Process_ID AND AD_PrintFormat.AD_Table_ID > 0)
+WHERE Record_ID > 0 AND AD_Table_ID IS NULL
+AND (SELECT COUNT(DISTINCT AD_PrintFormat.AD_Table_ID) FROM AD_PrintFormat JOIN AD_Process ON (AD_PrintFormat.JasperProcess_ID=AD_Process.AD_Process_ID) WHERE AD_Process.AD_Process_ID=AD_PInstance.AD_Process_ID AND AD_PrintFormat.AD_Table_ID > 0) = 1;
+
+-- set AD_Table_ID from info window process
+UPDATE AD_PInstance
+SET AD_Table_ID = (SELECT AD_InfoWindow.AD_Table_ID FROM AD_InfoProcess JOIN AD_InfoWindow ON (AD_InfoProcess.AD_InfoWindow_ID=AD_InfoWindow.AD_InfoWindow_ID) WHERE AD_InfoProcess.AD_Process_ID=AD_PInstance.AD_Process_ID)
+WHERE Record_ID > 0 AND AD_Table_ID IS NULL
+AND EXISTS (SELECT AD_InfoWindow.AD_Table_ID FROM AD_InfoProcess JOIN AD_InfoWindow ON (AD_InfoProcess.AD_InfoWindow_ID=AD_InfoWindow.AD_InfoWindow_ID) WHERE AD_InfoProcess.AD_Process_ID=AD_PInstance.AD_Process_ID);
+

--- a/migration/iD11/postgresql/202309111733_IDEMPIERE-5567_TestProcess.sql
+++ b/migration/iD11/postgresql/202309111733_IDEMPIERE-5567_TestProcess.sql
@@ -1,0 +1,15 @@
+-- IDEMPIERE-5567 Support of UUID as Key (FHCA-4195)
+SELECT register_migration_script('202309111733_IDEMPIERE-5567_TestProcess.sql') FROM dual;
+
+-- Sep 11, 2023, 5:33:43 PM CEST
+INSERT INTO AD_Process (AD_Process_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Name,IsReport,Value,IsDirectPrint,Classname,AccessLevel,EntityType,Statistic_Count,Statistic_Seconds,IsBetaFunctionality,ShowHelp,CopyFromProcess,AD_Process_UU,AllowMultipleExecution) VALUES (200155,0,0,'Y',TO_TIMESTAMP('2023-09-11 17:33:43','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-09-11 17:33:43','YYYY-MM-DD HH24:MI:SS'),100,'Switch Active Flag on this Test UU and its Details','N','TestUUChangeActive','N','org.idempiere.process.TestUUChangeActive','7','D',0,0,'N','Y','N','eb8d0521-c103-433d-9cad-071968a4d923','P')
+;
+
+-- Sep 11, 2023, 5:34:00 PM CEST
+INSERT INTO AD_ToolBarButton (AD_Client_ID,AD_Org_ID,Created,CreatedBy,ComponentName,IsActive,AD_ToolBarButton_ID,Name,Updated,UpdatedBy,IsCustomization,AD_ToolBarButton_UU,"action",AD_Tab_ID,AD_Process_ID,SeqNo,EntityType) VALUES (0,0,TO_TIMESTAMP('2023-09-11 17:34:00','YYYY-MM-DD HH24:MI:SS'),100,'TestUUChangeActive','Y',200132,'TestUUChangeActive',TO_TIMESTAMP('2023-09-11 17:34:00','YYYY-MM-DD HH24:MI:SS'),100,'N','89679ad7-dead-4697-b7be-5f1080071fd3','W',200348,200155,10,'D')
+;
+
+-- Sep 11, 2023, 6:03:39 PM CEST
+UPDATE AD_Process SET ShowHelp='S',Updated=TO_TIMESTAMP('2023-09-11 18:03:39','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Process_ID=200155
+;
+

--- a/migration/iD11/postgresql/202309111844_IDEMPIERE-5567_ADPInstance.sql
+++ b/migration/iD11/postgresql/202309111844_IDEMPIERE-5567_ADPInstance.sql
@@ -1,0 +1,176 @@
+- IDEMPIERE-5567 Support of UUID as Key (FHCA-4195)
+SELECT register_migration_script('202309111844_IDEMPIERE-5567_ADPInstance.sql') FROM dual;
+
+-- Sep 11, 2023, 6:44:35 PM CEST
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,FKConstraintType,IsHtml) VALUES (215912,0,'Table','Database Table information','The Database Table provides the information of the table definition',282,'AD_Table_ID',10,'N','N','N','N','N',0,'N',19,0,0,'Y',TO_TIMESTAMP('2023-09-11 18:44:34','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-09-11 18:44:34','YYYY-MM-DD HH24:MI:SS'),100,126,'Y','N','D','N','N','N','Y','2f7ad2ed-750c-40b9-b12a-8c47b58d3b42','Y',0,'N','N','N','N')
+;
+
+-- Sep 11, 2023, 6:45:53 PM CEST
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,FKConstraintType,IsHtml) VALUES (215913,0,'Record UUID',282,'Record_UU',36,'N','N','N','N','N',0,'N',200240,0,0,'Y',TO_TIMESTAMP('2023-09-11 18:45:52','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-09-11 18:45:52','YYYY-MM-DD HH24:MI:SS'),100,203804,'N','N','D','N','N','N','Y','a6104789-a5da-42e5-bfab-0c188630bbf1','Y',0,'N','N','D','N')
+;
+
+-- Sep 11, 2023, 6:46:17 PM CEST
+UPDATE AD_Column SET AD_Reference_ID=200202, FKConstraintType='D',Updated=TO_TIMESTAMP('2023-09-11 18:46:17','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=2782
+;
+
+-- Sep 11, 2023, 6:46:29 PM CEST
+UPDATE AD_Column SET IsUpdateable='N',Updated=TO_TIMESTAMP('2023-09-11 18:46:29','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=215912
+;
+
+-- Sep 11, 2023, 6:48:04 PM CEST
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (207720,'Name','Alphanumeric identifier of the entity','The name of an entity (record) is used as an default search option in addition to the search key. The name is up to 60 characters in length.',663,210890,'Y',60,170,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-09-11 18:48:04','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-09-11 18:48:04','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','bfef1933-138a-4c2e-a0f0-9b4e2f722939','Y',170,5)
+;
+
+-- Sep 11, 2023, 6:48:04 PM CEST
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (207721,'Table','Database Table information','The Database Table provides the information of the table definition',663,215912,'Y',10,180,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-09-11 18:48:04','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-09-11 18:48:04','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','f271284f-7b1d-4e78-86b3-0433b4d4b5f4','Y',180,2)
+;
+
+-- Sep 11, 2023, 6:48:05 PM CEST
+INSERT INTO AD_Field (AD_Field_ID,Name,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (207722,'Record UUID',663,215913,'Y',36,190,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-09-11 18:48:04','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-09-11 18:48:04','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','16d8bd0a-2133-4a94-99c9-c8f16bca5ced','Y',190,2)
+;
+
+-- Sep 11, 2023, 6:49:24 PM CEST
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=60, XPosition=1,Updated=TO_TIMESTAMP('2023-09-11 18:49:24','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207721
+;
+
+-- Sep 11, 2023, 6:49:24 PM CEST
+UPDATE AD_Field SET IsDisplayed='Y', DisplayLogic='@Record_UU@=''''', SeqNo=70, XPosition=4,Updated=TO_TIMESTAMP('2023-09-11 18:49:24','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=10494
+;
+
+-- Sep 11, 2023, 6:49:24 PM CEST
+UPDATE AD_Field SET IsDisplayed='Y', DisplayLogic='@Record_UU@!''''', SeqNo=80, XPosition=4,Updated=TO_TIMESTAMP('2023-09-11 18:49:24','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207722
+;
+
+-- Sep 11, 2023, 6:49:24 PM CEST
+UPDATE AD_Field SET SeqNo=90,Updated=TO_TIMESTAMP('2023-09-11 18:49:24','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=10497
+;
+
+-- Sep 11, 2023, 6:49:25 PM CEST
+UPDATE AD_Field SET SeqNo=100,Updated=TO_TIMESTAMP('2023-09-11 18:49:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=10500
+;
+
+-- Sep 11, 2023, 6:49:25 PM CEST
+UPDATE AD_Field SET SeqNo=110,Updated=TO_TIMESTAMP('2023-09-11 18:49:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=10501
+;
+
+-- Sep 11, 2023, 6:49:25 PM CEST
+UPDATE AD_Field SET SeqNo=120,Updated=TO_TIMESTAMP('2023-09-11 18:49:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207416
+;
+
+-- Sep 11, 2023, 6:49:25 PM CEST
+UPDATE AD_Field SET SeqNo=130,Updated=TO_TIMESTAMP('2023-09-11 18:49:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=10495
+;
+
+-- Sep 11, 2023, 6:49:25 PM CEST
+UPDATE AD_Field SET SeqNo=140,Updated=TO_TIMESTAMP('2023-09-11 18:49:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=202845
+;
+
+-- Sep 11, 2023, 6:49:25 PM CEST
+UPDATE AD_Field SET SeqNo=150,Updated=TO_TIMESTAMP('2023-09-11 18:49:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=202847
+;
+
+-- Sep 11, 2023, 6:49:25 PM CEST
+UPDATE AD_Field SET SeqNo=160,Updated=TO_TIMESTAMP('2023-09-11 18:49:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207405
+;
+
+-- Sep 11, 2023, 6:49:25 PM CEST
+UPDATE AD_Field SET SeqNo=170,Updated=TO_TIMESTAMP('2023-09-11 18:49:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207407
+;
+
+-- Sep 11, 2023, 6:49:25 PM CEST
+UPDATE AD_Field SET SeqNo=180,Updated=TO_TIMESTAMP('2023-09-11 18:49:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207406
+;
+
+-- Sep 11, 2023, 6:49:25 PM CEST
+UPDATE AD_Field SET SeqNo=190,Updated=TO_TIMESTAMP('2023-09-11 18:49:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207408
+;
+
+-- Sep 11, 2023, 6:49:25 PM CEST
+UPDATE AD_Field SET DisplayLogic='@Name@!''''', SeqNo=200,Updated=TO_TIMESTAMP('2023-09-11 18:49:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207720
+;
+
+-- Sep 12, 2023, 12:15:31 PM CEST
+UPDATE AD_Column SET FKConstraintName='ADTable_ADPInstance', FKConstraintType='N',Updated=TO_TIMESTAMP('2023-09-12 12:15:31','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=215912
+;
+
+-- Sep 12, 2023, 12:15:31 PM CEST
+ALTER TABLE AD_PInstance ADD COLUMN AD_Table_ID NUMERIC(10) DEFAULT NULL 
+;
+
+-- Sep 12, 2023, 12:15:31 PM CEST
+ALTER TABLE AD_PInstance ADD CONSTRAINT ADTable_ADPInstance FOREIGN KEY (AD_Table_ID) REFERENCES ad_table(ad_table_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Sep 12, 2023, 12:15:56 PM CEST
+ALTER TABLE AD_PInstance ADD COLUMN Record_UU VARCHAR(36) DEFAULT NULL 
+;
+
+-- Sep 12, 2023, 12:29:54 PM CEST
+UPDATE AD_Field SET DisplayLogic='@AD_Table_ID:0@>0',Updated=TO_TIMESTAMP('2023-09-12 12:29:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207721
+;
+
+-- Sep 12, 2023, 3:40:47 PM CEST
+UPDATE AD_Field SET DisplayLogic='(@Record_UU@='''' & @Record_ID@>0) | (@Record_UU@='''' & @AD_Table_ID@>0)',Updated=TO_TIMESTAMP('2023-09-12 15:40:47','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=10494
+;
+
+-- set AD_Table_ID from related column
+CREATE INDEX tmp_deleteme20230912 ON AD_Column (AD_Process_ID);
+
+UPDATE AD_PInstance
+SET AD_Table_ID = (SELECT DISTINCT AD_Table_ID FROM AD_Column WHERE AD_Column.AD_Process_ID=AD_PInstance.AD_Process_ID)
+WHERE Record_ID > 0 AND AD_Table_ID IS NULL
+AND (SELECT COUNT(DISTINCT AD_Table_ID) FROM AD_Column WHERE AD_Column.AD_Process_ID=AD_PInstance.AD_Process_ID) = 1;
+
+DROP INDEX tmp_deleteme20230912;
+
+-- set AD_Table_ID from related toolbar button
+UPDATE AD_PInstance
+SET AD_Table_ID = (SELECT DISTINCT AD_Tab.AD_Table_ID FROM AD_ToolbarButton JOIN AD_Tab ON (AD_Tab.AD_Tab_ID=AD_ToolbarButton.AD_Tab_ID) WHERE AD_ToolbarButton.AD_Process_ID=AD_PInstance.AD_Process_ID)
+WHERE Record_ID > 0 AND AD_Table_ID IS NULL
+AND (SELECT COUNT(DISTINCT AD_Tab.AD_Table_ID) FROM AD_ToolbarButton JOIN AD_Tab ON (AD_Tab.AD_Tab_ID=AD_ToolbarButton.AD_Tab_ID) WHERE AD_ToolbarButton.AD_Process_ID=AD_PInstance.AD_Process_ID) = 1;
+
+-- set AD_Table_ID from hardcoded reports
+UPDATE AD_PInstance SET AD_Table_ID = 259 /* C_Order */ WHERE Record_ID > 0 AND AD_Table_ID IS NULL AND AD_Process_ID = 110 /* Rpt C_Order */;
+
+UPDATE AD_PInstance SET AD_Table_ID = 318 /* C_Invoice */ WHERE Record_ID > 0 AND AD_Table_ID IS NULL AND AD_Process_ID = 116 /* Rpt C_Invoice */;
+
+UPDATE AD_PInstance SET AD_Table_ID = 319 /* M_InOut */ WHERE Record_ID > 0 AND AD_Table_ID IS NULL AND AD_Process_ID = 117 /* Rpt M_InOut */;
+
+UPDATE AD_PInstance SET AD_Table_ID = 301 /* C_Dunning */ WHERE Record_ID > 0 AND AD_Table_ID IS NULL AND AD_Process_ID = 159 /* Rpt C_Dunning */;
+
+UPDATE AD_PInstance SET AD_Table_ID = 203 /* C_Project */ WHERE Record_ID > 0 AND AD_Table_ID IS NULL AND AD_Process_ID = 217 /* Rpt C_Project */;
+
+UPDATE AD_PInstance SET AD_Table_ID = 674 /* C_RfQResponse */ WHERE Record_ID > 0 AND AD_Table_ID IS NULL AND AD_Process_ID = 276 /* Rpt C_RfQResponse */;
+
+UPDATE AD_PInstance SET AD_Table_ID = 727 /* M_InOutConfirm */ WHERE Record_ID > 0 AND AD_Table_ID IS NULL AND AD_Process_ID = 292 /* Rpt M_InOutConfirm */;
+
+UPDATE AD_PInstance SET AD_Table_ID = 335 /* C_Payment */ WHERE Record_ID > 0 AND AD_Table_ID IS NULL AND AD_Process_ID = 313 /* Rpt C_Payment */;
+
+UPDATE AD_PInstance SET AD_Table_ID = 53027 /* PP_Order */ WHERE Record_ID > 0 AND AD_Table_ID IS NULL AND AD_Process_ID = 53028 /* Rpt PP_Order */;
+
+UPDATE AD_PInstance SET AD_Table_ID = 53037 /* DD_Order */ WHERE Record_ID > 0 AND AD_Table_ID IS NULL AND AD_Process_ID = 53044 /* Rpt DD_Order */;
+
+-- set AD_Table_ID from report view
+UPDATE AD_PInstance
+SET AD_Table_ID = (SELECT AD_ReportView.AD_Table_ID FROM AD_ReportView JOIN AD_Process ON (AD_Process.AD_ReportView_ID=AD_ReportView.AD_ReportView_ID) WHERE AD_Process.AD_Process_ID=AD_PInstance.AD_Process_ID)
+WHERE Record_ID > 0 AND AD_Table_ID IS NULL
+AND EXISTS (SELECT AD_ReportView.AD_Table_ID FROM AD_ReportView JOIN AD_Process ON (AD_Process.AD_ReportView_ID=AD_ReportView.AD_ReportView_ID) WHERE AD_Process.AD_Process_ID=AD_PInstance.AD_Process_ID);
+
+-- set AD_Table_ID from table of print format
+UPDATE AD_PInstance
+SET AD_Table_ID = (SELECT AD_PrintFormat.AD_Table_ID FROM AD_PrintFormat JOIN AD_Process ON (AD_Process.AD_PrintFormat_ID=AD_PrintFormat.AD_PrintFormat_ID) WHERE AD_Process.AD_Process_ID=AD_PInstance.AD_Process_ID AND AD_PrintFormat.AD_Table_ID > 0)
+WHERE Record_ID > 0 AND AD_Table_ID IS NULL
+AND EXISTS (SELECT AD_PrintFormat.AD_Table_ID FROM AD_PrintFormat JOIN AD_Process ON (AD_Process.AD_PrintFormat_ID=AD_PrintFormat.AD_PrintFormat_ID) WHERE AD_Process.AD_Process_ID=AD_PInstance.AD_Process_ID AND AD_PrintFormat.AD_Table_ID > 0);
+
+-- set AD_Table_ID from table of jasper print format
+UPDATE AD_PInstance
+SET AD_Table_ID = (SELECT DISTINCT AD_PrintFormat.AD_Table_ID FROM AD_PrintFormat JOIN AD_Process ON (AD_PrintFormat.JasperProcess_ID=AD_Process.AD_Process_ID) WHERE AD_Process.AD_Process_ID=AD_PInstance.AD_Process_ID AND AD_PrintFormat.AD_Table_ID > 0)
+WHERE Record_ID > 0 AND AD_Table_ID IS NULL
+AND (SELECT COUNT(DISTINCT AD_PrintFormat.AD_Table_ID) FROM AD_PrintFormat JOIN AD_Process ON (AD_PrintFormat.JasperProcess_ID=AD_Process.AD_Process_ID) WHERE AD_Process.AD_Process_ID=AD_PInstance.AD_Process_ID AND AD_PrintFormat.AD_Table_ID > 0) = 1;
+
+-- set AD_Table_ID from info window process
+UPDATE AD_PInstance
+SET AD_Table_ID = (SELECT AD_InfoWindow.AD_Table_ID FROM AD_InfoProcess JOIN AD_InfoWindow ON (AD_InfoProcess.AD_InfoWindow_ID=AD_InfoWindow.AD_InfoWindow_ID) WHERE AD_InfoProcess.AD_Process_ID=AD_PInstance.AD_Process_ID)
+WHERE Record_ID > 0 AND AD_Table_ID IS NULL
+AND EXISTS (SELECT AD_InfoWindow.AD_Table_ID FROM AD_InfoProcess JOIN AD_InfoWindow ON (AD_InfoProcess.AD_InfoWindow_ID=AD_InfoWindow.AD_InfoWindow_ID) WHERE AD_InfoProcess.AD_Process_ID=AD_PInstance.AD_Process_ID);
+

--- a/org.adempiere.base.process/src/org/compiere/process/CreateWindowFromTable.java
+++ b/org.adempiere.base.process/src/org/compiere/process/CreateWindowFromTable.java
@@ -202,9 +202,9 @@ public class CreateWindowFromTable extends SvrProcess
 					tab.get_Table_ID(), tab.getAD_Tab_ID());
 
 			//Create Fields
-			ProcessInfo processInfo = new ProcessInfo("", SystemIDs.PROCESS_AD_TAB_CREATEFIELDS, 0, tab.getAD_Tab_ID());
+			ProcessInfo processInfo = new ProcessInfo("", SystemIDs.PROCESS_AD_TAB_CREATEFIELDS, MTab.Table_ID, tab.getAD_Tab_ID(), tab.getAD_Tab_UU());
 
-			MPInstance instance = new MPInstance(getCtx(), SystemIDs.PROCESS_AD_TAB_CREATEFIELDS, 0);
+			MPInstance instance = new MPInstance(getCtx(), SystemIDs.PROCESS_AD_TAB_CREATEFIELDS, MTab.Table_ID, tab.getAD_Tab_ID(), tab.getAD_Tab_UU());
 			instance.saveEx();
 			processInfo.setAD_PInstance_ID(instance.getAD_PInstance_ID());
 

--- a/org.adempiere.base.process/src/org/idempiere/process/TestUUChangeActive.java
+++ b/org.adempiere.base.process/src/org/idempiere/process/TestUUChangeActive.java
@@ -1,0 +1,88 @@
+/**********************************************************************
+* This file is part of iDempiere ERP Open Source                      *
+* http://www.idempiere.org                                            *
+*                                                                     *
+* Copyright (C) Contributors                                          *
+*                                                                     *
+* This program is free software; you can redistribute it and/or       *
+* modify it under the terms of the GNU General Public License         *
+* as published by the Free Software Foundation; either version 2      *
+* of the License, or (at your option) any later version.              *
+*                                                                     *
+* This program is distributed in the hope that it will be useful,     *
+* but WITHOUT ANY WARRANTY; without even the implied warranty of      *
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the        *
+* GNU General Public License for more details.                        *
+*                                                                     *
+* You should have received a copy of the GNU General Public License   *
+* along with this program; if not, write to the Free Software         *
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,          *
+* MA 02110-1301, USA.                                                 *
+*                                                                     *
+* Contributors:                                                       *
+* - Carlos Ruiz                                                       *
+**********************************************************************/
+package org.idempiere.process;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+
+import org.compiere.model.MProcessPara;
+import org.compiere.model.MTestUU;
+import org.compiere.model.Query;
+import org.compiere.model.X_TestUUDet;
+import org.compiere.process.ProcessInfoParameter;
+import org.compiere.process.SvrProcess;
+
+/**
+ * @author Carlos Ruiz - globalqss - bx-service
+ */
+@org.adempiere.base.annotation.Process
+public class TestUUChangeActive extends SvrProcess {
+
+	List<String> m_UUIDs;
+
+	/**
+	 * Prepare - e.g., get Parameters.
+	 */
+	protected void prepare() {
+		for (ProcessInfoParameter para : getParameter()) {
+			MProcessPara.validateUnknownParameter(getProcessInfo().getAD_Process_ID(), para);
+		}
+		m_UUIDs = getRecord_UUs();
+		if (m_UUIDs == null || m_UUIDs.size() == 0) {
+			m_UUIDs = new ArrayList<String>();
+			m_UUIDs.add(getRecord_UU());
+		}
+
+	} // prepare
+
+	/**
+	 * Perform process.
+	 * 
+	 * @return Message
+	 * @throws Exception
+	 */
+	protected String doIt() throws Exception {
+		if (log.isLoggable(Level.INFO))
+			log.info("");
+
+		for (String l_UUID : m_UUIDs) {
+			MTestUU testuu = new MTestUU(getCtx(), l_UUID, get_TrxName());
+			boolean setActive = ! testuu.isActive();
+			testuu.setIsActive(setActive);
+			testuu.saveEx();
+			List<X_TestUUDet> dets = new Query(getCtx(), X_TestUUDet.Table_Name, X_TestUUDet.COLUMNNAME_TestUU_UU+"=?", get_TrxName())
+				.setParameters(l_UUID)
+				.list();
+			for (X_TestUUDet det : dets) {
+				det.setIsActive(setActive);
+				det.saveEx();
+			}
+		}
+
+		return "@OK@";
+	} // doIt
+
+} // TestUUChangeActive

--- a/org.adempiere.base/src/org/adempiere/base/PackInFolderApplication.java
+++ b/org.adempiere.base/src/org/adempiere/base/PackInFolderApplication.java
@@ -74,7 +74,7 @@ public class PackInFolderApplication implements IApplication {
 			ProcessInfo pi = new ProcessInfo("PackInFolder", 200099);
 			pi.setAD_Client_ID(0);
 			pi.setAD_User_ID(SystemIDs.USER_SUPERUSER);
-			MPInstance instance = new MPInstance(ctx, 200099, 0);
+			MPInstance instance = new MPInstance(ctx, 200099, 0, 0, null);
 			instance.saveEx();
 			instance.createParameter(10, "Folder", directory);
 			pi.setAD_PInstance_ID(instance.getAD_PInstance_ID());

--- a/org.adempiere.base/src/org/compiere/install/Translation.java
+++ b/org.adempiere.base/src/org/compiere/install/Translation.java
@@ -561,7 +561,7 @@ public class Translation implements IApplication
 			ProcessInfo pi = new ProcessInfo("Synchronize Terminology", 172);
 			pi.setAD_Client_ID(0);
 			pi.setAD_User_ID(100);
-			MPInstance instance = new MPInstance(Env.getCtx(), 172, 0);
+			MPInstance instance = new MPInstance(Env.getCtx(), 172, -1, 0, null);
 			instance.saveEx();
 			pi.setAD_PInstance_ID(instance.getAD_PInstance_ID());
 			/*

--- a/org.adempiere.base/src/org/compiere/model/GridTab.java
+++ b/org.adempiere.base/src/org/compiere/model/GridTab.java
@@ -113,7 +113,7 @@ public class GridTab implements DataStatusListener, Evaluatee, Serializable
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = 4674027561845549215L;
+	private static final long serialVersionUID = 3039046293468517959L;
 
 	public static final String DEFAULT_STATUS_MESSAGE = "NavigateOrUpdate";
 
@@ -2455,7 +2455,17 @@ public class GridTab implements DataStatusListener, Evaluatee, Serializable
 	public int getKeyID (int row)
 	{
 		return m_mTable.getKeyID (row);
-	}   //  getCurrentKeyID
+	}   //  getKeyID
+
+	/**
+	 *  Get Key UUID of row
+	 *  @param  row row number
+	 *  @return The Key UUID of the row or -1 if not found
+	 */
+	public String getKeyUUID (int row)
+	{
+		return m_mTable.getKeyUUID (row);
+	}   //  getKeyUUID
 
 	/**
 	 *  Navigate absolute - goto Row - (zero based).

--- a/org.adempiere.base/src/org/compiere/model/I_AD_PInstance.java
+++ b/org.adempiere.base/src/org/compiere/model/I_AD_PInstance.java
@@ -140,6 +140,21 @@ public interface I_AD_PInstance
 
 	public org.compiere.model.I_AD_Session getAD_Session() throws RuntimeException;
 
+    /** Column name AD_Table_ID */
+    public static final String COLUMNNAME_AD_Table_ID = "AD_Table_ID";
+
+	/** Set Table.
+	  * Database Table information
+	  */
+	public void setAD_Table_ID (int AD_Table_ID);
+
+	/** Get Table.
+	  * Database Table information
+	  */
+	public int getAD_Table_ID();
+
+	public org.compiere.model.I_AD_Table getAD_Table() throws RuntimeException;
+
     /** Column name AD_User_ID */
     public static final String COLUMNNAME_AD_User_ID = "AD_User_ID";
 
@@ -262,6 +277,15 @@ public interface I_AD_PInstance
 	  * Direct internal record ID
 	  */
 	public int getRecord_ID();
+
+    /** Column name Record_UU */
+    public static final String COLUMNNAME_Record_UU = "Record_UU";
+
+	/** Set Record UUID	  */
+	public void setRecord_UU (String Record_UU);
+
+	/** Get Record UUID	  */
+	public String getRecord_UU();
 
     /** Column name ReportType */
     public static final String COLUMNNAME_ReportType = "ReportType";

--- a/org.adempiere.base/src/org/compiere/model/MPInstance.java
+++ b/org.adempiere.base/src/org/compiere/model/MPInstance.java
@@ -110,12 +110,27 @@ public class MPInstance extends X_AD_PInstance
 	 * 	Create Process Instance from Process and create parameters
 	 *	@param process process
 	 *	@param Record_ID Record
+	 *  @deprecated Please use {@link #MPInstance(MProcess, int, int, String)}
 	 */
 	public MPInstance (MProcess process, int Record_ID)
 	{
+		this(process, -1, Record_ID, null);
+	}
+
+	/**
+	 * 	Create Process Instance from Process and create parameters
+	 *	@param process process
+	 *  @param Table_ID
+	 *	@param Record_ID Record
+	 *  @param Record_UU
+	 */
+	public MPInstance (MProcess process, int Table_ID, int Record_ID, String Record_UU)
+	{
 		this (process.getCtx(), 0, null);
 		setAD_Process_ID (process.getAD_Process_ID());
+		setAD_Table_ID(Table_ID);
 		setRecord_ID (Record_ID);
+		setRecord_UU(Record_UU);
 		setAD_User_ID(Env.getAD_User_ID(process.getCtx()));
 		if (!save())		//	need to save for parameters
 			throw new IllegalArgumentException ("Cannot Save");
@@ -135,12 +150,26 @@ public class MPInstance extends X_AD_PInstance
 	 *	@param ctx context
 	 *	@param AD_Process_ID Process ID
 	 *	@param Record_ID record
+	 *  @deprecated Please use {@link #MPInstance(Properties, int, int, int, String)}
 	 */
 	public MPInstance (Properties ctx, int AD_Process_ID, int Record_ID)
 	{
+		this(ctx, AD_Process_ID, -1, Record_ID, null);
+	}
+
+	/**
+	 * 	New Constructor
+	 *	@param ctx context
+	 *	@param AD_Process_ID Process ID
+	 *	@param Record_ID record
+	 */
+	public MPInstance (Properties ctx, int AD_Process_ID, int Table_ID, int Record_ID, String Record_UU)
+	{
 		this(ctx, 0, null);
 		setAD_Process_ID (AD_Process_ID);
+		setAD_Table_ID(Table_ID);
 		setRecord_ID (Record_ID);
+		setRecord_UU(Record_UU);
 		setAD_User_ID(Env.getAD_User_ID(ctx));
 		setIsProcessing (false);
 	}	//	MPInstance

--- a/org.adempiere.base/src/org/compiere/model/MProcess.java
+++ b/org.adempiere.base/src/org/compiere/model/MProcess.java
@@ -301,6 +301,7 @@ public class MProcess extends X_AD_Process implements ImmutablePOSupport
 	 *	@param trx transaction
 	 *	@return Process Instance
 	 */
+	@Deprecated
 	public MPInstance processIt (int Record_ID, Trx trx)
 	{
 		return processIt(Record_ID, trx, true);
@@ -312,6 +313,7 @@ public class MProcess extends X_AD_Process implements ImmutablePOSupport
 	 *	@param trx transaction
 	 *	@return Process Instance
 	 */
+	@Deprecated
 	public MPInstance processIt (int Record_ID, Trx trx, boolean managedTrx)
 	{
 		MPInstance pInstance = new MPInstance (getCtx(), this.getAD_Process_ID(), Record_ID);
@@ -357,7 +359,7 @@ public class MProcess extends X_AD_Process implements ImmutablePOSupport
 	{
 		if (pi.getAD_PInstance_ID() == 0)
 		{
-			MPInstance pInstance = new MPInstance (getCtx(), this.getAD_Process_ID(), pi.getRecord_ID());
+			MPInstance pInstance = new MPInstance (getCtx(), this.getAD_Process_ID(), pi.getTable_ID(), pi.getRecord_ID(), pi.getRecord_UU());
 			//	Lock
 			pInstance.setIsProcessing(true);
 			pInstance.saveEx();

--- a/org.adempiere.base/src/org/compiere/model/X_AD_PInstance.java
+++ b/org.adempiere.base/src/org/compiere/model/X_AD_PInstance.java
@@ -31,7 +31,7 @@ public class X_AD_PInstance extends PO implements I_AD_PInstance, I_Persistent
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20230409L;
+	private static final long serialVersionUID = 20230912L;
 
     /** Standard Constructor */
     public X_AD_PInstance (Properties ctx, int AD_PInstance_ID, String trxName)
@@ -277,6 +277,34 @@ public class X_AD_PInstance extends PO implements I_AD_PInstance, I_Persistent
 		return ii.intValue();
 	}
 
+	public org.compiere.model.I_AD_Table getAD_Table() throws RuntimeException
+	{
+		return (org.compiere.model.I_AD_Table)MTable.get(getCtx(), org.compiere.model.I_AD_Table.Table_ID)
+			.getPO(getAD_Table_ID(), get_TrxName());
+	}
+
+	/** Set Table.
+		@param AD_Table_ID Database Table information
+	*/
+	public void setAD_Table_ID (int AD_Table_ID)
+	{
+		if (AD_Table_ID < 1)
+			set_ValueNoCheck (COLUMNNAME_AD_Table_ID, null);
+		else
+			set_ValueNoCheck (COLUMNNAME_AD_Table_ID, Integer.valueOf(AD_Table_ID));
+	}
+
+	/** Get Table.
+		@return Database Table information
+	  */
+	public int getAD_Table_ID()
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_AD_Table_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
 	public org.compiere.model.I_AD_User getAD_User() throws RuntimeException
 	{
 		return (org.compiere.model.I_AD_User)MTable.get(getCtx(), org.compiere.model.I_AD_User.Table_ID)
@@ -450,6 +478,21 @@ public class X_AD_PInstance extends PO implements I_AD_PInstance, I_Persistent
 		if (ii == null)
 			 return 0;
 		return ii.intValue();
+	}
+
+	/** Set Record UUID.
+		@param Record_UU Record UUID
+	*/
+	public void setRecord_UU (String Record_UU)
+	{
+		set_ValueNoCheck (COLUMNNAME_Record_UU, Record_UU);
+	}
+
+	/** Get Record UUID.
+		@return Record UUID	  */
+	public String getRecord_UU()
+	{
+		return (String)get_Value(COLUMNNAME_Record_UU);
 	}
 
 	/** Set Report Type.

--- a/org.adempiere.base/src/org/compiere/process/ProcessInfo.java
+++ b/org.adempiere.base/src/org/compiere/process/ProcessInfo.java
@@ -54,7 +54,7 @@ public class ProcessInfo implements Serializable
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = -795798319865809959L;
+	private static final long serialVersionUID = 8134286335553869253L;
 
 	private static final CLogger logger = CLogger.getCLogger(ProcessInfo.class);
 
@@ -161,6 +161,9 @@ public class ProcessInfo implements Serializable
 	
 	/**	Record IDs				*/
 	private List <Integer>		m_Record_IDs = null;
+
+	/**	Record UUs				*/
+	private List <String>		m_Record_UUs = null;
 
 	/** Export					*/
 	private boolean				m_export = false;
@@ -991,6 +994,16 @@ public class ProcessInfo implements Serializable
 	public void setRecord_IDs(List<Integer> Record_IDs)
 	{
 		m_Record_IDs = Record_IDs;
+	}
+
+	public List<String> getRecord_UUs()
+	{
+		return m_Record_UUs;
+	}
+
+	public void setRecord_UUs(List<String> Record_UUs)
+	{
+		m_Record_UUs = Record_UUs;
 	}
 
 	public void setRowCount(int rowCount) {

--- a/org.adempiere.base/src/org/compiere/process/ServerProcessCtl.java
+++ b/org.adempiere.base/src/org/compiere/process/ServerProcessCtl.java
@@ -83,7 +83,7 @@ public class ServerProcessCtl implements Runnable {
 		{
 			try 
 			{ 
-				instance = new MPInstance(Env.getCtx(), pi.getAD_Process_ID(), pi.getRecord_ID()); 
+				instance = new MPInstance(Env.getCtx(), pi.getAD_Process_ID(), pi.getTable_ID(), pi.getRecord_ID(), pi.getRecord_UU()); 
 			} 
 			catch (Exception e) 
 			{ 

--- a/org.adempiere.base/src/org/compiere/process/SvrProcess.java
+++ b/org.adempiere.base/src/org/compiere/process/SvrProcess.java
@@ -503,6 +503,25 @@ public abstract class SvrProcess implements ProcessCall
 	} // getRecord_IDs
 
 	/**
+	 *  Get Record_UU
+	 *  @return Record_UU
+	 */
+	protected String getRecord_UU()
+	{
+		return m_pi.getRecord_UU();
+	}   //  getRecord_UU
+
+	/**
+	 * Get Record_UUs
+	 * 
+	 * @return Record_UUs
+	 */
+	protected List<String> getRecord_UUs() 
+	{
+		return m_pi.getRecord_UUs();
+	} // getRecord_UUs
+
+	/**
 	 *  Get AD_User_ID
 	 *  @return AD_User_ID of Process owner or -1 if not found
 	 */

--- a/org.adempiere.base/src/org/compiere/report/FinReportJasper.java
+++ b/org.adempiere.base/src/org/compiere/report/FinReportJasper.java
@@ -70,7 +70,7 @@ public class FinReportJasper extends FinReport
 		m_report = new MReport (getCtx(), getRecord_ID(), get_TrxName());
 
 		MProcess proc = new MProcess(getCtx(), m_report.getJasperProcess_ID(), get_TrxName());
-	    MPInstance instance = new MPInstance(getCtx(), proc.getAD_Process_ID(), getRecord_ID());
+	    MPInstance instance = new MPInstance(getCtx(), proc.getAD_Process_ID(), MReport.Table_ID, getRecord_ID(), getRecord_UU());
 	    instance.saveEx();
 	    ProcessInfo poInfo = new ProcessInfo(proc.getName(), proc.getAD_Process_ID());
 	    poInfo.setParameter(pars);

--- a/org.adempiere.base/src/org/compiere/wf/MWFActivity.java
+++ b/org.adempiere.base/src/org/compiere/wf/MWFActivity.java
@@ -1146,7 +1146,7 @@ public class MWFActivity extends X_AD_WF_Activity implements Runnable
 				getAD_Table_ID(), getRecord_ID());
 			pi.setAD_User_ID(getAD_User_ID());
 			pi.setAD_Client_ID(getAD_Client_ID());
-			MPInstance pInstance = new MPInstance(getCtx(), process.getAD_Process_ID(), getRecord_ID());
+			MPInstance pInstance = new MPInstance(getCtx(), process.getAD_Process_ID(), getAD_Table_ID(), getRecord_ID(), null); // TODO: Support WFActivity with Record_UU
 			pInstance.saveEx();
 			fillParameter(pInstance, trx);
 			pi.setAD_PInstance_ID(pInstance.getAD_PInstance_ID());
@@ -1176,7 +1176,7 @@ public class MWFActivity extends X_AD_WF_Activity implements Runnable
 			if (log.isLoggable(Level.FINE)) log.fine("Process:AD_Process_ID=" + m_node.getAD_Process_ID());
 			//	Process
 			MProcess process = MProcess.get(getCtx(), m_node.getAD_Process_ID());
-			MPInstance pInstance = new MPInstance(getCtx(), process.getAD_Process_ID(), getRecord_ID());
+			MPInstance pInstance = new MPInstance(getCtx(), process.getAD_Process_ID(), getAD_Table_ID(), getRecord_ID(), null); // TODO: Support WFActivity with Record_UU
 			pInstance.setIsProcessing(true);
 			pInstance.saveEx();
 			try {

--- a/org.adempiere.base/src/org/eevolution/process/EnableNativeSequence.java
+++ b/org.adempiere.base/src/org/eevolution/process/EnableNativeSequence.java
@@ -126,7 +126,7 @@ public class EnableNativeSequence extends SvrProcess
 		Properties ctx = Env.getCtx();
 		int AD_Process_ID = PROCESS_AD_NATIVE_SEQUENCE_ENABLE; // HARDCODED
 
-		MPInstance pinstance = new MPInstance(ctx, AD_Process_ID, -1);
+		MPInstance pinstance = new MPInstance(ctx, AD_Process_ID, 0, -1, null);
 		pinstance.saveEx();
 
 		ProcessInfo pi = new ProcessInfo("", AD_Process_ID, 0, 0);

--- a/org.adempiere.server/src/main/server/org/compiere/server/Scheduler.java
+++ b/org.adempiere.server/src/main/server/org/compiere/server/Scheduler.java
@@ -194,7 +194,7 @@ public class Scheduler extends AdempiereServer
 		int AD_Table_ID = scheduler.getAD_Table_ID();
 		int Record_ID = scheduler.getRecord_ID();
 		//
-		MPInstance pInstance = new MPInstance(getCtx(), process.getAD_Process_ID(), Record_ID);
+		MPInstance pInstance = new MPInstance(getCtx(), process.getAD_Process_ID(), AD_Table_ID, Record_ID, null); // TODO: Support Schedule with Record_UU
 		pInstance.saveEx();
 		fillParameter(pInstance);
 		//

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/AbstractADWindowContent.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/AbstractADWindowContent.java
@@ -3611,6 +3611,7 @@ public abstract class AbstractADWindowContent extends AbstractUIPart implements 
 		//	Record_ID
 
 		int record_ID = adtabPanel.getGridTab().getRecord_ID();
+		String record_UU = adtabPanel.getGridTab().getRecord_UU();
 
 		//	Record_ID - Language Handling
 
@@ -3805,6 +3806,7 @@ public abstract class AbstractADWindowContent extends AbstractUIPart implements 
 		}   //  Posted
 
 		final int finalRecordId = record_ID;
+		final String finalRecordUU = record_UU;
 		final Callback<Boolean> postCallback = new Callback<Boolean>() {
 			@Override
 			public void onCallback(Boolean result) {
@@ -3818,7 +3820,7 @@ public abstract class AbstractADWindowContent extends AbstractUIPart implements 
 			@Override
 			public void onCallback(Boolean result) {
 				if (result) {
-					executeButtonProcess(wButton, startWOasking, table_ID, finalRecordId, isProcessMandatory, postCallback);
+					executeButtonProcess(wButton, startWOasking, table_ID, finalRecordId, finalRecordUU, isProcessMandatory, postCallback);
 				}
 			}
 		};
@@ -3925,11 +3927,28 @@ public abstract class AbstractADWindowContent extends AbstractUIPart implements 
 	public void executeButtonProcess(final IProcessButton wButton,
 			final boolean startWOasking, final int table_ID, final int record_ID,
 			boolean isProcessMandatory, Callback<Boolean> callback) {
+		executeButtonProcess(wButton, startWOasking, table_ID, record_ID, null, isProcessMandatory, callback);
+	}
+
+	/**
+	 * Show process, form or info window dialog for button.
+	 * Delegate to {@link #executeButtonProcess0(IProcessButton, boolean, int, int)} or {@link #executionButtonInfoWindow0(IProcessButton)}.
+	 * @param wButton
+	 * @param startWOasking
+	 * @param table_ID
+	 * @param record_ID
+	 * @param record_UU
+	 * @param isProcessMandatory
+	 * @param callback 
+	 */
+	public void executeButtonProcess(final IProcessButton wButton,
+			final boolean startWOasking, final int table_ID, final int record_ID, final String record_UU,
+			boolean isProcessMandatory, Callback<Boolean> callback) {
 		/**
 		 *  Start Process ----
 		 */
 
-		if (logger.isLoggable(Level.CONFIG)) logger.config("Process_ID=" + wButton.getProcess_ID() + ", InfoWindow_ID=" + wButton.getInfoWindow_ID() + ", Record_ID=" + record_ID);
+		if (logger.isLoggable(Level.CONFIG)) logger.config("Process_ID=" + wButton.getProcess_ID() + ", InfoWindow_ID=" + wButton.getInfoWindow_ID() + ", Record_ID=" + record_ID + ", Record_UU=" + record_UU);
 
 		if (wButton.getProcess_ID() == 0 && wButton.getInfoWindow_ID() == 0)
 		{
@@ -3962,7 +3981,7 @@ public abstract class AbstractADWindowContent extends AbstractUIPart implements 
 			if (wButton.getInfoWindow_ID() > 0)
 				executionButtonInfoWindow0(wButton);
 			else
-				executeButtonProcess0(wButton, startWOasking, table_ID, record_ID, callback);
+				executeButtonProcess0(wButton, startWOasking, table_ID, record_ID, record_UU, callback);
 		}
 	}
 
@@ -3976,6 +3995,20 @@ public abstract class AbstractADWindowContent extends AbstractUIPart implements 
 	 */
 	private void executeButtonProcess0(final IProcessButton wButton,
 			boolean startWOasking, int table_ID, int record_ID, Callback<Boolean> callback) {
+		executeButtonProcess0(wButton, startWOasking, table_ID, record_ID, null, callback);	
+	}
+
+	/**
+	 * Show {@link ADForm} or {@link ProcessModalDialog}.
+	 * @param wButton
+	 * @param startWOasking
+	 * @param table_ID
+	 * @param record_ID
+	 * @param record_UU
+	 * @param callback 
+	 */
+	private void executeButtonProcess0(final IProcessButton wButton,
+			boolean startWOasking, int table_ID, int record_ID, String record_UU, Callback<Boolean> callback) {
 		// call form
 		MProcess pr = new MProcess(ctx, wButton.getProcess_ID(), null);
 		int adFormID = pr.getAD_Form_ID();
@@ -3984,7 +4017,7 @@ public abstract class AbstractADWindowContent extends AbstractUIPart implements 
 			String title = wButton.getDescription();
 			if (title == null || title.length() == 0)
 				title = wButton.getDisplay();							
-			ProcessInfo pi = new ProcessInfo (title, wButton.getProcess_ID(), table_ID, record_ID);
+			ProcessInfo pi = new ProcessInfo (title, wButton.getProcess_ID(), table_ID, record_ID, record_UU);
 			pi.setAD_User_ID (Env.getAD_User_ID(ctx));
 			pi.setAD_Client_ID (Env.getAD_Client_ID(ctx));
 			IADTabpanel adtabPanel = null;
@@ -4029,22 +4062,32 @@ public abstract class AbstractADWindowContent extends AbstractUIPart implements 
 			else
 				adtabPanel = findADTabpanel(wButton);
 
-			ProcessInfo pi = new ProcessInfo("", wButton.getProcess_ID(), table_ID, record_ID);
+			ProcessInfo pi = new ProcessInfo("", wButton.getProcess_ID(), table_ID, record_ID, record_UU);
 			if (adtabPanel != null && adtabPanel.isGridView() && adtabPanel.getGridTab() != null)
 			{
 				int[] indices = adtabPanel.getGridTab().getSelection();
 				if (indices.length > 0)
 				{
-					List<Integer> records = new ArrayList<Integer>();
-					for (int i = 0; i < indices.length; i++)
-					{
-						int keyID = adtabPanel.getGridTab().getKeyID(indices[i]);
-						if (keyID > 0)
-							records.add(keyID);
+					MTable table = MTable.get(adtabPanel.getGridTab().getAD_Table_ID());
+					if (table.isUUIDKeyTable()) {
+						List<String> records = new ArrayList<String>();
+						for (int i = 0; i < indices.length; i++) {
+							String keyUUID = adtabPanel.getGridTab().getKeyUUID(indices[i]);
+							if (!Util.isEmpty(keyUUID))
+								records.add(keyUUID);
+						}
+						pi.setRecord_UUs(records);
+					} else {
+						List<Integer> records = new ArrayList<Integer>();
+						for (int i = 0; i < indices.length; i++) {
+							int keyID = adtabPanel.getGridTab().getKeyID(indices[i]);
+							if (keyID > 0)
+								records.add(keyID);
+						}
+						// IDEMPIERE-3998 Set multiple selected grid records into process info
+						pi.setRecord_IDs(records);
 					}
 
-					// IDEMPIERE-3998 Set multiple selected grid records into process info
-					pi.setRecord_IDs(records);
 				}
 			}
 

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/AbstractProcessDialog.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/AbstractProcessDialog.java
@@ -854,7 +854,7 @@ public abstract class AbstractProcessDialog extends Window implements IProcessUI
 			MPInstance instance = null;
 			try {
 				instance = new MPInstance(Env.getCtx(),
-						getProcessInfo().getAD_Process_ID(), getProcessInfo().getRecord_ID());
+						getProcessInfo().getAD_Process_ID(), getProcessInfo().getTable_ID(), getProcessInfo().getRecord_ID(), getProcessInfo().getRecord_UU());
 				instance.setName(saveName);
 				saveReportOptionToInstance(instance);
 				instance.saveEx();
@@ -1089,7 +1089,7 @@ public abstract class AbstractProcessDialog extends Window implements IProcessUI
 			if (count >= MSysConfig.getIntValue(MSysConfig.BACKGROUND_JOB_MAX_IN_SYSTEM, 20))
 				throw new IllegalStateException(Msg.getMsg(m_ctx, "BackgroundJobExceedMaxInSystem"));
 			
-			instance = new MPInstance(m_ctx, m_pi.getAD_Process_ID(), m_pi.getRecord_ID());
+			instance = new MPInstance(m_ctx, m_pi.getAD_Process_ID(), m_pi.getTable_ID(), m_pi.getRecord_ID(), m_pi.getRecord_UU());
 			instance.setIsRunAsJob(true);
 			instance.setIsProcessing(true);
 			instance.setNotificationType(getNotificationType());

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/WProcessCtl.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/WProcessCtl.java
@@ -16,6 +16,8 @@
  *****************************************************************************/
 package org.adempiere.webui.apps;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.logging.Level;
 
 import org.adempiere.util.IProcessUI;
@@ -34,7 +36,9 @@ import org.compiere.util.CLogger;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
 import org.compiere.util.Msg;
+import org.compiere.util.NamePair;
 import org.compiere.util.Trx;
+import org.compiere.util.ValueNamePair;
 import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.Executions;
 import org.zkoss.zk.ui.event.Event;
@@ -83,7 +87,7 @@ public class WProcessCtl extends AbstractProcessCtl {
 			MPInstance instance = null;
 			try
 			{
-				instance = new MPInstance(Env.getCtx(), pi.getAD_Process_ID(), pi.getRecord_ID());
+				instance = new MPInstance(Env.getCtx(), pi.getAD_Process_ID(), pi.getTable_ID(), pi.getRecord_ID(), pi.getRecord_UU());
 			}
 			catch (Exception e)
 			{
@@ -160,7 +164,7 @@ public class WProcessCtl extends AbstractProcessCtl {
 		if (pi.getAD_PInstance_ID() < 1) { //red1 bypass if PInstance exists
 			try
 			{
-				instance = new MPInstance(Env.getCtx(), pi.getAD_Process_ID(), pi.getRecord_ID());
+				instance = new MPInstance(Env.getCtx(), pi.getAD_Process_ID(), pi.getTable_ID(), pi.getRecord_ID(), pi.getRecord_UU());
 			}
 			catch (Exception e)
 			{
@@ -197,12 +201,21 @@ public class WProcessCtl extends AbstractProcessCtl {
 			}
 		}
 
-		if (pi.getRecord_IDs() != null && pi.getRecord_IDs().size() > 0)
-		{
+		if (pi.getRecord_UUs() != null && pi.getRecord_UUs().size() > 0) {
+			Collection<NamePair> vnps = new ArrayList<NamePair>();
+			for (String uuid : pi.getRecord_UUs()) {
+				vnps.add(new ValueNamePair(uuid, ""));
+			}
+			DB.createT_SelectionNewNP(pi.getAD_PInstance_ID(), vnps, null);
+			MPInstancePara ip = instance.createParameter(-1, "*RecordUUs*", pi.getRecord_UUs().toString());
+			ip.saveEx();
+		} else if (pi.getRecord_IDs() != null && pi.getRecord_IDs().size() > 0) {
 			DB.createT_Selection(pi.getAD_PInstance_ID(), pi.getRecord_IDs(), null);
 			MPInstancePara ip = instance.createParameter(-1, "*RecordIDs*", pi.getRecord_IDs().toString());
 			ip.saveEx();
 		}
+		
+
 		
 		//	execute
 		WProcessCtl worker = new WProcessCtl(aProcessUI, WindowNo, pi, trx);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/desktop/DashboardController.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/desktop/DashboardController.java
@@ -1602,10 +1602,7 @@ public class DashboardController implements EventListener<Event> {
 			 throw new IllegalArgumentException("Not a Report AD_Process_ID=" + process.getAD_Process_ID()
 				+ " - " + process.getName());
 		//	Process
-		int AD_Table_ID = 0;
-		int Record_ID = 0;
-		//
-		MPInstance pInstance = new MPInstance(Env.getCtx(), AD_Process_ID, Record_ID);
+		MPInstance pInstance = new MPInstance(Env.getCtx(), AD_Process_ID, 0, 0, null);
 		if(AD_PrintFormat_ID > 0)
 			pInstance.setAD_PrintFormat_ID(AD_PrintFormat_ID);
 		pInstance.setIsProcessing(true);
@@ -1614,8 +1611,7 @@ public class DashboardController implements EventListener<Event> {
 			if(!fillParameter(pInstance, parameters))
 				return null;
 			//
-			ProcessInfo pi = new ProcessInfo (process.getName(), process.getAD_Process_ID(),
-				AD_Table_ID, Record_ID);
+			ProcessInfo pi = new ProcessInfo (process.getName(), process.getAD_Process_ID(), 0, 0);
 			pi.setAD_User_ID(Env.getAD_User_ID(Env.getCtx()));
 			pi.setAD_Client_ID(Env.getAD_Client_ID(Env.getCtx()));
 			pi.setAD_PInstance_ID(pInstance.getAD_PInstance_ID());		

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoPanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoPanel.java
@@ -2579,7 +2579,7 @@ public abstract class InfoPanel extends Window implements EventListener<Event>, 
 		m_pi.setAD_User_ID(Env.getAD_User_ID(Env.getCtx()));
 		m_pi.setAD_Client_ID(Env.getAD_Client_ID(Env.getCtx()));
 
-		MPInstance instance = new MPInstance(Env.getCtx(), processId, 0);
+		MPInstance instance = new MPInstance(Env.getCtx(), processId, 0, 0, null);
 		instance.saveEx();
 		final int pInstanceID = instance.getAD_PInstance_ID();
 		// devCoffee - enable use of special forms from process related with info windows

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/action/ReportAction.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/action/ReportAction.java
@@ -44,6 +44,7 @@ import org.adempiere.webui.window.Dialog;
 import org.compiere.model.GridTab;
 import org.compiere.model.MQuery;
 import org.compiere.model.MRole;
+import org.compiere.model.MTable;
 import org.compiere.model.PrintInfo;
 import org.compiere.print.MPrintFormat;
 import org.compiere.print.ReportCtl;
@@ -289,13 +290,17 @@ public class ReportAction implements EventListener<Event>
 		//	Query
 		boolean currentRowOnly = chkCurrentRowOnly.isChecked();
 		int Record_ID = 0;
+		String Record_UU = null;
 		List <Integer> RecordIDs = null;
+		List <String> RecordUUs = null;
 		MQuery query = new MQuery(gridTab.getTableName());
+		MTable table = MTable.get(gridTab.getAD_Table_ID());
 		StringBuilder whereClause = new StringBuilder("");
 
 		if (currentRowOnly)
 		{
 			Record_ID = gridTab.getRecord_ID();
+			Record_UU = gridTab.getRecord_UU();
 			whereClause.append(gridTab.getTableModel().getWhereClause(gridTab.getCurrentRow()));
 			if (whereClause.length() == 0)
 				whereClause.append(gridTab.getTableModel().getSelectWhereClause());
@@ -304,10 +309,16 @@ public class ReportAction implements EventListener<Event>
 		else
 		{
 			whereClause.append(gridTab.getTableModel().getSelectWhereClause());
-			RecordIDs = new ArrayList<Integer>();
-			for(int i = 0; i < gridTab.getRowCount(); i++)
-			{
-				RecordIDs.add(gridTab.getKeyID(i));
+			if (table.isUUIDKeyTable()) {
+				RecordUUs = new ArrayList<String>();
+				for(int i = 0; i < gridTab.getRowCount(); i++) {
+					RecordUUs.add(gridTab.getKeyUUID(i));
+				}
+			} else {
+				RecordIDs = new ArrayList<Integer>();
+				for(int i = 0; i < gridTab.getRowCount(); i++) {
+					RecordIDs.add(gridTab.getKeyID(i));
+				}
 			}
 		}
 
@@ -340,14 +351,15 @@ public class ReportAction implements EventListener<Event>
 
 		query.addRestriction(whereClause.toString());
 
-		PrintInfo info = new PrintInfo(pf.getName(), pf.getAD_Table_ID(), Record_ID);
+		PrintInfo info = new PrintInfo(pf.getName(), pf.getAD_Table_ID(), Record_ID, Record_UU);
 		info.setDescription(query.getInfo());
 		
 		if(pf != null && pf.getJasperProcess_ID() > 0)
 		{			
 			// It's a report using the JasperReports engine
-			ProcessInfo pi = new ProcessInfo ("", pf.getJasperProcess_ID(), pf.getAD_Table_ID(), Record_ID);
+			ProcessInfo pi = new ProcessInfo ("", pf.getJasperProcess_ID(), pf.getAD_Table_ID(), Record_ID, Record_UU);
 			pi.setRecord_IDs(RecordIDs);
+			pi.setRecord_UUs(RecordUUs);
 			//pi.setIsBatch(true);
 			
 			if (export)

--- a/org.idempiere.test/src/org/idempiere/test/base/InitialClientSetupTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/base/InitialClientSetupTest.java
@@ -65,7 +65,7 @@ public class InitialClientSetupTest extends AbstractTestCase {
 		int AD_Process_ID = 53161;
 		MProcess process = MProcess.get(AD_Process_ID);
 		
-		MPInstance pinstance = new MPInstance(process, 0);
+		MPInstance pinstance = new MPInstance(process, 0, 0, null);
 		MPInstancePara[] paras = pinstance.getParameters();
 		for (MPInstancePara para : paras) {
 			if (para.getParameterName().equals("ClientName")) {

--- a/org.idempiere.test/src/org/idempiere/test/base/QueryTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/base/QueryTest.java
@@ -366,7 +366,7 @@ public class QueryTest extends AbstractTestCase {
 		int count = DB.getSQLValueEx(null, "SELECT Count(AD_PInstance_ID) FROM AD_PInstance");
 		if (count == 0) {
 			//Generate Shipments (manual)
-			new MPInstance(MProcess.get(Env.getCtx(), 199), 0);
+			new MPInstance(MProcess.get(Env.getCtx(), 199), 0, 0, null);
 		}
 		
 		// Get one AD_PInstance_ID

--- a/org.idempiere.test/src/org/idempiere/test/commission/CommissionRunTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/commission/CommissionRunTest.java
@@ -147,7 +147,7 @@ public class CommissionRunTest extends AbstractTestCase {
 		assertEquals(DocAction.STATUS_Completed, creditMemo.getDocStatus(), "Credit Memo document status is not completed: " + creditMemo.getDocStatus());
 
 		MProcess process = MProcess.get(PROCESS_GENERATE_COMMISSION);
-		MPInstance pinstance = new MPInstance(process, 0);
+		MPInstance pinstance = new MPInstance(process, 0, 0, null);
 		MPInstancePara[] paras = pinstance.getParameters();
 		for (MPInstancePara para : paras) {
 			if (para.getParameterName().equals("StartDate")) {

--- a/org.idempiere.test/src/org/idempiere/test/form/PaySelectFormTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/form/PaySelectFormTest.java
@@ -164,8 +164,7 @@ public class PaySelectFormTest extends AbstractTestCase {
 			
 			//create pay selection check
 			int AD_Process_ID = SystemIDs.PROCESS_C_PAYSELECTION_CREATEPAYMENT;
-			MPInstance mpi = new MPInstance(Env.getCtx(), AD_Process_ID, 0);
-			mpi.setRecord_ID(paySelection.get_ID());
+			MPInstance mpi = new MPInstance(Env.getCtx(), AD_Process_ID, MPaySelection.Table_ID, paySelection.get_ID(), paySelection.getC_PaySelection_UU());
 			mpi.saveEx();
 			MPInstancePara para = new MPInstancePara(mpi, 10);
 			para.setParameter(MPaySelection.COLUMNNAME_IsOnePaymentPerInvoice, false);

--- a/org.idempiere.test/src/org/idempiere/test/model/InvoiceCustomerTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/InvoiceCustomerTest.java
@@ -222,7 +222,7 @@ public class InvoiceCustomerTest extends AbstractTestCase {
 		assertEquals(0, line1.getQtyInvoiced().intValue());
 
 		int AD_Process_ID = SystemIDs.PROCESS_C_INVOICE_GENERATE_MANUAL;
-		MPInstance instance = new MPInstance(Env.getCtx(), AD_Process_ID, 0);
+		MPInstance instance = new MPInstance(Env.getCtx(), AD_Process_ID, 0, 0, null);
 		instance.saveEx();
 		String insert = "INSERT INTO T_SELECTION(AD_PINSTANCE_ID, T_SELECTION_ID) Values (?, ?)";
 		DB.executeUpdateEx(insert, new Object[] {instance.getAD_PInstance_ID(), order.getC_Order_ID()}, null);
@@ -338,7 +338,7 @@ public class InvoiceCustomerTest extends AbstractTestCase {
 		assertEquals(DocAction.STATUS_Completed, rma.getDocStatus());
 
 		int AD_Process_ID = SystemIDs.PROCESS_C_INVOICE_GENERATERMA_MANUAL;
-		MPInstance instance = new MPInstance(Env.getCtx(), AD_Process_ID, 0);
+		MPInstance instance = new MPInstance(Env.getCtx(), AD_Process_ID, 0, 0, null);
 		instance.saveEx();
 		String insert = "INSERT INTO T_SELECTION(AD_PINSTANCE_ID, T_SELECTION_ID) Values (?, ?)";
 		DB.executeUpdateEx(insert, new Object[] {instance.getAD_PInstance_ID(), rma.get_ID()}, null);
@@ -434,7 +434,7 @@ public class InvoiceCustomerTest extends AbstractTestCase {
 		assertEquals(0, line2.getQtyInvoiced().intValue());
 
 		int AD_Process_ID = SystemIDs.PROCESS_C_INVOICE_GENERATE;
-		MPInstance instance = new MPInstance(Env.getCtx(), AD_Process_ID, 0);
+		MPInstance instance = new MPInstance(Env.getCtx(), AD_Process_ID, 0, 0, null);
 		instance.saveEx();
 
 		//call process

--- a/org.idempiere.test/src/org/idempiere/test/model/MStorageOnHandTestIsolated.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/MStorageOnHandTestIsolated.java
@@ -173,7 +173,7 @@ public class MStorageOnHandTestIsolated extends AbstractTestCase {
 			count = query.setParameters(product3.get_ID()).count();
 			assertEquals(1, count);
 			
-			MPInstance instance = new MPInstance(Env.getCtx(), SystemIDs.PROCESS_M_StorageCleanup, 0);
+			MPInstance instance = new MPInstance(Env.getCtx(), SystemIDs.PROCESS_M_StorageCleanup, 0, 0, null);
 			instance.saveEx();
 			MPInstancePara para = new MPInstancePara(instance, 10);
 			para.setParameterName("C_DocType_ID");

--- a/org.idempiere.test/src/org/idempiere/test/model/ProductionTestIsolated.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/ProductionTestIsolated.java
@@ -385,7 +385,7 @@ public class ProductionTestIsolated extends AbstractTestCase {
 			mulchX.setIsVerified(true);
 			mulchX.saveEx();
 			
-			MPInstance instance = new MPInstance(Env.getCtx(), rollUpProcessId, 0);
+			MPInstance instance = new MPInstance(Env.getCtx(), rollUpProcessId, 0, 0, null);
 			instance.saveEx();
 			MPInstancePara para = new MPInstancePara(instance, 10);
 			para.setParameterName("M_Product_ID");

--- a/org.idempiere.test/src/org/idempiere/test/model/PurchaseOrderTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/PurchaseOrderTest.java
@@ -648,7 +648,7 @@ public class PurchaseOrderTest extends AbstractTestCase {
 		assertEquals(DocAction.STATUS_Completed, rma.getDocStatus());
 		
 		int AD_Process_ID = PROCESS_M_INOUT_GENERATERMA_MANUAL;
-		MPInstance instance = new MPInstance(Env.getCtx(), AD_Process_ID, 0);
+		MPInstance instance = new MPInstance(Env.getCtx(), AD_Process_ID, 0, 0, null);
 		instance.saveEx();
 		
 		String insert = "INSERT INTO T_SELECTION(AD_PINSTANCE_ID, T_SELECTION_ID) Values (?, ?)";

--- a/org.idempiere.test/src/org/idempiere/test/model/SalesOrderTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/SalesOrderTest.java
@@ -449,7 +449,7 @@ public class SalesOrderTest extends AbstractTestCase {
 		assertEquals(1, line1.getQtyReserved().intValue());
 		
 		int AD_Process_ID = PROCESS_M_INOUT_GENERATE_MANUAL;
-		MPInstance instance = new MPInstance(Env.getCtx(), AD_Process_ID, 0);
+		MPInstance instance = new MPInstance(Env.getCtx(), AD_Process_ID, 0, 0, null);
 		instance.saveEx();
 		
 		String insert = "INSERT INTO T_SELECTION(AD_PINSTANCE_ID, T_SELECTION_ID) Values (?, ?)";
@@ -497,7 +497,7 @@ public class SalesOrderTest extends AbstractTestCase {
 		line1.load(getTrxName());
 		assertEquals(1, line1.getQtyReserved().intValue());
 		
-		instance = new MPInstance(Env.getCtx(), AD_Process_ID, 0);
+		instance = new MPInstance(Env.getCtx(), AD_Process_ID, 0, 0, null);
 		instance.saveEx();
 		DB.executeUpdateEx(insert, new Object[] {instance.getAD_PInstance_ID(), order1.getC_Order_ID()}, null);
 		
@@ -545,7 +545,7 @@ public class SalesOrderTest extends AbstractTestCase {
 		assertEquals(DocAction.STATUS_Completed, payment.getDocStatus());
 		
 		//call process with payment
-		instance = new MPInstance(Env.getCtx(), AD_Process_ID, 0);
+		instance = new MPInstance(Env.getCtx(), AD_Process_ID, 0, 0, null);
 		instance.saveEx();
 		DB.executeUpdateEx(insert, new Object[] {instance.getAD_PInstance_ID(), order1.getC_Order_ID()}, null);
 		pi = new ProcessInfo ("InOutGen", AD_Process_ID);
@@ -588,7 +588,7 @@ public class SalesOrderTest extends AbstractTestCase {
 		assertEquals(1, line1.getQtyReserved().intValue());
 		
 		//create invoice
-		instance = new MPInstance(Env.getCtx(), SystemIDs.PROCESS_C_INVOICE_GENERATE_MANUAL, 0);
+		instance = new MPInstance(Env.getCtx(), SystemIDs.PROCESS_C_INVOICE_GENERATE_MANUAL, 0, 0, null);
 		instance.saveEx();
 		DB.executeUpdateEx(insert, new Object[] {instance.getAD_PInstance_ID(), order2.getC_Order_ID()}, null);		
 		pi = new ProcessInfo ("InvoiceGenerateManual", AD_Process_ID);
@@ -629,7 +629,7 @@ public class SalesOrderTest extends AbstractTestCase {
 		assertEquals(DocAction.STATUS_Completed, payment.getDocStatus());
 		
 		//call process with payment
-		instance = new MPInstance(Env.getCtx(), AD_Process_ID, 0);
+		instance = new MPInstance(Env.getCtx(), AD_Process_ID, 0, 0, null);
 		instance.saveEx();
 		DB.executeUpdateEx(insert, new Object[] {instance.getAD_PInstance_ID(), order2.getC_Order_ID()}, null);
 		pi = new ProcessInfo ("InOutGen", AD_Process_ID);
@@ -732,7 +732,7 @@ public class SalesOrderTest extends AbstractTestCase {
 		
 		//generate shipment
 		int AD_Process_ID = PROCESS_M_INOUT_GENERATE_MANUAL;
-		MPInstance instance = new MPInstance(Env.getCtx(), AD_Process_ID, 0);
+		MPInstance instance = new MPInstance(Env.getCtx(), AD_Process_ID, 0, 0, null);
 		instance.saveEx();
 		
 		String insert = "INSERT INTO T_SELECTION(AD_PINSTANCE_ID, T_SELECTION_ID) Values (?, ?)";
@@ -1566,7 +1566,7 @@ public class SalesOrderTest extends AbstractTestCase {
 		assertEquals(DocAction.STATUS_Completed, order.getDocStatus());
 
 		int AD_Process_ID = PROCESS_M_INOUT_GENERATE_MANUAL;
-		MPInstance instance = new MPInstance(Env.getCtx(), AD_Process_ID, 0);
+		MPInstance instance = new MPInstance(Env.getCtx(), AD_Process_ID, 0, 0, null);
 		instance.saveEx();
 
 		String insert = "INSERT INTO T_SELECTION(AD_PINSTANCE_ID, T_SELECTION_ID) Values (?, ?)";

--- a/org.idempiere.webservices/WEB-INF/src/org/idempiere/adinterface/Process.java
+++ b/org.idempiere.webservices/WEB-INF/src/org/idempiere/adinterface/Process.java
@@ -488,7 +488,7 @@ public class Process {
 	
 	private static MPInstance fillParameter(CompiereService m_cs, DataRow dr, MProcess process, Map<String, Object> requestCtx) throws Exception
 	{
-		MPInstance pInstance = new MPInstance(Env.getCtx(), process.getAD_Process_ID(), 0);
+		MPInstance pInstance = new MPInstance(Env.getCtx(), process.getAD_Process_ID(), 0, 0, null);
 		pInstance.saveEx();
 		
 		DataField f[] = dr.getFieldArray();


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5567

- Implement support to run processes on UUID based tables
- Added SvrProcess.getRecord_UU and getRecord_UUs support
- Added TestUUChangeActive process as toolbar button on "Test UU Based Table" window - supports single and multi
- Added AD_PInstance.AD_Table_ID and AD_PInstance.Record_UU
- NOTE: the migration script tries the best to fill AD_PInstance.AD_Table_ID from different sources, but at the end is very possible that some records will be left with empty table
- The MPInstance constructors that don't manage AD_Table_ID were marked as deprecated to ease discovering the missing parts in plugins

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [x] I have made corresponding changes to the documentation as follows:
- - [x] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- [x] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

