### PR TITLE
IDEMPIERE-5866: different identifiers of info window and m_table cause in…

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
@@ -633,7 +633,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 			} 
 
 			if (m_count <= 0) {
-				testQueryForEachIdentify();
+				testQueryForEachIdentifier();
 			}
 		}
 		
@@ -662,18 +662,22 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 			try{
 				autocompleteEditor.setValue(queryValue);
 				testCount(false);
+
 			}catch(Exception ex){
 				// => don't run test in case not success set value
 				log.log(Level.SEVERE, "error", ex.getCause());
 			}
 		}else {
 			// => don't run test in case not found auto complete column
-			log.log(Level.SEVERE, String.format("can't found column for autocomplete query for field %s - field id %s. first identify column on m_table need to exists on identifies of info window", 
-					m_gridfield.getColumnName(), m_gridfield.getAD_Column_ID()));
+			if(!Util.isEmpty(autoCompleteSearchColumn))
+				log.log(Level.SEVERE, String.format("Auto complete search column (%s) not found for field %s (field id %s). ",
+						autoCompleteSearchColumn, m_gridfield.getColumnName(), m_gridfield.getAD_Column_ID()));
+			else if (identifiers.size() == 0)
+				log.log(Level.SEVERE, String.format("Info window (%s) has no identifier columns", this.infoWindow.getName()));
 		}
 	}
 	
-	protected void testQueryForEachIdentify() {
+	protected void testQueryForEachIdentifier() {
 		for (int i = 0; i < identifiers.size(); i++) {
 			WEditor editor = identifiers.get(i);
 
@@ -684,7 +688,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 			}
 			
 			testCount(false);
-			
+
 			if (m_count > 0) {
 				break;
 			} else {
@@ -728,7 +732,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 		
 		// case not exists mLookup.getLookupInfo().lookupDisplayColumnNames
 		// or no identifiers on info window exists on m_table
-		// fail back to old logic just set values to parameter
+		// fall back to old logic and just set values to identifiers
 		if (fillIdentifiers.size() == 0) {
 			for(int i = 0; i < values.length && i < identifiers.size(); i++) {
 				fillIdentifiers.add(identifiers.get(i));
@@ -736,12 +740,15 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 			}
 		}
 		
-		// do fill value to editor (both case correct order and non-correct order by fail back)
+
+
+		// do fill value to editor (for both corrected order and fall back)
 		for(int i = 0; i < fillIdentifiers.size(); i++) {
 			WEditor editor = fillIdentifiers.get(i);
 			editor.setValue(fillValues.get(i).trim());
 		}
 		testCount(false);
+
 	}
 	
 	@Override

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
@@ -624,16 +624,16 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 		if (isAutoComplete) {
 			testQueryForAutoComplete();
 		}else {
-			testQueryForEachIdentify();
-			
-			if (m_count <= 0) {			
-				String separator = MSysConfig.getValue(MSysConfig.IDENTIFIER_SEPARATOR, "_", Env.getAD_Client_ID(Env.getCtx()));
-				String[] values = queryValue.split("[" + separator.trim()+"]");
-				if (values.length > 0) {
-					splitValue = true;
-					
-					testQueryForSplit(values);
-				} 
+			String separator = MSysConfig.getValue(MSysConfig.IDENTIFIER_SEPARATOR, "_", Env.getAD_Client_ID(Env.getCtx()));
+			String[] values = queryValue.split("[" + separator.trim()+"]");
+
+			if (values.length > 1) {
+				splitValue = true;
+				testQueryForSplit(values);
+			} 
+
+			if (m_count <= 0) {
+				testQueryForEachIdentify();
 			}
 		}
 		

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
@@ -651,9 +651,9 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 				if (values.length > 0) {
 					splitValue = true;
 					
-					// store identifiers on info window already sort follow identify on m_table
+					// store identifiers on info window, sort to follow identifier on m_table
 					List<WEditor> fillIdentifiers = new ArrayList<>();
-					// store query value already ignore value for identify not exists on info window
+					// store query value, ignore value for identifier not exists on info window
 					// this list is sync with fillIdentifiers (size and order)
 					List<String> fillValues = new ArrayList<>();
 					
@@ -672,7 +672,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 							int indexFinal = i;
 							List<String> tableIdentifiersFinal = tableIdentifiers;
 							
-							// sort identify of info window follow m_table
+							// sort identifiers of info window to follow m_table
 							// ignore identifiers exists on m_table but not exists on info window
 							identifiers.forEach((Consumer<WEditor>)(identifierEditor) -> {
 								if (identifierEditor.getColumnName().equals(tableIdentifiersFinal.get(indexFinal))) {
@@ -684,7 +684,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 					}
 					
 					// case not exists mLookup.getLookupInfo().lookupDisplayColumnNames
-					// or non identify on info window exists on m_table 
+					// or no identifiers on info window exists on m_table
 					// fail back to old logic just set values to parameter
 					if (fillIdentifiers.size() == 0) {
 						for(int i = 0; i < values.length && i < identifiers.size(); i++) {


### PR DESCRIPTION
…fo window fill query text to wrong identifier column

https://idempiere.atlassian.net/browse/IDEMPIERE-5866

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [ ] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

