### PR TITLE
IDEMPIERE-5935 - Fixes non-updatable product info window subtabs to auto-select first record functionality

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoPanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoPanel.java
@@ -33,10 +33,12 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Set;
 import java.util.Vector;
 import java.util.logging.Level;
 
@@ -3548,6 +3550,11 @@ public abstract class InfoPanel extends Window implements EventListener<Event>, 
 
             	((HtmlBasedComponent)contentPanel.getSelectedItem()).focus();
             	contentPanel.getSelectedItem().setSelected(true);
+
+            	Set<Listitem> selectionList = new LinkedHashSet<>();
+            	selectionList.add(contentPanel.getSelectedItem());
+
+            	Events.postEvent(new SelectEvent<>(Events.ON_SELECT, contentPanel, selectionList));
         	}
 
         	setStatusSelected ();


### PR DESCRIPTION
# Refs
[Mattermost](https://mattermost.idempiere.org/idempiere/pl/9j6pr87c97nc8k5qaoqofjy4ec)
[IDEMPIERE-5935](https://idempiere.atlassian.net/browse/IDEMPIERE-5935)

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.



[IDEMPIERE-5935]: https://idempiere.atlassian.net/browse/IDEMPIERE-5935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ