### PR TITLE
IDEMPIERE-5835 [Process Info] - Disallow Multiple Executions by different users

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MProcess.java
+++ b/org.adempiere.base/src/org/compiere/model/MProcess.java
@@ -50,7 +50,12 @@ public class MProcess extends X_AD_Process implements ImmutablePOSupport
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = 6928560924056836659L;
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -2068744950300991237L;
+
 
 	/**
 	 * 	Get MProcess from Cache (immutable)
@@ -640,6 +645,18 @@ public class MProcess extends X_AD_Process implements ImmutablePOSupport
 		if (m_parameters != null && m_parameters.length > 0)
 			Arrays.stream(m_parameters).forEach(e -> e.markImmutable());
 		return this;
+	}
+
+	/**
+	 * 	Called before Save for Pre-Save Operation
+	 * 	@param newRecord new record
+	 *	@return true if record can be saved
+	 */
+	@Override
+	protected boolean beforeSave(boolean newRecord) {
+		if (getAllowMultipleExecution() == null)
+			setAllowMultipleExecution(ALLOWMULTIPLEEXECUTION_NotFromSameUserAndParameters);
+		return true;
 	}
 
 }	//	MProcess


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5835?focusedCommentId=50273

- assign the default programatically to cover old 2Packs having this value as NULL

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
