### PR TITLE
IDEMPIERE-5878 Wrong GL posting in allocation for payment REVERSE/ACCRUAL, if payment WITH charge

### DIFF
--- a/org.adempiere.base/src/org/compiere/acct/Doc_AllocationHdr.java
+++ b/org.adempiere.base/src/org/compiere/acct/Doc_AllocationHdr.java
@@ -32,6 +32,7 @@ import org.compiere.model.MAcctSchemaElement;
 import org.compiere.model.MAllocationHdr;
 import org.compiere.model.MAllocationLine;
 import org.compiere.model.MCashLine;
+import org.compiere.model.MCharge;
 import org.compiere.model.MConversionRate;
 import org.compiere.model.MDocType;
 import org.compiere.model.MFactAcct;
@@ -687,7 +688,9 @@ public class Doc_AllocationHdr extends Doc
 		//	or Doc.ACCTTYPE_PaymentSelect (AP) or V_Prepayment
 		int accountType = Doc.ACCTTYPE_UnallocatedCash;
 		//
-		String sql = "SELECT p.C_BankAccount_ID, d.DocBaseType, p.IsReceipt, p.IsPrepayment "
+		int C_Charge_ID = 0;
+		
+		String sql = "SELECT p.C_BankAccount_ID, d.DocBaseType, p.IsReceipt, p.IsPrepayment, p.C_Charge_ID "
 				+ "FROM C_Payment p INNER JOIN C_DocType d ON (p.C_DocType_ID=d.C_DocType_ID) "
 				+ "WHERE C_Payment_ID=?";
 		PreparedStatement pstmt = null;
@@ -700,6 +703,7 @@ public class Doc_AllocationHdr extends Doc
 			if (rs.next ())
 			{
 				setC_BankAccount_ID(rs.getInt(1));
+				C_Charge_ID = rs.getInt(5);				// Charge
 				if (DOCTYPE_APPayment.equals(rs.getString(2)))
 					accountType = Doc.ACCTTYPE_PaymentSelect;
 				//	Prepayment
@@ -728,6 +732,9 @@ public class Doc_AllocationHdr extends Doc
 			log.log(Level.SEVERE, "NONE for C_Payment_ID=" + C_Payment_ID);
 			return null;
 		}
+		
+		if (C_Charge_ID != 0)
+			return MCharge.getAccount(C_Charge_ID, as);
 		return getAccount (accountType, as);
 	}	//	getPaymentAcct
 


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5878

1. Create a payment/receipt in period 1 for USD 1,000. Instead of selecting an open invoice (allocation), enter a charge, for example a bank charge, or an income account.
```
USD/COP 1:4000

COP accounting schema:
DR Bank in Transit COP 4,000,000
CR Bank Charge COP 4,000,000

USD accounting schema:
DR Bank in Transit USD 1,000
CR Bank Charge USD 1,000
```
2. REVERSE/ACCRUAL payment/receipt in period 2.
```
USD/COP 1:5000

COP accounting schema:
DR Bank Charge COP 5,000,000
CR Bank in Transit COP 5,000,000

USD accounting schema:
DR Bank Charge USD 1,000
CR Bank in Transit USD 1,000
```
3. The reversal in step 2 creates an allocation document between the payment and payment reversal document.
```
COP accounting schema:
DR Unallocated Cash 4,000,000
CR Unallocated Cash 5,000,000
DR Realized Loss 1,000,000
```
There are several problems here:
- The allocation's total unallocated cash amount (or payment selection in case of vendor payment) is NOT zero, offset by realized gain/loss. It's required that the total unallocated cash amounts are always zero after allocation.
- The original bank charge expenses are not zero after payment REVERSE/ACCRUAL.

Expected result:
Allocation document to post to the original charge account instead of unallocated cash/payment selection account
```
COP accounting schema:
DR Bank Charge COP 4,000,000 
CR Bank Charge COP 5,000,000 
DR Realized Loss COP 1,000,000
```