### PR TITLE
IDEMPIERE 5929 - Looping on ZK happening on Exceptions caused by IServerPushCallback.updateUI implementations

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/desktop/TabbedDesktop.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/desktop/TabbedDesktop.java
@@ -287,7 +287,12 @@ public abstract class TabbedDesktop extends AbstractDesktop {
 				int windowNo = (Integer)windowNoAttribute;
 				refTab = windowContainer.getTab(windowNo);
 			}
-			windowContainer.replace(refTab, window, title);
+
+			if (refTab == null)
+				windowContainer.addWindow(tabPanel, title, true, null);
+			else
+				windowContainer.replace(refTab, window, title);
+
 		}
 		else {
 	    	windowContainer.addWindow(tabPanel, title, true, null);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/part/WindowContainer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/part/WindowContainer.java
@@ -710,12 +710,6 @@ public class WindowContainer extends AbstractUIPart implements EventListener<Eve
      */
     public org.zkoss.zul.Tab replace(org.zkoss.zul.Tab refTab, Window comp, String title) {
     	 
-         if (refTab == null)  
-         {
-         	throw new IllegalArgumentException();
-         }
-         else
-         {
          	org.zkoss.zul.Tabpanel refpanel = refTab.getLinkedPanel();
          	Component firstChild = refpanel.getFirstChild();
          	if(firstChild instanceof Window) {
@@ -732,7 +726,7 @@ public class WindowContainer extends AbstractUIPart implements EventListener<Eve
          		firstChild.detach();
          		comp.setParent(refpanel);
          	}
-         }
+
          if (title != null) 
          {
  	        setTabTitle(title, refTab);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/part/WindowContainer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/part/WindowContainer.java
@@ -709,29 +709,28 @@ public class WindowContainer extends AbstractUIPart implements EventListener<Eve
      * @return org.zkoss.zul.Tab
      */
     public org.zkoss.zul.Tab replace(org.zkoss.zul.Tab refTab, Window comp, String title) {
-    	 
-         	org.zkoss.zul.Tabpanel refpanel = refTab.getLinkedPanel();
-         	Component firstChild = refpanel.getFirstChild();
-         	if(firstChild instanceof Window) {
-	     		if(firstChild instanceof ProcessDialog)
-	     			((ProcessDialog)firstChild).unlockUI(null);
-	     		else if(firstChild instanceof ZkReportViewer)
-					((ZkReportViewer)firstChild).hideBusyMask();
-				else if(firstChild instanceof AbstractADWindowContent)
-					((AbstractADWindowContent)firstChild).hideBusyMask();
-	     		((Window) firstChild).onClose();
-	     		comp.setParent(refpanel);
-         	}
-         	else {
-         		firstChild.detach();
-         		comp.setParent(refpanel);
-         	}
-
-         if (title != null) 
-         {
- 	        setTabTitle(title, refTab);
-         }
-        return refTab;
+		org.zkoss.zul.Tabpanel refpanel = refTab.getLinkedPanel();
+		Component firstChild = refpanel.getFirstChild();
+		if(firstChild instanceof Window) {
+			if(firstChild instanceof ProcessDialog)
+				((ProcessDialog)firstChild).unlockUI(null);
+			else if(firstChild instanceof ZkReportViewer)
+				((ZkReportViewer)firstChild).hideBusyMask();
+			else if(firstChild instanceof AbstractADWindowContent)
+				((AbstractADWindowContent)firstChild).hideBusyMask();
+			((Window) firstChild).onClose();
+			comp.setParent(refpanel);
+		}
+		else {
+			firstChild.detach();
+			comp.setParent(refpanel);
+		}
+		
+		if (title != null) 
+		{
+			setTabTitle(title, refTab);
+		}
+		return refTab;
     }
     
     /**

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/part/WindowContainer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/part/WindowContainer.java
@@ -709,36 +709,35 @@ public class WindowContainer extends AbstractUIPart implements EventListener<Eve
      * @return org.zkoss.zul.Tab
      */
     public org.zkoss.zul.Tab replace(org.zkoss.zul.Tab refTab, Window comp, String title) {
-
-    	if (refTab == null)  
-        {
-        	throw new IllegalArgumentException();
-        }
-        else
-        {
-			org.zkoss.zul.Tabpanel refpanel = refTab.getLinkedPanel();
-			Component firstChild = refpanel.getFirstChild();
-			if(firstChild instanceof Window) {
-				if(firstChild instanceof ProcessDialog)
-					((ProcessDialog)firstChild).unlockUI(null);
-				else if(firstChild instanceof ZkReportViewer)
+    	 
+         if (refTab == null)  
+         {
+         	throw new IllegalArgumentException();
+         }
+         else
+         {
+         	org.zkoss.zul.Tabpanel refpanel = refTab.getLinkedPanel();
+         	Component firstChild = refpanel.getFirstChild();
+         	if(firstChild instanceof Window) {
+	     		if(firstChild instanceof ProcessDialog)
+	     			((ProcessDialog)firstChild).unlockUI(null);
+	     		else if(firstChild instanceof ZkReportViewer)
 					((ZkReportViewer)firstChild).hideBusyMask();
 				else if(firstChild instanceof AbstractADWindowContent)
 					((AbstractADWindowContent)firstChild).hideBusyMask();
-				((Window) firstChild).onClose();
-				comp.setParent(refpanel);
-			}
-			else {
-				firstChild.detach();
-				comp.setParent(refpanel);
-			}
-        }
-		
-		if (title != null) 
-		{
-			setTabTitle(title, refTab);
-		}
-		return refTab;
+	     		((Window) firstChild).onClose();
+	     		comp.setParent(refpanel);
+         	}
+         	else {
+         		firstChild.detach();
+         		comp.setParent(refpanel);
+         	}
+         }
+         if (title != null) 
+         {
+ 	        setTabTitle(title, refTab);
+         }
+        return refTab;
     }
     
     /**

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/part/WindowContainer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/part/WindowContainer.java
@@ -709,22 +709,30 @@ public class WindowContainer extends AbstractUIPart implements EventListener<Eve
      * @return org.zkoss.zul.Tab
      */
     public org.zkoss.zul.Tab replace(org.zkoss.zul.Tab refTab, Window comp, String title) {
-		org.zkoss.zul.Tabpanel refpanel = refTab.getLinkedPanel();
-		Component firstChild = refpanel.getFirstChild();
-		if(firstChild instanceof Window) {
-			if(firstChild instanceof ProcessDialog)
-				((ProcessDialog)firstChild).unlockUI(null);
-			else if(firstChild instanceof ZkReportViewer)
-				((ZkReportViewer)firstChild).hideBusyMask();
-			else if(firstChild instanceof AbstractADWindowContent)
-				((AbstractADWindowContent)firstChild).hideBusyMask();
-			((Window) firstChild).onClose();
-			comp.setParent(refpanel);
-		}
-		else {
-			firstChild.detach();
-			comp.setParent(refpanel);
-		}
+
+    	if (refTab == null)  
+        {
+        	throw new IllegalArgumentException();
+        }
+        else
+        {
+			org.zkoss.zul.Tabpanel refpanel = refTab.getLinkedPanel();
+			Component firstChild = refpanel.getFirstChild();
+			if(firstChild instanceof Window) {
+				if(firstChild instanceof ProcessDialog)
+					((ProcessDialog)firstChild).unlockUI(null);
+				else if(firstChild instanceof ZkReportViewer)
+					((ZkReportViewer)firstChild).hideBusyMask();
+				else if(firstChild instanceof AbstractADWindowContent)
+					((AbstractADWindowContent)firstChild).hideBusyMask();
+				((Window) firstChild).onClose();
+				comp.setParent(refpanel);
+			}
+			else {
+				firstChild.detach();
+				comp.setParent(refpanel);
+			}
+        }
 		
 		if (title != null) 
 		{


### PR DESCRIPTION
# Refs
[Ticket](https://idempiere.atlassian.net/browse/IDEMPIERE-5929)
[MatterMost](https://mattermost.idempiere.org/idempiere/pl/zawqq7tu53fj8mk1c6kwqhrtie)
# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

