### PR TITLE
IDEMPIERE-5931 Generate Invoices (manual) displays RMA for selection despite AR Credit memo already completed.

### DIFF
--- a/migration/iD10/oracle/202311221523_IDEMPIERE-5931.sql
+++ b/migration/iD10/oracle/202311221523_IDEMPIERE-5931.sql
@@ -1,0 +1,146 @@
+-- IDEMPIERE-5931 Generate Invoices (manual) displays RMA for selection despite AR Credit memo already completed.
+SELECT register_migration_script('202311221523_IDEMPIERE-5931.sql') FROM dual;
+
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Nov 22, 2023, 3:23:50 PM MYT
+UPDATE AD_ViewComponent SET WhereClause='WHERE rma.docstatus = ''CO''
+AND dt.docbasetype = ''SOO''
+AND NOT EXISTS (SELECT 1
+	FROM c_invoice i
+	WHERE i.m_rma_id = rma.m_rma_id
+    AND i.docstatus IN (''IP'', ''CO'', ''CL''))
+AND NOT EXISTS (SELECT 1
+	FROM c_invoice i
+	JOIN c_invoiceline il ON il.c_invoice_id = i.c_invoice_id
+	JOIN m_rmaline rl ON rl.m_rmaline_id = il.m_rmaline_id
+	WHERE rl.m_rma_id = rma.m_rma_id
+    AND i.docstatus IN (''IP'', ''CO'', ''CL''))
+AND EXISTS (SELECT 1
+	FROM c_invoiceline il
+	JOIN m_inoutline iol ON il.m_inoutline_id = iol.m_inoutline_id
+	JOIN c_invoice i ON i.c_invoice_id = il.c_invoice_id
+	WHERE i.docstatus IN (''CO'', ''CL'') AND EXISTS (SELECT 1
+		FROM m_rmaline rl
+		WHERE rl.m_rma_id = rma.m_rma_id
+		AND iol.m_inoutline_id = rl.m_inoutline_id
+		AND rl.m_inoutline_id IS NOT NULL
+		AND COALESCE(rl.QtyInvoiced,0) < rl.Qty)
+	UNION 
+	SELECT 1
+	FROM c_invoiceline il
+	JOIN c_orderline ol ON il.c_orderline_id = ol.c_orderline_id
+	JOIN c_invoice i ON i.c_invoice_id = il.c_invoice_id
+	WHERE i.docstatus IN (''CO'', ''CL'') AND EXISTS (SELECT 1
+		FROM m_rmaline rl 
+		JOIN m_inoutline iol ON iol.m_inoutline_id = rl.m_inoutline_id
+		WHERE rl.m_rma_id = rma.m_rma_id
+		AND iol.c_orderline_id = ol.c_orderline_id
+		AND iol.c_orderline_id IS NOT NULL
+		AND COALESCE(rl.QtyInvoiced,0) < rl.Qty))',Updated=TO_TIMESTAMP('2023-11-22 15:23:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_ViewComponent_ID=200220
+;
+
+-- Nov 22, 2023, 3:24:03 PM MYT
+CREATE OR REPLACE VIEW C_Invoice_Candidate_v(AD_Client_ID, AD_Org_ID, Created, Updated, IsActive, C_BPartner_ID, C_Order_ID, M_InOut_ID, DocumentNo, DateOrdered, C_DocType_ID, InvoiceRule, TotalLines, DocSource, C_Invoice_Candidate_v_ID) AS SELECT o.ad_client_id AS AD_Client_ID, o.ad_org_id AS AD_Org_ID, o.created AS Created, o.updated AS Updated, o.isactive AS IsActive, o.c_bpartner_id AS C_BPartner_ID, o.c_order_id AS C_Order_ID, NULL AS M_InOut_ID, o.documentno AS DocumentNo, o.dateordered AS DateOrdered, o.c_doctype_id AS C_DocType_ID, o.invoicerule AS InvoiceRule, sum((l.qtyordered - l.qtyinvoiced) * l.priceactual) AS TotalLines, 'O' AS DocSource, o.c_order_id AS C_Invoice_Candidate_v_ID FROM c_order o
+JOIN c_orderline l ON o.c_order_id = l.c_order_id
+JOIN c_bpartner bp ON o.c_bpartner_id = bp.c_bpartner_id
+LEFT JOIN c_invoiceschedule si ON bp.c_invoiceschedule_id = si.c_invoiceschedule_id WHERE (o.docstatus IN ('CO', 'CL', 'IP')) AND (o.c_doctype_id IN ( SELECT c_doctype.c_doctype_id
+           FROM c_doctype
+          WHERE c_doctype.docbasetype = 'SOO' AND (c_doctype.docsubtypeso NOT IN ('ON', 'OB', 'WR')))) AND l.qtyordered <> l.qtyinvoiced AND (o.invoicerule = 'I' OR o.invoicerule = 'O' AND NOT (EXISTS ( SELECT 1
+           FROM c_orderline zz1
+          WHERE zz1.c_order_id = o.c_order_id AND zz1.qtyordered <> zz1.qtydelivered)) OR o.invoicerule = 'D' AND l.qtyinvoiced <> l.qtydelivered OR o.invoicerule = 'S' AND bp.c_invoiceschedule_id IS NULL OR o.invoicerule = 'S' AND bp.c_invoiceschedule_id IS NOT NULL AND (si.invoicefrequency IS NULL OR si.invoicefrequency = 'D' OR si.invoicefrequency = 'W' OR si.invoicefrequency = 'T' AND (trunc(o.dateordered) <= (firstof(getdate(), 'MM') + si.invoicedaycutoff - 1) AND trunc(getdate()) >= (firstof(o.dateordered, 'MM') + si.invoiceday - 1) OR trunc(o.dateordered) <= (firstof(getdate(), 'MM') + si.invoicedaycutoff + 14) AND trunc(getdate()) >= (firstof(o.dateordered, 'MM') + si.invoiceday + 14)) OR si.invoicefrequency = 'M' AND trunc(o.dateordered) <= (firstof(getdate(), 'MM') + si.invoicedaycutoff - 1) AND trunc(getdate()) >= (firstof(o.dateordered, 'MM') + si.invoiceday - 1))) GROUP BY o.ad_client_id, o.ad_org_id, o.created, o.updated, o.isactive, o.c_bpartner_id, o.c_order_id, o.documentno, o.dateordered, o.c_doctype_id,o.invoicerule UNION  ALL SELECT rma.ad_client_id AS AD_Client_ID, rma.ad_org_id AS AD_Org_ID, rma.created AS Created, rma.updated AS Updated, rma.isactive AS IsActive, rma.c_bpartner_id AS C_BPartner_ID, rma.c_order_id AS C_Order_ID, rma.inout_id AS M_InOut_ID, rma.documentno AS DocumentNo, rma.created AS DateOrdered, rma.c_doctype_id AS C_DocType_ID, NULL AS InvoiceRule, rma.amt AS TotalLines, 'R' AS DocSource, rma.m_rma_id AS C_Invoice_Candidate_v_ID FROM   m_rma rma
+JOIN c_doctype dt ON rma.c_doctype_id = dt.c_doctype_id
+ WHERE rma.docstatus = 'CO'
+AND dt.docbasetype = 'SOO'
+AND NOT EXISTS (SELECT 1
+	FROM c_invoice i
+	WHERE i.m_rma_id = rma.m_rma_id
+    AND i.docstatus IN ('IP', 'CO', 'CL'))
+AND NOT EXISTS (SELECT 1
+	FROM c_invoice i
+	JOIN c_invoiceline il ON il.c_invoice_id = i.c_invoice_id
+	JOIN m_rmaline rl ON rl.m_rmaline_id = il.m_rmaline_id
+	WHERE rl.m_rma_id = rma.m_rma_id
+    AND i.docstatus IN ('IP', 'CO', 'CL'))
+AND EXISTS (SELECT 1
+	FROM c_invoiceline il
+	JOIN m_inoutline iol ON il.m_inoutline_id = iol.m_inoutline_id
+	JOIN c_invoice i ON i.c_invoice_id = il.c_invoice_id
+	WHERE i.docstatus IN ('CO', 'CL') AND EXISTS (SELECT 1
+		FROM m_rmaline rl
+		WHERE rl.m_rma_id = rma.m_rma_id
+		AND iol.m_inoutline_id = rl.m_inoutline_id
+		AND rl.m_inoutline_id IS NOT NULL
+		AND COALESCE(rl.QtyInvoiced,0) < rl.Qty)
+	UNION 
+	SELECT 1
+	FROM c_invoiceline il
+	JOIN c_orderline ol ON il.c_orderline_id = ol.c_orderline_id
+	JOIN c_invoice i ON i.c_invoice_id = il.c_invoice_id
+	WHERE i.docstatus IN ('CO', 'CL') AND EXISTS (SELECT 1
+		FROM m_rmaline rl 
+		JOIN m_inoutline iol ON iol.m_inoutline_id = rl.m_inoutline_id
+		WHERE rl.m_rma_id = rma.m_rma_id
+		AND iol.c_orderline_id = ol.c_orderline_id
+		AND iol.c_orderline_id IS NOT NULL
+		AND COALESCE(rl.QtyInvoiced,0) < rl.Qty))
+;
+
+-- Nov 22, 2023, 4:57:03 PM MYT
+UPDATE AD_ViewComponent SET WhereClause='WHERE RMA.docstatus = ''CO''
+AND DT.docbasetype = ''POO''
+AND EXISTS (SELECT 1
+	FROM m_rma R
+	INNER JOIN m_rmaline RL ON R.m_rma_id = RL.m_rma_id
+	WHERE R.m_rma_id = RMA.m_rma_id
+	AND RL.isactive = ''Y''
+	AND RL.m_inoutline_id > 0
+	AND RL.qtydelivered < RL.qty)
+AND NOT EXISTS (SELECT 1
+	FROM m_inout OIO
+	WHERE OIO.m_rma_id = RMA.m_rma_id
+	AND OIO.docstatus IN (''IP'', ''CO'', ''CL''))
+AND NOT EXISTS (SELECT 1
+	FROM m_inout OIO
+	JOIN m_inoutline IL ON IL.m_inout_id = OIO.m_inout_id
+	JOIN m_rmaline RL ON RL.m_rmaline_id = IL.m_rmaline_id
+	WHERE RL.m_rma_id = rma.m_rma_id
+    AND OIO.docstatus IN (''IP'', ''CO'', ''CL''))',Updated=TO_TIMESTAMP('2023-11-22 16:57:03','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_ViewComponent_ID=200219
+;
+
+-- Nov 22, 2023, 4:57:16 PM MYT
+CREATE OR REPLACE VIEW M_InOut_Candidate_v(AD_Client_ID, AD_Org_ID, Created, Updated, IsActive, C_BPartner_ID, C_Order_ID, DocumentNo, DateOrdered, C_DocType_ID, POReference, Description, SalesRep_ID, M_Warehouse_ID, M_InOut_ID, TotalLines, DocSource, M_InOut_Candidate_v_ID, DeliveryRule) AS SELECT o.ad_client_id AS AD_Client_ID, o.ad_org_id AS AD_Org_ID, o.created AS Created, o.updated AS Updated, o.isactive AS IsActive, o.c_bpartner_id AS C_BPartner_ID, o.c_order_id AS C_Order_ID, o.documentno AS DocumentNo, o.dateordered AS DateOrdered, o.c_doctype_id AS C_DocType_ID, o.poreference AS POReference, o.description AS Description, o.salesrep_id AS SalesRep_ID, l.m_warehouse_id AS M_Warehouse_ID, NULL AS M_InOut_ID, sum((l.qtyordered - l.qtydelivered) * l.priceactual) AS TotalLines, 'O' AS DocSource, o.c_order_id AS M_InOut_Candidate_v_ID, o.deliveryrule AS DeliveryRule FROM c_order o
+JOIN c_orderline l ON o.c_order_id = l.c_order_id WHERE o.docstatus = 'CO' AND o.isdelivered = 'N' AND (o.c_doctype_id IN ( SELECT c_doctype.c_doctype_id
+           FROM c_doctype
+          WHERE c_doctype.docbasetype = 'SOO' AND (c_doctype.docsubtypeso NOT IN ('ON', 'OB', 'WR')))) AND o.deliveryrule <> 'M' AND (l.m_product_id IS NULL OR (EXISTS ( SELECT 1
+           FROM m_product p
+          WHERE l.m_product_id = p.m_product_id AND p.isexcludeautodelivery = 'N'))) AND l.qtyordered <> l.qtydelivered AND (l.m_product_id IS NOT NULL OR l.c_charge_id IS NOT NULL) AND NOT (EXISTS ( SELECT 1
+           FROM m_inoutline iol
+             JOIN m_inout io ON iol.m_inout_id = io.m_inout_id
+          WHERE iol.c_orderline_id = l.c_orderline_id AND (io.docstatus IN ('DR', 'IN', 'IP', 'WC')))) GROUP BY o.ad_client_id, o.ad_org_id, o.c_bpartner_id, o.c_order_id, o.documentno, o.dateordered, o.c_doctype_id, o.poreference, o.description, o.salesrep_id, l.m_warehouse_id, o.created, o.updated, o.isactive, o.deliveryrule
+ UNION  ALL SELECT rma.ad_client_id AS AD_Client_ID, rma.ad_org_id AS AD_Org_ID, rma.created AS Created, rma.updated AS Updated, rma.isactive AS IsActive, rma.c_bpartner_id AS C_BPartner_ID, rma.c_order_id AS C_Order_ID, rma.documentno AS DocumentNo, rma.created AS DateOrdered, rma.c_doctype_id AS C_DocType_ID, NULL AS POReference, NULL AS Description, NULL AS SalesRep_ID, io.m_warehouse_id AS M_Warehouse_ID, rma.inout_id AS M_InOut_ID, rma.amt AS TotalLines, 'R' AS DocSource, rma.m_rma_id AS M_InOut_Candidate_v_ID, NULL AS DeliveryRule FROM m_rma RMA
+       INNER JOIN ad_org ORG ON RMA.ad_org_id = ORG.ad_org_id
+       INNER JOIN c_doctype DT ON RMA.c_doctype_id = DT.c_doctype_id
+       INNER JOIN c_bpartner BP ON RMA.c_bpartner_id = BP.c_bpartner_id
+       INNER JOIN m_inout IO ON RMA.inout_id = IO.m_inout_id WHERE RMA.docstatus = 'CO'
+AND DT.docbasetype = 'POO'
+AND EXISTS (SELECT 1
+	FROM m_rma R
+	INNER JOIN m_rmaline RL ON R.m_rma_id = RL.m_rma_id
+	WHERE R.m_rma_id = RMA.m_rma_id
+	AND RL.isactive = 'Y'
+	AND RL.m_inoutline_id > 0
+	AND RL.qtydelivered < RL.qty)
+AND NOT EXISTS (SELECT 1
+	FROM m_inout OIO
+	WHERE OIO.m_rma_id = RMA.m_rma_id
+	AND OIO.docstatus IN ('IP', 'CO', 'CL'))
+AND NOT EXISTS (SELECT 1
+	FROM m_inout OIO
+	JOIN m_inoutline IL ON IL.m_inout_id = OIO.m_inout_id
+	JOIN m_rmaline RL ON RL.m_rmaline_id = IL.m_rmaline_id
+	WHERE RL.m_rma_id = rma.m_rma_id
+    AND OIO.docstatus IN ('IP', 'CO', 'CL'))
+;
+

--- a/migration/iD10/oracle/202312011228_IDEMPIERE-5931.sql
+++ b/migration/iD10/oracle/202312011228_IDEMPIERE-5931.sql
@@ -1,0 +1,113 @@
+-- IDEMPIERE-5931 Generate Invoices (manual) displays RMA for selection despite AR Credit memo already completed.
+SELECT register_migration_script('202312011228_IDEMPIERE-5931.sql') FROM dual;
+
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Dec 1, 2023, 1:05:12 PM MYT
+UPDATE AD_ViewColumn SET ColumnSQL='l.QtyOrdered-SUM(COALESCE(m.Qty,l.QtyInvoiced))',Updated=TO_TIMESTAMP('2023-12-01 13:05:12','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_ViewColumn_ID=217539
+;
+
+-- Dec 1, 2023, 1:05:34 PM MYT
+UPDATE AD_ViewComponent SET OtherClause='GROUP BY l.QtyOrdered,CASE WHEN l.QtyOrdered=0 THEN 0 ELSE l.QtyEntered/l.QtyOrdered END,
+l.C_UOM_ID, po.VendorProductNo, l.M_Product_ID, l.C_Charge_ID, l.Line, l.C_OrderLine_ID, o.IsSOTrx, 
+l.AD_Client_ID, l.AD_Org_ID, l.IsActive,l.c_bpartner_id,l.C_Order_ID 
+HAVING l.QtyOrdered-SUM(COALESCE(m.Qty,l.QtyInvoiced)) <> 0',Updated=TO_TIMESTAMP('2023-12-01 13:05:34','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_ViewComponent_ID=200227
+;
+
+-- Dec 1, 2023, 1:06:05 PM MYT
+CREATE OR REPLACE VIEW C_Invoice_CreateFrom_v(CreditQty, Qty, Multiplier, C_UOM_ID, M_Product_ID, C_Charge_ID, VendorProductNo, Line, C_OrderLine_ID, M_InOutLine_ID, M_RMALine_ID, C_BPartner_ID, C_Order_ID, M_InOut_ID, M_RMA_ID, C_Invoice_CreateFrom_v_ID, AD_Client_ID, AD_Org_ID, IsActive, IsSOTrx, AD_Table_ID) AS SELECT SUM(COALESCE(m.Qty,0)) AS CreditQty, l.QtyOrdered-SUM(COALESCE(m.Qty,l.QtyInvoiced)) AS Qty, CASE WHEN l.QtyOrdered=0 THEN 0 ELSE l.QtyEntered/l.QtyOrdered END AS Multiplier, l.C_UOM_ID AS C_UOM_ID, COALESCE(l.M_Product_ID, 0) AS M_Product_ID, COALESCE(l.C_Charge_ID, 0) AS C_Charge_ID, po.VendorProductNo AS VendorProductNo, l.Line AS Line, l.C_OrderLine_ID AS C_OrderLine_ID, 0 AS M_InOutLine_ID, 0 AS M_RMALine_ID, l.C_BPartner_ID AS C_BPartner_ID, l.C_Order_ID AS C_Order_ID, 0 AS M_InOut_ID, 0 AS M_RMA_ID, l.C_OrderLine_ID AS C_Invoice_CreateFrom_v_ID, l.AD_Client_ID AS AD_Client_ID, l.AD_Org_ID AS AD_Org_ID, l.IsActive AS IsActive, o.IsSOTrx AS IsSOTrx, 260 AS AD_Table_ID FROM C_OrderLine l
+     JOIN C_Order o ON o.C_Order_ID = l.C_Order_ID 
+     LEFT JOIN M_Product_PO po ON l.M_Product_ID = po.M_Product_ID AND l.C_BPartner_ID = po.C_BPartner_ID
+     LEFT JOIN M_MatchPO m ON l.c_orderline_id = m.C_OrderLine_ID AND m.C_InvoiceLine_ID IS NOT NULL AND COALESCE(m.Reversal_ID,0)=0
+     LEFT JOIN M_Product p ON l.M_Product_ID = p.M_Product_ID GROUP BY l.QtyOrdered,CASE WHEN l.QtyOrdered=0 THEN 0 ELSE l.QtyEntered/l.QtyOrdered END,
+l.C_UOM_ID, po.VendorProductNo, l.M_Product_ID, l.C_Charge_ID, l.Line, l.C_OrderLine_ID, o.IsSOTrx, 
+l.AD_Client_ID, l.AD_Org_ID, l.IsActive,l.c_bpartner_id,l.C_Order_ID 
+HAVING l.QtyOrdered-SUM(COALESCE(m.Qty,l.QtyInvoiced)) <> 0 UNION  ALL SELECT CASE WHEN io.IsSOTrx='N' THEN (l.Movementqty-SUM(COALESCE(mi.Qty, 0))*CASE WHEN io.MovementType = 'V-' THEN -1 ELSE 1 END) ELSE (l.Movementqty-SUM(COALESCE(mi.Qty, 0))*CASE WHEN io.MovementType = 'V-' THEN -1 ELSE 1 END) END AS CreditQty, l.Movementqty-SUM(COALESCE(mi.Qty, 0))*CASE WHEN io.MovementType = 'V-' THEN -1 ELSE 1 END AS Qty, l.QtyEntered/l.MovementQty AS Multiplier, l.C_UOM_ID AS C_UOM_ID, l.M_Product_ID AS M_Product_ID, l.C_Charge_ID AS C_Charge_ID, po.VendorProductNo AS VendorProductNo, l.Line AS Line, l.C_OrderLine_ID AS C_OrderLine_ID, l.M_InOutLine_ID AS M_InOutLine_ID, 0 AS M_RMALine_ID, io.C_BPartner_ID AS C_BPartner_ID, 0 AS C_Order_ID, l.M_InOut_ID AS M_InOut_ID, 0 AS M_RMA_ID, l.M_InOutLine_ID AS C_Invoice_CreateFrom_v_ID, l.AD_Client_ID AS AD_Client_ID, l.AD_Org_ID AS AD_Org_ID, l.IsActive AS IsActive, io.IsSOTrx AS IsSOTrx, 320 AS AD_Table_ID FROM M_InOutLine l
+     LEFT JOIN M_Product p ON l.M_Product_ID = p.M_Product_ID
+     JOIN M_InOut io ON l.m_inout_id= io.M_InOut_ID
+     LEFT JOIN M_Product_PO po ON l.M_Product_ID = po.M_Product_ID AND io.C_BPartner_ID = po.C_BPartner_ID
+     LEFT JOIN M_MatchInv mi ON l.M_InOutLine_ID = mi.M_InOutLine_ID WHERE l.MovementQty <> 0 AND io.IsSOTrx='N' GROUP BY io.MovementType, l.MovementQty, l.QtyEntered/l.MovementQty, l.C_UOM_ID, po.VendorProductNo, l.M_Product_ID, l.C_Charge_ID, 
+	 l.Line, l.C_OrderLine_ID, l.M_InOutLine_ID, io.C_BPartner_ID, l.M_InOut_ID, io.IsSOTrx, l.AD_Client_ID, l.AD_Org_ID, l.IsActive 
+	 HAVING l.MovementQty-SUM(COALESCE(mi.Qty, 0)) <> 0 UNION  ALL SELECT l.MovementQty-SUM(COALESCE(il.QtyInvoiced,0)) AS CreditQty, l.MovementQty-SUM(COALESCE(il.QtyInvoiced,0)) AS Qty, l.QtyEntered/l.MovementQty AS Multiplier, l.C_UOM_ID AS C_UOM_ID, l.M_Product_ID AS M_Product_ID, l.C_Charge_ID AS C_Charge_ID, po.VendorProductNo AS VendorProductNo, l.Line AS Line, l.C_OrderLine_ID AS C_OrderLine_ID, l.M_InOutLine_ID AS M_InOutLine_ID, 0 AS M_RMALine_ID, io.C_BPartner_ID AS C_BPartner_ID, 0 AS C_Order_ID, l.M_InOut_ID AS M_InOut_ID, 0 AS M_RMA_ID, l.M_InOutLine_ID AS C_Invoice_CreateFrom_v_ID, l.AD_Client_ID AS AD_Client_ID, l.AD_Org_ID AS AD_Org_ID, l.IsActive AS IsActive, io.IsSOTrx AS IsSOTrx, 320 AS AD_Table_ID FROM M_InOutLine l
+     LEFT JOIN M_Product p ON l.M_Product_ID = p.M_Product_ID
+     JOIN M_InOut io ON l.m_inout_id= io.M_InOut_ID
+     LEFT JOIN M_Product_PO po ON l.M_Product_ID = po.M_Product_ID AND io.C_BPartner_ID = po.C_BPartner_ID
+     LEFT JOIN C_InvoiceLine il ON l.M_InOutLine_ID = il.M_InOutLine_ID  WHERE l.MovementQty <> 0 AND io.IsSOTrx='Y' GROUP BY io.MovementType, l.MovementQty, l.QtyEntered/l.MovementQty, l.C_UOM_ID, po.VendorProductNo, l.M_Product_ID, l.C_Charge_ID, 
+	 l.Line, l.C_OrderLine_ID, l.M_InOutLine_ID, io.C_BPartner_ID, l.M_InOut_ID, io.IsSOTrx, l.AD_Client_ID, l.AD_Org_ID, l.IsActive 
+	 HAVING l.MovementQty-SUM(COALESCE(il.QtyInvoiced,0)) <> 0 UNION  ALL SELECT rl.Qty - COALESCE(rl.QtyInvoiced, 0) AS CreditQty, rl.Qty - COALESCE(rl.QtyInvoiced, 0) AS Qty, 1 AS Multiplier, uom.C_UOM_ID AS C_UOM_ID, p.M_Product_ID AS M_Product_ID, c.C_Charge_ID AS C_Charge_ID, po.VendorProductNo AS VendorProductNo, rl.Line AS Line, 0 AS C_OrderLine_ID, 0 AS M_InOutLine_ID, rl.M_RMALine_ID AS M_RMALine_ID, r.C_BPartner_ID AS C_BPartner_ID, 0 AS C_Order_ID, 0 AS M_InOut_ID, r.m_rma_id AS M_RMA_ID, rl.M_RMALine_ID AS C_Invoice_CreateFrom_v_ID, rl.AD_Client_ID AS AD_Client_ID, rl.AD_Org_ID AS AD_Org_ID, rl.IsActive AS IsActive, r.IsSOTrx AS IsSOTrx, 660 AS AD_Table_ID FROM m_rmaline rl
+     JOIN m_rma r ON r.m_rma_id = rl.m_rma_id
+     JOIN m_inoutline iol ON rl.m_inoutline_id = iol.m_inoutline_id
+     LEFT JOIN m_product p ON p.m_product_id = iol.m_product_id
+     LEFT JOIN c_uom uom ON uom.c_uom_id = COALESCE(p.c_uom_id, iol.c_uom_id)
+     LEFT JOIN c_charge c ON c.c_charge_id = iol.c_charge_id
+     LEFT JOIN m_product_po po ON rl.m_product_id = po.m_product_id AND r.c_bpartner_id = po.c_bpartner_id WHERE rl.m_inoutline_id IS NOT NULL UNION  ALL SELECT rl.Qty - COALESCE(rl.QtyInvoiced, 0) AS CreditQty, rl.Qty - COALESCE(rl.QtyInvoiced, 0) AS Qty, 1 AS Multiplier, uom.C_UOM_ID AS C_UOM_ID, p.M_Product_ID AS M_Product_ID, 0 AS C_Charge_ID, po.VendorProductNo AS VendorProductNo, rl.Line AS Line, 0 AS C_OrderLine_ID, 0 AS M_InOutLine_ID, rl.M_RMALine_ID AS M_RMALine_ID, r.C_BPartner_ID AS C_BPartner_ID, 0 AS C_Order_ID, 0 AS M_InOut_ID, r.M_RMA_ID AS M_RMA_ID, rl.M_RMALine_ID AS C_Invoice_CreateFrom_v_ID, rl.AD_Client_ID AS AD_Client_ID, rl.AD_Org_ID AS AD_Org_ID, rl.IsActive AS IsActive, r.IsSOTrx AS IsSOTrx, 660 AS AD_Table_ID FROM m_rmaline rl
+     JOIN m_rma r ON r.m_rma_id = rl.m_rma_id
+     JOIN m_product p ON p.m_product_id = rl.m_product_id
+     LEFT JOIN c_uom uom ON uom.c_uom_id = p.c_uom_id
+     LEFT JOIN m_product_po po ON rl.m_product_id = po.m_product_id AND r.c_bpartner_id = po.c_bpartner_id WHERE rl.m_product_id IS NOT NULL AND rl.m_inoutline_id IS NULL UNION  ALL SELECT rl.Qty - COALESCE(rl.QtyInvoiced, 0) AS CreditQty, rl.Qty - COALESCE(rl.QtyInvoiced, 0) AS Qty, 1 AS Multiplier, uom.C_UOM_ID AS C_UOM_ID, 0 AS M_Product_ID, c.C_Charge_ID AS C_Charge_ID, NULL AS VendorProductNo, rl.Line AS Line, 0 AS C_OrderLine_ID, 0 AS M_InOutLine_ID, rl.M_RMALine_ID AS M_RMALine_ID, r.C_BPartner_ID AS C_BPartner_ID, 0 AS C_Order_ID, 0 AS M_InOut_ID, r.m_rma_id AS M_RMA_ID, rl.M_RMALine_ID AS C_Invoice_CreateFrom_v_ID, rl.AD_Client_ID AS AD_Client_ID, rl.AD_Org_ID AS AD_Org_ID, rl.IsActive AS IsActive, r.IsSOTrx AS IsSOTrx, 660 AS AD_Table_ID FROM m_rmaline rl
+     JOIN m_rma r ON r.m_rma_id = rl.m_rma_id
+     JOIN c_charge c ON c.c_charge_id = rl.c_charge_id
+     LEFT JOIN c_uom uom ON uom.c_uom_id = 100 WHERE rl.c_charge_id IS NOT NULL AND rl.m_inoutline_id IS NULL
+;
+
+-- Dec 1, 2023, 4:08:04 PM MYT
+UPDATE AD_InfoColumn SET DisplayLogic='@C_Order_ID@=0 & @M_InOut_ID@=0 & (@DocBaseType@=''APC'' | @DocBaseType@=''ARC'')',Updated=TO_TIMESTAMP('2023-12-01 16:08:04','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_InfoColumn_ID=200278
+;
+
+-- Dec 1, 2023, 4:37:05 PM MYT
+UPDATE AD_Val_Rule SET Code='C_BPartner_ID=@C_BPartner_ID@ AND IsSOTrx=''@IsSOTrx@'' AND DocStatus IN (''CL'',''CO'') AND 
+(CASE WHEN IsSOTrx=''N'' THEN 
+M_InOut_ID IN (
+SELECT sl.M_InOut_ID FROM M_InOutLine sl 
+LEFT OUTER JOIN M_MatchInv mi ON (sl.M_InOutLine_ID=mi.M_InOutLine_ID) 
+JOIN M_InOut s2 ON (sl.M_InOut_ID=s2.M_InOut_ID) 
+WHERE s2.C_BPartner_ID=@C_BPartner_ID@ AND s2.IsSOTrx=''@IsSOTrx@'' AND s2.DocStatus IN (''CL'',''CO'') 
+GROUP BY sl.M_InOut_ID,sl.MovementQty,s2.MovementType,mi.M_InOutLine_ID 
+HAVING (sl.MovementQty <> SUM(mi.Qty) * CASE WHEN s2.MovementType = ''V-'' THEN -1 ELSE 1 END 
+AND mi.M_InOutLine_ID IS NOT NULL) OR mi.M_InOutLine_ID IS NULL
+) 
+ELSE
+M_InOut_ID IN (
+SELECT sl.M_InOut_ID FROM M_InOutLine sl 
+INNER JOIN M_InOut s2 ON (sl.M_InOut_ID=s2.M_InOut_ID) 
+LEFT JOIN C_InvoiceLine il ON sl.M_InOutLine_ID = il.M_InOutLine_ID 
+WHERE s2.C_BPartner_ID=@C_BPartner_ID@ AND s2.IsSOTrx=''@IsSOTrx@'' AND s2.DocStatus IN (''CL'',''CO'') 
+GROUP BY sl.M_InOutLine_ID 
+HAVING sl.MovementQty - sum(COALESCE(il.QtyInvoiced,0)) > 0 
+) 
+END)
+AND M_InOut_ID IN (
+SELECT iol.M_InOut_ID FROM M_InOutLine iol
+JOIN M_InOut io ON (io.M_InOut_ID = iol.M_InOut_ID) 
+JOIN C_OrderLine ol ON (ol.C_OrderLine_ID = iol.C_OrderLine_ID) 
+WHERE io.C_BPartner_ID=@C_BPartner_ID@ AND io.IsSOTrx=''@IsSOTrx@'' AND io.DocStatus IN (''CL'',''CO'') 
+AND ol.QtyOrdered-ol.QtyInvoiced != 0
+UNION
+SELECT iol.M_InOut_ID FROM M_InOutLine iol
+JOIN M_InOut io ON (io.M_InOut_ID = iol.M_InOut_ID) 
+JOIN M_RMALine rl ON (rl.M_RMALine_ID = iol.M_RMALine_ID) 
+WHERE io.C_BPartner_ID=@C_BPartner_ID@ AND io.IsSOTrx=''@IsSOTrx@'' AND io.DocStatus IN (''CL'',''CO'') 
+AND rl.Qty-COALESCE(rl.QtyInvoiced,0) != 0
+)',Updated=TO_TIMESTAMP('2023-12-01 16:37:05','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Val_Rule_ID=200167
+;
+
+-- Dec 1, 2023, 5:31:46 PM MYT
+UPDATE AD_Val_Rule SET Code='C_BPartner_ID=@C_BPartner_ID@ AND IsSOTrx=''@IsSOTrx@'' AND DocStatus IN (''CL'',''CO'') AND C_Invoice_ID IN (
+SELECT il.C_Invoice_ID FROM C_InvoiceLine il 
+LEFT OUTER JOIN M_MatchInv mi ON (il.C_InvoiceLine_ID=mi.C_InvoiceLine_ID) 
+JOIN C_Invoice i2 ON (il.C_Invoice_ID = i2.C_Invoice_ID) 
+WHERE i2.C_BPartner_ID=@C_BPartner_ID@ AND i2.IsSOTrx=''@IsSOTrx@'' AND i2.DocStatus IN (''CL'',''CO'') 
+AND il.M_Product_ID IS NOT NULL 
+GROUP BY il.C_Invoice_ID,mi.C_InvoiceLine_ID,il.QtyInvoiced 
+HAVING (il.QtyInvoiced<>SUM(mi.Qty) AND mi.C_InvoiceLine_ID IS NOT NULL) OR mi.C_InvoiceLine_ID IS NULL) 
+AND C_Invoice_ID IN (
+SELECT il.C_Invoice_ID FROM C_InvoiceLine il
+JOIN C_Invoice i ON (i.C_Invoice_ID = il.C_Invoice_ID) 
+JOIN C_OrderLine ol ON (ol.C_OrderLine_ID = il.C_OrderLine_ID) 
+WHERE i.C_BPartner_ID=@C_BPartner_ID@ AND i.IsSOTrx=''@IsSOTrx@'' AND i.DocStatus IN (''CL'',''CO'') 
+AND il.M_Product_ID IS NOT NULL 
+AND il.M_InOutLine_ID IS NULL 
+AND ol.QtyOrdered-ol.QtyDelivered != 0)',Updated=TO_TIMESTAMP('2023-12-01 17:31:46','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Val_Rule_ID=200165
+;
+

--- a/migration/iD10/postgresql/202311221523_IDEMPIERE-5931.sql
+++ b/migration/iD10/postgresql/202311221523_IDEMPIERE-5931.sql
@@ -1,0 +1,70 @@
+-- IDEMPIERE-5931 Generate Invoices (manual) displays RMA for selection despite AR Credit memo already completed.
+SELECT register_migration_script('202311221523_IDEMPIERE-5931.sql') FROM dual;
+
+-- Nov 22, 2023, 3:23:50 PM MYT
+UPDATE AD_ViewComponent SET WhereClause='WHERE rma.docstatus = ''CO''
+AND dt.docbasetype = ''SOO''
+AND NOT EXISTS (SELECT 1
+	FROM c_invoice i
+	WHERE i.m_rma_id = rma.m_rma_id
+    AND i.docstatus IN (''IP'', ''CO'', ''CL''))
+AND NOT EXISTS (SELECT 1
+	FROM c_invoice i
+	JOIN c_invoiceline il ON il.c_invoice_id = i.c_invoice_id
+	JOIN m_rmaline rl ON rl.m_rmaline_id = il.m_rmaline_id
+	WHERE rl.m_rma_id = rma.m_rma_id
+    AND i.docstatus IN (''IP'', ''CO'', ''CL''))
+AND EXISTS (SELECT 1
+	FROM c_invoiceline il
+	JOIN m_inoutline iol ON il.m_inoutline_id = iol.m_inoutline_id
+	JOIN c_invoice i ON i.c_invoice_id = il.c_invoice_id
+	WHERE i.docstatus IN (''CO'', ''CL'') AND EXISTS (SELECT 1
+		FROM m_rmaline rl
+		WHERE rl.m_rma_id = rma.m_rma_id
+		AND iol.m_inoutline_id = rl.m_inoutline_id
+		AND rl.m_inoutline_id IS NOT NULL
+		AND COALESCE(rl.QtyInvoiced,0) < rl.Qty)
+	UNION 
+	SELECT 1
+	FROM c_invoiceline il
+	JOIN c_orderline ol ON il.c_orderline_id = ol.c_orderline_id
+	JOIN c_invoice i ON i.c_invoice_id = il.c_invoice_id
+	WHERE i.docstatus IN (''CO'', ''CL'') AND EXISTS (SELECT 1
+		FROM m_rmaline rl 
+		JOIN m_inoutline iol ON iol.m_inoutline_id = rl.m_inoutline_id
+		WHERE rl.m_rma_id = rma.m_rma_id
+		AND iol.c_orderline_id = ol.c_orderline_id
+		AND iol.c_orderline_id IS NOT NULL
+		AND COALESCE(rl.QtyInvoiced,0) < rl.Qty))',Updated=TO_TIMESTAMP('2023-11-22 15:23:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_ViewComponent_ID=200220
+;
+
+-- Nov 22, 2023, 3:24:03 PM MYT
+CREATE OR REPLACE VIEW C_Invoice_Candidate_v(AD_Client_ID, AD_Org_ID, Created, Updated, IsActive, C_BPartner_ID, C_Order_ID, M_InOut_ID, DocumentNo, DateOrdered, C_DocType_ID, InvoiceRule, TotalLines, DocSource, C_Invoice_Candidate_v_ID) AS SELECT o.ad_client_id AS AD_Client_ID, o.ad_org_id AS AD_Org_ID, o.created AS Created, o.updated AS Updated, o.isactive AS IsActive, o.c_bpartner_id AS C_BPartner_ID, o.c_order_id AS C_Order_ID, NULL AS M_InOut_ID, o.documentno AS DocumentNo, o.dateordered AS DateOrdered, o.c_doctype_id AS C_DocType_ID, o.invoicerule AS InvoiceRule, sum((l.qtyordered - l.qtyinvoiced) * l.priceactual) AS TotalLines, 'O' AS DocSource, o.c_order_id AS C_Invoice_Candidate_v_ID FROM c_order o JOIN c_orderline l ON o.c_order_id = l.c_order_id JOIN c_bpartner bp ON o.c_bpartner_id = bp.c_bpartner_id LEFT JOIN c_invoiceschedule si ON bp.c_invoiceschedule_id = si.c_invoiceschedule_id WHERE (o.docstatus IN ('CO', 'CL', 'IP')) AND (o.c_doctype_id IN ( SELECT c_doctype.c_doctype_id FROM c_doctype WHERE c_doctype.docbasetype = 'SOO' AND (c_doctype.docsubtypeso NOT IN ('ON', 'OB', 'WR')))) AND l.qtyordered <> l.qtyinvoiced AND (o.invoicerule = 'I' OR o.invoicerule = 'O' AND NOT (EXISTS ( SELECT 1 FROM c_orderline zz1 WHERE zz1.c_order_id = o.c_order_id AND zz1.qtyordered <> zz1.qtydelivered)) OR o.invoicerule = 'D' AND l.qtyinvoiced <> l.qtydelivered OR o.invoicerule = 'S' AND bp.c_invoiceschedule_id IS NULL OR o.invoicerule = 'S' AND bp.c_invoiceschedule_id IS NOT NULL AND (si.invoicefrequency IS NULL OR si.invoicefrequency = 'D' OR si.invoicefrequency = 'W' OR si.invoicefrequency = 'T' AND (trunc(o.dateordered) <= (firstof(statement_timestamp(), 'MM') + si.invoicedaycutoff - 1) AND trunc(statement_timestamp()) >= (firstof(o.dateordered, 'MM') + si.invoiceday - 1) OR trunc(o.dateordered) <= (firstof(statement_timestamp(), 'MM') + si.invoicedaycutoff + 14) AND trunc(statement_timestamp()) >= (firstof(o.dateordered, 'MM') + si.invoiceday + 14)) OR si.invoicefrequency = 'M' AND trunc(o.dateordered) <= (firstof(statement_timestamp(), 'MM') + si.invoicedaycutoff - 1) AND trunc(statement_timestamp()) >= (firstof(o.dateordered, 'MM') + si.invoiceday - 1))) GROUP BY o.ad_client_id, o.ad_org_id, o.created, o.updated, o.isactive, o.c_bpartner_id, o.c_order_id, o.documentno, o.dateordered, o.c_doctype_id,o.invoicerule UNION ALL SELECT rma.ad_client_id AS AD_Client_ID, rma.ad_org_id AS AD_Org_ID, rma.created AS Created, rma.updated AS Updated, rma.isactive AS IsActive, rma.c_bpartner_id AS C_BPartner_ID, rma.c_order_id AS C_Order_ID, rma.inout_id AS M_InOut_ID, rma.documentno AS DocumentNo, rma.created AS DateOrdered, rma.c_doctype_id AS C_DocType_ID, NULL AS InvoiceRule, rma.amt AS TotalLines, 'R' AS DocSource, rma.m_rma_id AS C_Invoice_Candidate_v_ID FROM m_rma rma JOIN c_doctype dt ON rma.c_doctype_id = dt.c_doctype_id WHERE rma.docstatus = 'CO' AND dt.docbasetype = 'SOO' AND NOT EXISTS (SELECT 1 FROM c_invoice i WHERE i.m_rma_id = rma.m_rma_id AND i.docstatus IN ('IP', 'CO', 'CL')) AND NOT EXISTS (SELECT 1 FROM c_invoice i JOIN c_invoiceline il ON il.c_invoice_id = i.c_invoice_id JOIN m_rmaline rl ON rl.m_rmaline_id = il.m_rmaline_id WHERE rl.m_rma_id = rma.m_rma_id AND i.docstatus IN ('IP', 'CO', 'CL')) AND EXISTS (SELECT 1 FROM c_invoiceline il JOIN m_inoutline iol ON il.m_inoutline_id = iol.m_inoutline_id JOIN c_invoice i ON i.c_invoice_id = il.c_invoice_id WHERE i.docstatus IN ('CO', 'CL') AND EXISTS (SELECT 1 FROM m_rmaline rl WHERE rl.m_rma_id = rma.m_rma_id AND iol.m_inoutline_id = rl.m_inoutline_id AND rl.m_inoutline_id IS NOT NULL AND COALESCE(rl.QtyInvoiced,0) < rl.Qty) UNION SELECT 1 FROM c_invoiceline il JOIN c_orderline ol ON il.c_orderline_id = ol.c_orderline_id JOIN c_invoice i ON i.c_invoice_id = il.c_invoice_id WHERE i.docstatus IN ('CO', 'CL') AND EXISTS (SELECT 1 FROM m_rmaline rl JOIN m_inoutline iol ON iol.m_inoutline_id = rl.m_inoutline_id WHERE rl.m_rma_id = rma.m_rma_id AND iol.c_orderline_id = ol.c_orderline_id AND iol.c_orderline_id IS NOT NULL AND COALESCE(rl.QtyInvoiced,0) < rl.Qty))
+;
+
+-- Nov 22, 2023, 4:57:03 PM MYT
+UPDATE AD_ViewComponent SET WhereClause='WHERE RMA.docstatus = ''CO''
+AND DT.docbasetype = ''POO''
+AND EXISTS (SELECT 1
+	FROM m_rma R
+	INNER JOIN m_rmaline RL ON R.m_rma_id = RL.m_rma_id
+	WHERE R.m_rma_id = RMA.m_rma_id
+	AND RL.isactive = ''Y''
+	AND RL.m_inoutline_id > 0
+	AND RL.qtydelivered < RL.qty)
+AND NOT EXISTS (SELECT 1
+	FROM m_inout OIO
+	WHERE OIO.m_rma_id = RMA.m_rma_id
+	AND OIO.docstatus IN (''IP'', ''CO'', ''CL''))
+AND NOT EXISTS (SELECT 1
+	FROM m_inout OIO
+	JOIN m_inoutline IL ON IL.m_inout_id = OIO.m_inout_id
+	JOIN m_rmaline RL ON RL.m_rmaline_id = IL.m_rmaline_id
+	WHERE RL.m_rma_id = rma.m_rma_id
+    AND OIO.docstatus IN (''IP'', ''CO'', ''CL''))',Updated=TO_TIMESTAMP('2023-11-22 16:57:03','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_ViewComponent_ID=200219
+;
+
+-- Nov 22, 2023, 4:57:16 PM MYT
+CREATE OR REPLACE VIEW M_InOut_Candidate_v(AD_Client_ID, AD_Org_ID, Created, Updated, IsActive, C_BPartner_ID, C_Order_ID, DocumentNo, DateOrdered, C_DocType_ID, POReference, Description, SalesRep_ID, M_Warehouse_ID, M_InOut_ID, TotalLines, DocSource, M_InOut_Candidate_v_ID, DeliveryRule) AS SELECT o.ad_client_id AS AD_Client_ID, o.ad_org_id AS AD_Org_ID, o.created AS Created, o.updated AS Updated, o.isactive AS IsActive, o.c_bpartner_id AS C_BPartner_ID, o.c_order_id AS C_Order_ID, o.documentno AS DocumentNo, o.dateordered AS DateOrdered, o.c_doctype_id AS C_DocType_ID, o.poreference AS POReference, o.description AS Description, o.salesrep_id AS SalesRep_ID, l.m_warehouse_id AS M_Warehouse_ID, NULL AS M_InOut_ID, sum((l.qtyordered - l.qtydelivered) * l.priceactual) AS TotalLines, 'O' AS DocSource, o.c_order_id AS M_InOut_Candidate_v_ID, o.deliveryrule AS DeliveryRule FROM c_order o JOIN c_orderline l ON o.c_order_id = l.c_order_id WHERE o.docstatus = 'CO' AND o.isdelivered = 'N' AND (o.c_doctype_id IN ( SELECT c_doctype.c_doctype_id FROM c_doctype WHERE c_doctype.docbasetype = 'SOO' AND (c_doctype.docsubtypeso NOT IN ('ON', 'OB', 'WR')))) AND o.deliveryrule <> 'M' AND (l.m_product_id IS NULL OR (EXISTS ( SELECT 1 FROM m_product p WHERE l.m_product_id = p.m_product_id AND p.isexcludeautodelivery = 'N'))) AND l.qtyordered <> l.qtydelivered AND (l.m_product_id IS NOT NULL OR l.c_charge_id IS NOT NULL) AND NOT (EXISTS ( SELECT 1 FROM m_inoutline iol JOIN m_inout io ON iol.m_inout_id = io.m_inout_id WHERE iol.c_orderline_id = l.c_orderline_id AND (io.docstatus IN ('DR', 'IN', 'IP', 'WC')))) GROUP BY o.ad_client_id, o.ad_org_id, o.c_bpartner_id, o.c_order_id, o.documentno, o.dateordered, o.c_doctype_id, o.poreference, o.description, o.salesrep_id, l.m_warehouse_id, o.created, o.updated, o.isactive, o.deliveryrule UNION ALL SELECT rma.ad_client_id AS AD_Client_ID, rma.ad_org_id AS AD_Org_ID, rma.created AS Created, rma.updated AS Updated, rma.isactive AS IsActive, rma.c_bpartner_id AS C_BPartner_ID, rma.c_order_id AS C_Order_ID, rma.documentno AS DocumentNo, rma.created AS DateOrdered, rma.c_doctype_id AS C_DocType_ID, NULL AS POReference, NULL AS Description, NULL AS SalesRep_ID, io.m_warehouse_id AS M_Warehouse_ID, rma.inout_id AS M_InOut_ID, rma.amt AS TotalLines, 'R' AS DocSource, rma.m_rma_id AS M_InOut_Candidate_v_ID, NULL AS DeliveryRule FROM m_rma RMA INNER JOIN ad_org ORG ON RMA.ad_org_id = ORG.ad_org_id INNER JOIN c_doctype DT ON RMA.c_doctype_id = DT.c_doctype_id INNER JOIN c_bpartner BP ON RMA.c_bpartner_id = BP.c_bpartner_id INNER JOIN m_inout IO ON RMA.inout_id = IO.m_inout_id WHERE RMA.docstatus = 'CO' AND DT.docbasetype = 'POO' AND EXISTS (SELECT 1 FROM m_rma R INNER JOIN m_rmaline RL ON R.m_rma_id = RL.m_rma_id WHERE R.m_rma_id = RMA.m_rma_id AND RL.isactive = 'Y' AND RL.m_inoutline_id > 0 AND RL.qtydelivered < RL.qty) AND NOT EXISTS (SELECT 1 FROM m_inout OIO WHERE OIO.m_rma_id = RMA.m_rma_id AND OIO.docstatus IN ('IP', 'CO', 'CL')) AND NOT EXISTS (SELECT 1 FROM m_inout OIO JOIN m_inoutline IL ON IL.m_inout_id = OIO.m_inout_id JOIN m_rmaline RL ON RL.m_rmaline_id = IL.m_rmaline_id WHERE RL.m_rma_id = rma.m_rma_id AND OIO.docstatus IN ('IP', 'CO', 'CL'))
+;
+

--- a/migration/iD10/postgresql/202312011228_IDEMPIERE-5931.sql
+++ b/migration/iD10/postgresql/202312011228_IDEMPIERE-5931.sql
@@ -1,0 +1,78 @@
+-- IDEMPIERE-5931 Generate Invoices (manual) displays RMA for selection despite AR Credit memo already completed.
+SELECT register_migration_script('202312011228_IDEMPIERE-5931.sql') FROM dual;
+
+-- Dec 1, 2023, 1:05:12 PM MYT
+UPDATE AD_ViewColumn SET ColumnSQL='l.QtyOrdered-SUM(COALESCE(m.Qty,l.QtyInvoiced))',Updated=TO_TIMESTAMP('2023-12-01 13:05:12','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_ViewColumn_ID=217539
+;
+
+-- Dec 1, 2023, 1:05:34 PM MYT
+UPDATE AD_ViewComponent SET OtherClause='GROUP BY l.QtyOrdered,CASE WHEN l.QtyOrdered=0 THEN 0 ELSE l.QtyEntered/l.QtyOrdered END,
+l.C_UOM_ID, po.VendorProductNo, l.M_Product_ID, l.C_Charge_ID, l.Line, l.C_OrderLine_ID, o.IsSOTrx, 
+l.AD_Client_ID, l.AD_Org_ID, l.IsActive,l.c_bpartner_id,l.C_Order_ID 
+HAVING l.QtyOrdered-SUM(COALESCE(m.Qty,l.QtyInvoiced)) <> 0',Updated=TO_TIMESTAMP('2023-12-01 13:05:34','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_ViewComponent_ID=200227
+;
+
+-- Dec 1, 2023, 1:06:05 PM MYT
+CREATE OR REPLACE VIEW C_Invoice_CreateFrom_v(CreditQty, Qty, Multiplier, C_UOM_ID, M_Product_ID, C_Charge_ID, VendorProductNo, Line, C_OrderLine_ID, M_InOutLine_ID, M_RMALine_ID, C_BPartner_ID, C_Order_ID, M_InOut_ID, M_RMA_ID, C_Invoice_CreateFrom_v_ID, AD_Client_ID, AD_Org_ID, IsActive, IsSOTrx, AD_Table_ID) AS SELECT SUM(COALESCE(m.Qty,0)) AS CreditQty, l.QtyOrdered-SUM(COALESCE(m.Qty,l.QtyInvoiced)) AS Qty, CASE WHEN l.QtyOrdered=0 THEN 0 ELSE l.QtyEntered/l.QtyOrdered END AS Multiplier, l.C_UOM_ID AS C_UOM_ID, COALESCE(l.M_Product_ID, 0) AS M_Product_ID, COALESCE(l.C_Charge_ID, 0) AS C_Charge_ID, po.VendorProductNo AS VendorProductNo, l.Line AS Line, l.C_OrderLine_ID AS C_OrderLine_ID, 0 AS M_InOutLine_ID, 0 AS M_RMALine_ID, l.C_BPartner_ID AS C_BPartner_ID, l.C_Order_ID AS C_Order_ID, 0 AS M_InOut_ID, 0 AS M_RMA_ID, l.C_OrderLine_ID AS C_Invoice_CreateFrom_v_ID, l.AD_Client_ID AS AD_Client_ID, l.AD_Org_ID AS AD_Org_ID, l.IsActive AS IsActive, o.IsSOTrx AS IsSOTrx, 260 AS AD_Table_ID FROM C_OrderLine l JOIN C_Order o ON o.C_Order_ID = l.C_Order_ID LEFT JOIN M_Product_PO po ON l.M_Product_ID = po.M_Product_ID AND l.C_BPartner_ID = po.C_BPartner_ID LEFT JOIN M_MatchPO m ON l.c_orderline_id = m.C_OrderLine_ID AND m.C_InvoiceLine_ID IS NOT NULL AND COALESCE(m.Reversal_ID,0)=0 LEFT JOIN M_Product p ON l.M_Product_ID = p.M_Product_ID GROUP BY l.QtyOrdered,CASE WHEN l.QtyOrdered=0 THEN 0 ELSE l.QtyEntered/l.QtyOrdered END, l.C_UOM_ID, po.VendorProductNo, l.M_Product_ID, l.C_Charge_ID, l.Line, l.C_OrderLine_ID, o.IsSOTrx, l.AD_Client_ID, l.AD_Org_ID, l.IsActive,l.c_bpartner_id,l.C_Order_ID HAVING l.QtyOrdered-SUM(COALESCE(m.Qty,l.QtyInvoiced)) <> 0 UNION ALL SELECT CASE WHEN io.IsSOTrx='N' THEN (l.Movementqty-SUM(COALESCE(mi.Qty, 0))*CASE WHEN io.MovementType = 'V-' THEN -1 ELSE 1 END) ELSE (l.Movementqty-SUM(COALESCE(mi.Qty, 0))*CASE WHEN io.MovementType = 'V-' THEN -1 ELSE 1 END) END AS CreditQty, l.Movementqty-SUM(COALESCE(mi.Qty, 0))*CASE WHEN io.MovementType = 'V-' THEN -1 ELSE 1 END AS Qty, l.QtyEntered/l.MovementQty AS Multiplier, l.C_UOM_ID AS C_UOM_ID, l.M_Product_ID AS M_Product_ID, l.C_Charge_ID AS C_Charge_ID, po.VendorProductNo AS VendorProductNo, l.Line AS Line, l.C_OrderLine_ID AS C_OrderLine_ID, l.M_InOutLine_ID AS M_InOutLine_ID, 0 AS M_RMALine_ID, io.C_BPartner_ID AS C_BPartner_ID, 0 AS C_Order_ID, l.M_InOut_ID AS M_InOut_ID, 0 AS M_RMA_ID, l.M_InOutLine_ID AS C_Invoice_CreateFrom_v_ID, l.AD_Client_ID AS AD_Client_ID, l.AD_Org_ID AS AD_Org_ID, l.IsActive AS IsActive, io.IsSOTrx AS IsSOTrx, 320 AS AD_Table_ID FROM M_InOutLine l LEFT JOIN M_Product p ON l.M_Product_ID = p.M_Product_ID JOIN M_InOut io ON l.m_inout_id= io.M_InOut_ID LEFT JOIN M_Product_PO po ON l.M_Product_ID = po.M_Product_ID AND io.C_BPartner_ID = po.C_BPartner_ID LEFT JOIN M_MatchInv mi ON l.M_InOutLine_ID = mi.M_InOutLine_ID WHERE l.MovementQty <> 0 AND io.IsSOTrx='N' GROUP BY io.MovementType, l.MovementQty, l.QtyEntered/l.MovementQty, l.C_UOM_ID, po.VendorProductNo, l.M_Product_ID, l.C_Charge_ID, l.Line, l.C_OrderLine_ID, l.M_InOutLine_ID, io.C_BPartner_ID, l.M_InOut_ID, io.IsSOTrx, l.AD_Client_ID, l.AD_Org_ID, l.IsActive HAVING l.MovementQty-SUM(COALESCE(mi.Qty, 0)) <> 0 UNION ALL SELECT l.MovementQty-SUM(COALESCE(il.QtyInvoiced,0)) AS CreditQty, l.MovementQty-SUM(COALESCE(il.QtyInvoiced,0)) AS Qty, l.QtyEntered/l.MovementQty AS Multiplier, l.C_UOM_ID AS C_UOM_ID, l.M_Product_ID AS M_Product_ID, l.C_Charge_ID AS C_Charge_ID, po.VendorProductNo AS VendorProductNo, l.Line AS Line, l.C_OrderLine_ID AS C_OrderLine_ID, l.M_InOutLine_ID AS M_InOutLine_ID, 0 AS M_RMALine_ID, io.C_BPartner_ID AS C_BPartner_ID, 0 AS C_Order_ID, l.M_InOut_ID AS M_InOut_ID, 0 AS M_RMA_ID, l.M_InOutLine_ID AS C_Invoice_CreateFrom_v_ID, l.AD_Client_ID AS AD_Client_ID, l.AD_Org_ID AS AD_Org_ID, l.IsActive AS IsActive, io.IsSOTrx AS IsSOTrx, 320 AS AD_Table_ID FROM M_InOutLine l LEFT JOIN M_Product p ON l.M_Product_ID = p.M_Product_ID JOIN M_InOut io ON l.m_inout_id= io.M_InOut_ID LEFT JOIN M_Product_PO po ON l.M_Product_ID = po.M_Product_ID AND io.C_BPartner_ID = po.C_BPartner_ID LEFT JOIN C_InvoiceLine il ON l.M_InOutLine_ID = il.M_InOutLine_ID WHERE l.MovementQty <> 0 AND io.IsSOTrx='Y' GROUP BY io.MovementType, l.MovementQty, l.QtyEntered/l.MovementQty, l.C_UOM_ID, po.VendorProductNo, l.M_Product_ID, l.C_Charge_ID, l.Line, l.C_OrderLine_ID, l.M_InOutLine_ID, io.C_BPartner_ID, l.M_InOut_ID, io.IsSOTrx, l.AD_Client_ID, l.AD_Org_ID, l.IsActive HAVING l.MovementQty-SUM(COALESCE(il.QtyInvoiced,0)) <> 0 UNION ALL SELECT rl.Qty - COALESCE(rl.QtyInvoiced, 0) AS CreditQty, rl.Qty - COALESCE(rl.QtyInvoiced, 0) AS Qty, 1 AS Multiplier, uom.C_UOM_ID AS C_UOM_ID, p.M_Product_ID AS M_Product_ID, c.C_Charge_ID AS C_Charge_ID, po.VendorProductNo AS VendorProductNo, rl.Line AS Line, 0 AS C_OrderLine_ID, 0 AS M_InOutLine_ID, rl.M_RMALine_ID AS M_RMALine_ID, r.C_BPartner_ID AS C_BPartner_ID, 0 AS C_Order_ID, 0 AS M_InOut_ID, r.m_rma_id AS M_RMA_ID, rl.M_RMALine_ID AS C_Invoice_CreateFrom_v_ID, rl.AD_Client_ID AS AD_Client_ID, rl.AD_Org_ID AS AD_Org_ID, rl.IsActive AS IsActive, r.IsSOTrx AS IsSOTrx, 660 AS AD_Table_ID FROM m_rmaline rl JOIN m_rma r ON r.m_rma_id = rl.m_rma_id JOIN m_inoutline iol ON rl.m_inoutline_id = iol.m_inoutline_id LEFT JOIN m_product p ON p.m_product_id = iol.m_product_id LEFT JOIN c_uom uom ON uom.c_uom_id = COALESCE(p.c_uom_id, iol.c_uom_id) LEFT JOIN c_charge c ON c.c_charge_id = iol.c_charge_id LEFT JOIN m_product_po po ON rl.m_product_id = po.m_product_id AND r.c_bpartner_id = po.c_bpartner_id WHERE rl.m_inoutline_id IS NOT NULL UNION ALL SELECT rl.Qty - COALESCE(rl.QtyInvoiced, 0) AS CreditQty, rl.Qty - COALESCE(rl.QtyInvoiced, 0) AS Qty, 1 AS Multiplier, uom.C_UOM_ID AS C_UOM_ID, p.M_Product_ID AS M_Product_ID, 0 AS C_Charge_ID, po.VendorProductNo AS VendorProductNo, rl.Line AS Line, 0 AS C_OrderLine_ID, 0 AS M_InOutLine_ID, rl.M_RMALine_ID AS M_RMALine_ID, r.C_BPartner_ID AS C_BPartner_ID, 0 AS C_Order_ID, 0 AS M_InOut_ID, r.M_RMA_ID AS M_RMA_ID, rl.M_RMALine_ID AS C_Invoice_CreateFrom_v_ID, rl.AD_Client_ID AS AD_Client_ID, rl.AD_Org_ID AS AD_Org_ID, rl.IsActive AS IsActive, r.IsSOTrx AS IsSOTrx, 660 AS AD_Table_ID FROM m_rmaline rl JOIN m_rma r ON r.m_rma_id = rl.m_rma_id JOIN m_product p ON p.m_product_id = rl.m_product_id LEFT JOIN c_uom uom ON uom.c_uom_id = p.c_uom_id LEFT JOIN m_product_po po ON rl.m_product_id = po.m_product_id AND r.c_bpartner_id = po.c_bpartner_id WHERE rl.m_product_id IS NOT NULL AND rl.m_inoutline_id IS NULL UNION ALL SELECT rl.Qty - COALESCE(rl.QtyInvoiced, 0) AS CreditQty, rl.Qty - COALESCE(rl.QtyInvoiced, 0) AS Qty, 1 AS Multiplier, uom.C_UOM_ID AS C_UOM_ID, 0 AS M_Product_ID, c.C_Charge_ID AS C_Charge_ID, NULL AS VendorProductNo, rl.Line AS Line, 0 AS C_OrderLine_ID, 0 AS M_InOutLine_ID, rl.M_RMALine_ID AS M_RMALine_ID, r.C_BPartner_ID AS C_BPartner_ID, 0 AS C_Order_ID, 0 AS M_InOut_ID, r.m_rma_id AS M_RMA_ID, rl.M_RMALine_ID AS C_Invoice_CreateFrom_v_ID, rl.AD_Client_ID AS AD_Client_ID, rl.AD_Org_ID AS AD_Org_ID, rl.IsActive AS IsActive, r.IsSOTrx AS IsSOTrx, 660 AS AD_Table_ID FROM m_rmaline rl JOIN m_rma r ON r.m_rma_id = rl.m_rma_id JOIN c_charge c ON c.c_charge_id = rl.c_charge_id LEFT JOIN c_uom uom ON uom.c_uom_id = 100 WHERE rl.c_charge_id IS NOT NULL AND rl.m_inoutline_id IS NULL
+;
+
+-- Dec 1, 2023, 4:08:04 PM MYT
+UPDATE AD_InfoColumn SET DisplayLogic='@C_Order_ID@=0 & @M_InOut_ID@=0 & (@DocBaseType@=''APC'' | @DocBaseType@=''ARC'')',Updated=TO_TIMESTAMP('2023-12-01 16:08:04','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_InfoColumn_ID=200278
+;
+
+-- Dec 1, 2023, 4:37:05 PM MYT
+UPDATE AD_Val_Rule SET Code='C_BPartner_ID=@C_BPartner_ID@ AND IsSOTrx=''@IsSOTrx@'' AND DocStatus IN (''CL'',''CO'') AND 
+(CASE WHEN IsSOTrx=''N'' THEN 
+M_InOut_ID IN (
+SELECT sl.M_InOut_ID FROM M_InOutLine sl 
+LEFT OUTER JOIN M_MatchInv mi ON (sl.M_InOutLine_ID=mi.M_InOutLine_ID) 
+JOIN M_InOut s2 ON (sl.M_InOut_ID=s2.M_InOut_ID) 
+WHERE s2.C_BPartner_ID=@C_BPartner_ID@ AND s2.IsSOTrx=''@IsSOTrx@'' AND s2.DocStatus IN (''CL'',''CO'') 
+GROUP BY sl.M_InOut_ID,sl.MovementQty,s2.MovementType,mi.M_InOutLine_ID 
+HAVING (sl.MovementQty <> SUM(mi.Qty) * CASE WHEN s2.MovementType = ''V-'' THEN -1 ELSE 1 END 
+AND mi.M_InOutLine_ID IS NOT NULL) OR mi.M_InOutLine_ID IS NULL
+) 
+ELSE
+M_InOut_ID IN (
+SELECT sl.M_InOut_ID FROM M_InOutLine sl 
+INNER JOIN M_InOut s2 ON (sl.M_InOut_ID=s2.M_InOut_ID) 
+LEFT JOIN C_InvoiceLine il ON sl.M_InOutLine_ID = il.M_InOutLine_ID 
+WHERE s2.C_BPartner_ID=@C_BPartner_ID@ AND s2.IsSOTrx=''@IsSOTrx@'' AND s2.DocStatus IN (''CL'',''CO'') 
+GROUP BY sl.M_InOutLine_ID 
+HAVING sl.MovementQty - sum(COALESCE(il.QtyInvoiced,0)) > 0 
+) 
+END)
+AND M_InOut_ID IN (
+SELECT iol.M_InOut_ID FROM M_InOutLine iol
+JOIN M_InOut io ON (io.M_InOut_ID = iol.M_InOut_ID) 
+JOIN C_OrderLine ol ON (ol.C_OrderLine_ID = iol.C_OrderLine_ID) 
+WHERE io.C_BPartner_ID=@C_BPartner_ID@ AND io.IsSOTrx=''@IsSOTrx@'' AND io.DocStatus IN (''CL'',''CO'') 
+AND ol.QtyOrdered-ol.QtyInvoiced != 0
+UNION
+SELECT iol.M_InOut_ID FROM M_InOutLine iol
+JOIN M_InOut io ON (io.M_InOut_ID = iol.M_InOut_ID) 
+JOIN M_RMALine rl ON (rl.M_RMALine_ID = iol.M_RMALine_ID) 
+WHERE io.C_BPartner_ID=@C_BPartner_ID@ AND io.IsSOTrx=''@IsSOTrx@'' AND io.DocStatus IN (''CL'',''CO'') 
+AND rl.Qty-COALESCE(rl.QtyInvoiced,0) != 0
+)',Updated=TO_TIMESTAMP('2023-12-01 16:37:05','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Val_Rule_ID=200167
+;
+
+-- Dec 1, 2023, 5:31:46 PM MYT
+UPDATE AD_Val_Rule SET Code='C_BPartner_ID=@C_BPartner_ID@ AND IsSOTrx=''@IsSOTrx@'' AND DocStatus IN (''CL'',''CO'') AND C_Invoice_ID IN (
+SELECT il.C_Invoice_ID FROM C_InvoiceLine il 
+LEFT OUTER JOIN M_MatchInv mi ON (il.C_InvoiceLine_ID=mi.C_InvoiceLine_ID) 
+JOIN C_Invoice i2 ON (il.C_Invoice_ID = i2.C_Invoice_ID) 
+WHERE i2.C_BPartner_ID=@C_BPartner_ID@ AND i2.IsSOTrx=''@IsSOTrx@'' AND i2.DocStatus IN (''CL'',''CO'') 
+AND il.M_Product_ID IS NOT NULL 
+GROUP BY il.C_Invoice_ID,mi.C_InvoiceLine_ID,il.QtyInvoiced 
+HAVING (il.QtyInvoiced<>SUM(mi.Qty) AND mi.C_InvoiceLine_ID IS NOT NULL) OR mi.C_InvoiceLine_ID IS NULL) 
+AND C_Invoice_ID IN (
+SELECT il.C_Invoice_ID FROM C_InvoiceLine il
+JOIN C_Invoice i ON (i.C_Invoice_ID = il.C_Invoice_ID) 
+JOIN C_OrderLine ol ON (ol.C_OrderLine_ID = il.C_OrderLine_ID) 
+WHERE i.C_BPartner_ID=@C_BPartner_ID@ AND i.IsSOTrx=''@IsSOTrx@'' AND i.DocStatus IN (''CL'',''CO'') 
+AND il.M_Product_ID IS NOT NULL 
+AND il.M_InOutLine_ID IS NULL 
+AND ol.QtyOrdered-ol.QtyDelivered != 0)',Updated=TO_TIMESTAMP('2023-12-01 17:31:46','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Val_Rule_ID=200165
+;
+


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5931

**Generate Invoices (manual)**
1. Create and complete a Customer RMA
2. Create and complete a Customer Return for the Customer RMA created in Step 1
3. Go to the 'Generate Invoices (manual)' window
3. The Customer RMA created in Step 1 should appear for selection
5. Go to the 'Invoice (Customer)' window
6. Create an AR Credit Memo
7. Use the 'Create lines from' window to create lines from the Customer Return created in Step 4
8. Complete the AR Credit Memo
9. Go to the 'Generate Invoices (manual)' window
10. The Customer RMA created in Step 1 should not appear for selection

**Generate Shipments (manual)**
1. Create and complete a Vendor RMA
2. Go to the 'Generate Shipments (manual)' window
4. The Vendor RMA created in Step 1 should appear for selection
5. Go to the 'Return to Vendor' window
6. Create a Vendor Return
7. Use the 'Create lines from' window to create lines from the Vendor RMA created in Step 1
8. Complete the Vendor Return
9. Go to the 'Generate Shipments (manual)' window
10. The Vendor RMA created in Step 1 should not appear for selection