### PR TITLE
IDEMPIERE-5879:Customization official buttons isn't complete implement

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MToolBarButton.java
+++ b/org.adempiere.base/src/org/compiere/model/MToolBarButton.java
@@ -78,7 +78,6 @@ public class MToolBarButton extends X_AD_ToolBarButton {
 		Query query = new Query(Env.getCtx(), MTable.get(Env.getCtx(), Table_ID),
 				"Action=? AND (AD_ToolbarButton_ID<=? OR ActionClassName IS NOT NULL) AND AD_Tab_ID IS NULL", trxName);
 		List<MToolBarButton> list = query.setParameters(action, MTable.MAX_OFFICIAL_ID)
-				.setOnlyActiveRecords(true)
 				.setOrderBy("CASE WHEN COALESCE(SeqNo,0)=0 THEN AD_ToolBarButton_ID ELSE SeqNo END").list();
 		if (list != null && !list.isEmpty()) {
 			buttons = list.toArray(buttons);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/action/Actions.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/action/Actions.java
@@ -22,6 +22,7 @@ import org.adempiere.base.Service;
 import org.adempiere.webui.theme.ITheme;
 import org.adempiere.webui.theme.ThemeManager;
 import org.compiere.util.CCache;
+import org.compiere.util.Util;
 import org.zkoss.image.AImage;
 
 /**
@@ -34,13 +35,21 @@ public class Actions {
 	private static final String ACTION_IMAGES_PATH = "/action/images/";
 	private static CCache<String, IServiceHolder<IAction>> trackerCache = new CCache<String, IServiceHolder<IAction>>(null, "ActionsServiceTracker", 5, false);
 	private static CCache<String, AImage> imageCache = new CCache<String, AImage>(null, "ActionsImages",5, false);
+	private static String defaultAction = "org.adempiere.webui.action.DefaultToolbarAction";
 	
 	/**
+	 * in case button don't setup a action, it should use default action (example to show hello)
+	 * in case no default action then it should return null shouldn't return first registered service
 	 * 
+     * think about use a default IAction for case setup action (actionId isn't empty) but not yet registered service
 	 * @param actionId
 	 * @return {@link IServiceHolder}
 	 */
 	public static IServiceHolder<IAction> getAction(String actionId) {
+		
+		if (Util.isEmpty(actionId, true))
+			actionId = defaultAction;
+		
 		IServiceHolder<IAction> action = null;
 		synchronized (trackerCache) {
 			action = trackerCache.get(actionId);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/action/IAction.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/action/IAction.java
@@ -13,6 +13,13 @@
  *****************************************************************************/
 package org.adempiere.webui.action;
 
+import org.adempiere.webui.LayoutUtils;
+import org.adempiere.webui.theme.ThemeManager;
+import org.compiere.model.MToolBarButton;
+import org.compiere.util.Env;
+import org.compiere.util.Msg;
+import org.compiere.util.Util;
+import org.zkoss.image.AImage;
 import org.zkoss.zul.Toolbarbutton;
 
 /**
@@ -27,11 +34,49 @@ public interface IAction {
 	 */
 	public void execute(Object target);
 	
+	public default void decorate(Toolbarbutton btn, MToolBarButton mButton) {
+		String actionId = mButton.getActionClassName();
+		String labelKey = actionId + ".label";
+		String tooltipKey = actionId + ".tooltip";
+		String label = Msg.getMsg(Env.getCtx(), labelKey, true);
+		String tooltiptext = Msg.getMsg(Env.getCtx(), labelKey, false);
+		if (Util.isEmpty(tooltiptext, true))
+			tooltiptext = Msg.getMsg(Env.getCtx(), tooltipKey, true);
+		else
+			tooltipKey = labelKey;
+		if (labelKey.equals(label)) {
+			label = mButton.getName();
+		}
+		if (tooltipKey.equals(tooltiptext) || labelKey.equals(tooltiptext)) {
+			tooltipKey = null;
+		}
+		
+		btn.setIconSclass(null);
+		if (ThemeManager.isUseFontIconForImage()) {
+			String iconSclass = Actions.getActionIconSclass(actionId);
+			if (!Util.isEmpty(iconSclass, true)) {
+				btn.setIconSclass(iconSclass);
+				LayoutUtils.addSclass("font-icon-toolbar-button", btn);
+			}
+		}
+		//not using font icon, fallback to image or label
+		if (Util.isEmpty(btn.getIconSclass(), true)) {
+			AImage aImage = Actions.getActionImage(actionId);
+			if (aImage != null) {
+				btn.setImageContent(aImage);
+			} else {
+				btn.setLabel(label);
+			}
+		}
+	}
 	/**
 	 * you can customize toolbar button like add style, client javascript,...
+	 * @deprecated(forRemoval = true, since = "11")
+	 * replace by {@link #decorate(Toolbarbutton, String)}
 	 * @param toolbarButton
 	 */
-	public default void decorate(Toolbarbutton toolbarButton) {		
+	public default void decorate(Toolbarbutton btn) {	
+		decorate(btn, null);
 	}
 	
 	/**

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/AbstractADWindowContent.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/AbstractADWindowContent.java
@@ -2144,7 +2144,7 @@ public abstract class AbstractADWindowContent extends AbstractUIPart implements 
         IADTabpanel adtab = adTabbox.getSelectedTabpanel();
         toolbar.enableProcessButton(adtab != null && adtab.isEnableProcessButton());
         toolbar.enableCustomize(adtab.isEnableCustomizeButton());
-
+        toolbar.dynamicDisplay();
     }
 
 	/**

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/DetailPane.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/DetailPane.java
@@ -470,7 +470,7 @@ public class DetailPane extends Panel implements EventListener<Event>, IdSpace {
 		MToolBarButton[] officialButtons = MToolBarButton.getToolbarButtons("D", null);
 		for (MToolBarButton toolbarButton : officialButtons) {
 			if ( !toolbarButton.isActive() ) {
-				buttons.remove(toolbarButton.getComponentName());
+				ADWindowToolbar.removeButton(buttons, toolbarButton.getComponentName());
 			} else {
 				if ( toolbarButton.isCustomization() ) {
 					String actionId = toolbarButton.getActionClassName();


### PR DESCRIPTION
just implement for header toolbar first

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [ ] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

