### PR TITLE
IDEMPIERE-5567 Support of UUID as Key (FHCA-4195)

### DIFF
--- a/org.adempiere.base/src/org/adempiere/util/ModelClassGenerator.java
+++ b/org.adempiere.base/src/org/adempiere/util/ModelClassGenerator.java
@@ -194,33 +194,34 @@ public class ModelClassGenerator
 			 .append(String.format("%1$tY%1$tm%1$td", new Timestamp(System.currentTimeMillis())))
 		 	 .append("L;").append(NL);
 
-		 if (tableHasIds) {
-			//	Standard ID Constructor
-			 start.append(NL)
-			 .append("    /** Standard Constructor */").append(NL)
-			 .append("    public ").append(className).append(" (Properties ctx, int ").append(keyColumn).append(", String trxName)").append(NL)
-			 .append("    {").append(NL)
-			 .append("      super (ctx, ").append(keyColumn).append(", trxName);").append(NL)
-			 .append("      /** if (").append(keyColumn).append(" == 0)").append(NL)
-			 .append("        {").append(NL)
-			 .append(mandatory) 
-			 .append("        } */").append(NL)
-			 .append("    }").append(NL)
-			//	Constructor End
+		 String suffix = "";
+		 if (! tableHasIds)
+			 suffix = "_ignored";
+		 //	Standard ID Constructor
+		 start.append(NL)
+		 .append("    /** Standard Constructor */").append(NL)
+		 .append("    public ").append(className).append(" (Properties ctx, int ").append(keyColumn+suffix).append(", String trxName)").append(NL)
+		 .append("    {").append(NL)
+		 .append("      super (ctx, ").append(keyColumn+suffix).append(", trxName);").append(NL)
+		 .append("      /** if (").append(keyColumn+suffix).append(" == 0)").append(NL)
+		 .append("        {").append(NL)
+		 .append(mandatory) 
+		 .append("        } */").append(NL)
+		 .append("    }").append(NL)
+		 //	Constructor End
 
-			//	Standard ID Constructor + Virtual Columns
-			 .append(NL)
-			 .append("    /** Standard Constructor */").append(NL)
-			 .append("    public ").append(className).append(" (Properties ctx, int ").append(keyColumn).append(", String trxName, String ... virtualColumns)").append(NL)
-			 .append("    {").append(NL)
-			 .append("      super (ctx, ").append(keyColumn).append(", trxName, virtualColumns);").append(NL)
-			 .append("      /** if (").append(keyColumn).append(" == 0)").append(NL)
-			 .append("        {").append(NL)
-			 .append(mandatory)
-			 .append("        } */").append(NL)
-			 .append("    }").append(NL);
-			//	Constructor End
-		 }
+		 //	Standard ID Constructor + Virtual Columns
+		 .append(NL)
+		 .append("    /** Standard Constructor */").append(NL)
+		 .append("    public ").append(className).append(" (Properties ctx, int ").append(keyColumn+suffix).append(", String trxName, String ... virtualColumns)").append(NL)
+		 .append("    {").append(NL)
+		 .append("      super (ctx, ").append(keyColumn+suffix).append(", trxName, virtualColumns);").append(NL)
+		 .append("      /** if (").append(keyColumn+suffix).append(" == 0)").append(NL)
+		 .append("        {").append(NL)
+		 .append(mandatory)
+		 .append("        } */").append(NL)
+		 .append("    }").append(NL);
+		 //	Constructor End
 
 				//	Standard UUID Constructor
 		 start.append(NL)


### PR DESCRIPTION
- Generate the int constructor even when the table doesn't have IDs, this is to avoid error on MappedModelFactory.scan, like 
```
Sep 13, 2023 9:11:57 AM org.idempiere.model.MappedModelFactory scan INFO: com.trekglobal.idempiere.rest.api.model.X_REST_RefreshToken.<init>(java.util.Properties,int,java.lang.String) java.lang.NoSuchMethodException: com.trekglobal.idempiere.rest.api.model.X_REST_RefreshToken.<init>(java.util.Properties,int,java.lang.String)
        at java.base/java.lang.Class.getConstructor0(Class.java:3585)
        at java.base/java.lang.Class.getDeclaredConstructor(Class.java:2754)
        at org.idempiere.model.MappedModelFactory.scan(MappedModelFactory.java:152)
        at com.trekglobal.idempiere.rest.api.Activator.start(Activator.java:41)

```
# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
