### PR TITLE
IDEMPIERE-5013 set HikariCP initial pool size to 10 - as it was in c3p0

### DIFF
--- a/org.compiere.db.oracle.provider/META-INF/pool/server.default.properties
+++ b/org.compiere.db.oracle.provider/META-INF/pool/server.default.properties
@@ -42,7 +42,7 @@ connectionTimeout=60000
 # recommend not setting this value and instead allowing HikariCP to act as a 
 # fixed size connection pool. 
 # Default: same as maximumPoolSize
-#minimumIdle=
+minimumIdle=10
 
 # This property controls the maximum size that the pool is allowed to reach, 
 # including both idle and in-use connections. Basically this value will determine 
@@ -52,7 +52,7 @@ connectionTimeout=60000
 # will block for up to connectionTimeout milliseconds before timing out. Please 
 # read about pool sizing: https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
 # Default: 10
-maximumPoolSize=90
+maximumPoolSize=150
 
 # This property controls the maximum lifetime of a connection in the pool. An 
 # in-use connection will never be retired, only when it is closed will it then be 


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5013?focusedCommentId=50186

- Applying the same as we did in commit f76c39889c for PostgreSQL
- For some reason c3p0 was configured with MaxPoolSize=150 for oracle (90 for PostgreSQL) - setting same default

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [ ] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
