### PR TITLE
IDEMPIERE-5567 Support of UUID as Key (FHCA-4195) - Translation

### DIFF
--- a/migration/iD11/oracle/202311261544_IDEMPIERE-5567_TestUU_Trl.sql
+++ b/migration/iD11/oracle/202311261544_IDEMPIERE-5567_TestUU_Trl.sql
@@ -1,0 +1,220 @@
+-- IDEMPIERE-5567 Trl
+SELECT register_migration_script('202311261544_IDEMPIERE-5567_TestUU_Trl.sql') FROM dual;
+
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Nov 26, 2023, 3:44:34 PM CET
+UPDATE AD_Column SET IsTranslated='Y',Updated=TO_TIMESTAMP('2023-11-26 15:44:34','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=215787
+;
+
+-- Nov 26, 2023, 3:44:34 PM CET
+UPDATE AD_Column SET IsTranslated='Y',Updated=TO_TIMESTAMP('2023-11-26 15:44:34','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=215788
+;
+
+-- Nov 26, 2023, 3:44:34 PM CET
+UPDATE AD_Column SET IsTranslated='Y',Updated=TO_TIMESTAMP('2023-11-26 15:44:34','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=215789
+;
+
+-- Nov 26, 2023, 3:44:34 PM CET
+INSERT INTO AD_Table (AD_Table_ID,Name,TableName,AccessLevel,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsSecurityEnabled,IsDeleteable,IsHighVolume,IsView,EntityType,IsChangeLog,ReplicationType,AD_Table_UU,Processing) VALUES (200401,'Test UU Based Table Trl','TestUU_Trl','7',0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:34','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:34','YYYY-MM-DD HH24:MI:SS'),100,'N','N','N','N','D','Y','L','f9550679-8ca3-41b0-9cde-e0a548dcf810','N')
+;
+
+-- Nov 26, 2023, 3:44:35 PM CET
+INSERT INTO AD_Sequence (Name,CurrentNext,IsAudited,StartNewYear,Description,IsActive,IsTableID,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,AD_Sequence_ID,IsAutoSequence,StartNo,IncrementNo,CurrentNextSys,AD_Sequence_UU) VALUES ('TestUU_Trl',1000000,'N','N','Table TestUU_Trl','Y','Y',0,0,TO_TIMESTAMP('2023-11-26 15:44:34','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:34','YYYY-MM-DD HH24:MI:SS'),100,200472,'Y',1000000,1,200000,'92fb41f9-331d-4347-be48-bab548899ea6')
+;
+
+-- Nov 26, 2023, 3:44:35 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,ReadOnlyLogic,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216115,0.0,'Tenant','Tenant for this installation.','A Tenant is a company or a legal entity. You cannot share data between Tenants.',200401,'AD_Client_ID','@#AD_Client_ID@',10,'N','N','Y','N','N','N',30,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:35','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:35','YYYY-MM-DD HH24:MI:SS'),100,102,'N','N','1=1','D','N','9dba4404-cab0-45d0-a3cd-110254048910','N')
+;
+
+-- Nov 26, 2023, 3:44:35 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216116,0.0,'Organization','Organizational entity within tenant','An organization is a unit of your tenant or legal entity - examples are store, department. You can share data between organizations.',200401,'AD_Org_ID','@AD_Org_ID@',10,'N','N','Y','N','N','N',19,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:35','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:35','YYYY-MM-DD HH24:MI:SS'),100,113,'N','N','D','N','1780d388-3915-4a54-a45a-ce91aa060628','N')
+;
+
+-- Nov 26, 2023, 3:44:36 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216117,0.0,'Created','Date this record was created','The Created field indicates the date that this record was created.',200401,'Created',7,'N','N','Y','N','N','N',16,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:35','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:35','YYYY-MM-DD HH24:MI:SS'),100,245,'N','N','D','N','e60eecc7-e025-411a-b021-937f67576e3c','N')
+;
+
+-- Nov 26, 2023, 3:44:36 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Reference_Value_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216118,0.0,'Created By','User who created this records','The Created By field indicates the user who created this record.',200401,'CreatedBy',10,'N','N','Y','N','N','N',30,110,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:36','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:36','YYYY-MM-DD HH24:MI:SS'),100,246,'N','N','D','N','16dc5467-d3bf-42d9-997c-9ef3810e9a93','N')
+;
+
+-- Nov 26, 2023, 3:44:36 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216119,0.0,'Updated','Date this record was updated','The Updated field indicates the date that this record was updated.',200401,'Updated',7,'N','N','Y','N','N','N',16,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:36','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:36','YYYY-MM-DD HH24:MI:SS'),100,607,'N','N','D','N','2b729e86-ad3c-4903-9351-97ac067dc7c4','N')
+;
+
+-- Nov 26, 2023, 3:44:37 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Reference_Value_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216120,0.0,'Updated By','User who updated this records','The Updated By field indicates the user who updated this record.',200401,'UpdatedBy',10,'N','N','Y','N','N','N',30,110,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:36','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:36','YYYY-MM-DD HH24:MI:SS'),100,608,'N','N','D','N','3530e79f-8bd4-4e00-9dc7-79552f4b1000','N')
+;
+
+-- Nov 26, 2023, 3:44:37 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216121,0.0,'Active','The record is active in the system','There are two methods of making records unavailable in the system: One is to delete the record, the other is to de-activate the record. A de-activated record is not available for selection, but available for reports.
+There are two reasons for de-activating and not deleting records:
+(1) The system requires the record for audit purposes.
+(2) The record is referenced by other records. E.g., you cannot delete a Business Partner, if there are invoices for this partner record existing. You de-activate the Business Partner and prevent that this record is used for future entries.',200401,'IsActive','Y',1,'N','N','Y','N','N','N',20,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:37','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:37','YYYY-MM-DD HH24:MI:SS'),100,348,'Y','N','D','N','afb9d90e-74b1-40a6-836b-81ed1dd0c880','N')
+;
+
+-- Nov 26, 2023, 3:44:38 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton,FKConstraintType) VALUES (216122,0.0,'Test UU',200401,'TestUU_UU',36,'N','Y','Y','N','N','N',200235,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:37','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:37','YYYY-MM-DD HH24:MI:SS'),100,203793,'N','N','D','N','8a59d366-92fd-49be-88c2-e6849ada566e','N','C')
+;
+
+-- Nov 26, 2023, 3:44:38 PM CET
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,ColumnName,Name,PrintName,EntityType,AD_Element_UU) VALUES (203861,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:38','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:38','YYYY-MM-DD HH24:MI:SS'),100,'TestUU_Trl_UU','TestUU_Trl_UU','TestUU_Trl_UU','D','da895afb-ec26-46f9-b070-1e2272eb5c40')
+;
+
+-- Nov 26, 2023, 3:44:38 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216123,0.0,'TestUU_Trl_UU',200401,'TestUU_Trl_UU',36,'N','N','N','N','N','N',200231,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:38','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:38','YYYY-MM-DD HH24:MI:SS'),100,203861,'Y','N','D','N','09d73322-2a14-4dc9-b7db-f64eb77082ea','N')
+;
+
+-- Nov 26, 2023, 3:44:39 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Reference_Value_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216124,0.0,'Language','Language for this entity','The Language identifies the language to use for display and formatting',200401,'AD_Language',6,'N','Y','Y','N','N','N',18,106,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:38','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:38','YYYY-MM-DD HH24:MI:SS'),100,109,'N','N','D','N','6237c307-ae64-46af-ab3b-c1f96fa1a04c','N')
+;
+
+-- Nov 26, 2023, 3:44:39 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216125,0.0,'Translated','This column is translated','The Translated checkbox indicates if this column is translated.',200401,'IsTranslated','N',1,'N','N','Y','N','N','N',20,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:39','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:39','YYYY-MM-DD HH24:MI:SS'),100,420,'Y','N','D','N','26987a3f-db4e-4ad0-9670-7a5a51a279b8','N')
+;
+
+-- Nov 26, 2023, 3:44:39 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,SeqNoSelection,IsToolbarButton) VALUES (216126,0.0,'Name','Alphanumeric identifier of the entity','The name of an entity (record) is used as an default search option in addition to the search key. The name is up to 60 characters in length.',200401,'Name',60,'N','N','Y','N','Y','N',10,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:39','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:39','YYYY-MM-DD HH24:MI:SS'),100,469,'Y','Y','D','N','4c71cec2-96c2-489c-b160-208fb8c775b7',10,'N')
+;
+
+-- Nov 26, 2023, 3:44:40 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216127,0.0,'Description','Optional short description of the record','A description is limited to 255 characters.',200401,'Description',255,'N','N','N','N','N','N',10,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:39','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:39','YYYY-MM-DD HH24:MI:SS'),100,275,'Y','N','D','N','c752348d-c243-473f-bec4-ff3698edb3da','N')
+;
+
+-- Nov 26, 2023, 3:44:40 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216128,0.0,'Comment/Help','Comment or Hint','The Help field contains a hint, comment or help about the use of this item.',200401,'Help',2000,'N','N','N','N','N','N',10,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:40','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:40','YYYY-MM-DD HH24:MI:SS'),100,326,'Y','N','D','N','e6f341ee-bb79-425c-acf3-dc333084834e','N')
+;
+
+-- Nov 26, 2023, 3:44:40 PM CET
+INSERT INTO AD_TableIndex (AD_Client_ID,AD_Org_ID,AD_TableIndex_ID,AD_TableIndex_UU,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,AD_Table_ID,IsCreateConstraint,IsUnique,Processing,IsKey) VALUES (0,0,201264,'340c302a-9e94-4580-b0fa-2483f12c1f28',TO_TIMESTAMP('2023-11-26 15:44:40','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','TestUU_Trl_pkey',TO_TIMESTAMP('2023-11-26 15:44:40','YYYY-MM-DD HH24:MI:SS'),100,200401,'Y','Y','N','Y')
+;
+
+-- Nov 26, 2023, 3:44:41 PM CET
+INSERT INTO AD_IndexColumn (AD_Client_ID,AD_Org_ID,AD_IndexColumn_ID,AD_IndexColumn_UU,Created,CreatedBy,EntityType,IsActive,Updated,UpdatedBy,AD_Column_ID,AD_TableIndex_ID,SeqNo) VALUES (0,0,201712,'b8e0052c-2844-4fad-831f-b73dc1446f0e',TO_TIMESTAMP('2023-11-26 15:44:41','YYYY-MM-DD HH24:MI:SS'),100,'D','Y',TO_TIMESTAMP('2023-11-26 15:44:41','YYYY-MM-DD HH24:MI:SS'),100,216124,201264,10)
+;
+
+-- Nov 26, 2023, 3:44:41 PM CET
+INSERT INTO AD_IndexColumn (AD_Client_ID,AD_Org_ID,AD_IndexColumn_ID,AD_IndexColumn_UU,Created,CreatedBy,EntityType,IsActive,Updated,UpdatedBy,AD_Column_ID,AD_TableIndex_ID,SeqNo) VALUES (0,0,201713,'0661b58b-f207-48d3-af48-ebb85049adab',TO_TIMESTAMP('2023-11-26 15:44:41','YYYY-MM-DD HH24:MI:SS'),100,'D','Y',TO_TIMESTAMP('2023-11-26 15:44:41','YYYY-MM-DD HH24:MI:SS'),100,216122,201264,20)
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+UPDATE AD_Column SET IsAllowCopy='N', FKConstraintName='ADClient_TestUUTrl', FKConstraintType='N',Updated=TO_TIMESTAMP('2023-11-26 15:44:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216115
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+UPDATE AD_Column SET IsUpdateable='N', FKConstraintName='ADLanguage_TestUUTrl', FKConstraintType='N',Updated=TO_TIMESTAMP('2023-11-26 15:44:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216124
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+UPDATE AD_Column SET IsAllowCopy='N', FKConstraintName='ADOrg_TestUUTrl', FKConstraintType='N',Updated=TO_TIMESTAMP('2023-11-26 15:44:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216116
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+UPDATE AD_Column SET IsAllowCopy='N', FKConstraintName='CreatedBy_TestUUTrl', FKConstraintType='N',Updated=TO_TIMESTAMP('2023-11-26 15:44:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216118
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+UPDATE AD_Column SET FieldLength=36, IsUpdateable='N', FKConstraintName='TestUUUU_TestUUTrl', FKConstraintType='C',Updated=TO_TIMESTAMP('2023-11-26 15:44:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216122
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+UPDATE AD_Column SET IsAllowCopy='N', FKConstraintName='UpdatedBy_TestUUTrl', FKConstraintType='N',Updated=TO_TIMESTAMP('2023-11-26 15:44:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216120
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+CREATE TABLE TestUU_Trl (AD_Client_ID NUMBER(10) NOT NULL, AD_Language VARCHAR2(6 CHAR) NOT NULL, AD_Org_ID NUMBER(10) NOT NULL, Created DATE NOT NULL, CreatedBy NUMBER(10) NOT NULL, Description VARCHAR2(255 CHAR) DEFAULT NULL , Help VARCHAR2(2000 CHAR) DEFAULT NULL , IsActive CHAR(1) DEFAULT 'Y' CHECK (IsActive IN ('Y','N')) NOT NULL, IsTranslated CHAR(1) DEFAULT 'N' CHECK (IsTranslated IN ('Y','N')) NOT NULL, Name VARCHAR2(60 CHAR) NOT NULL, TestUU_Trl_UU VARCHAR2(36 CHAR) DEFAULT NULL , TestUU_UU VARCHAR2(36 CHAR) NOT NULL, Updated DATE NOT NULL, UpdatedBy NUMBER(10) NOT NULL, CONSTRAINT TestUU_Trl_UU_idx UNIQUE (TestUU_Trl_UU))
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+ALTER TABLE TestUU_Trl ADD CONSTRAINT ADClient_TestUUTrl FOREIGN KEY (AD_Client_ID) REFERENCES ad_client(ad_client_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+ALTER TABLE TestUU_Trl ADD CONSTRAINT ADLanguage_TestUUTrl FOREIGN KEY (AD_Language) REFERENCES ad_language(ad_language) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+ALTER TABLE TestUU_Trl ADD CONSTRAINT ADOrg_TestUUTrl FOREIGN KEY (AD_Org_ID) REFERENCES ad_org(ad_org_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+ALTER TABLE TestUU_Trl ADD CONSTRAINT CreatedBy_TestUUTrl FOREIGN KEY (CreatedBy) REFERENCES ad_user(ad_user_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+ALTER TABLE TestUU_Trl ADD CONSTRAINT TestUUUU_TestUUTrl FOREIGN KEY (TestUU_UU) REFERENCES TestUU(TestUU_UU) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+ALTER TABLE TestUU_Trl ADD CONSTRAINT UpdatedBy_TestUUTrl FOREIGN KEY (UpdatedBy) REFERENCES ad_user(ad_user_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Nov 26, 2023, 3:45:03 PM CET
+ALTER TABLE TestUU_Trl ADD CONSTRAINT TestUU_Trl_pkey PRIMARY KEY (AD_Language,TestUU_UU)
+;
+
+-- Nov 26, 2023, 3:45:28 PM CET
+INSERT INTO AD_Tab (AD_Tab_ID,Name,AD_Window_ID,SeqNo,IsSingleRow,AD_Table_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,HasTree,IsTranslationTab,IsReadOnly,AD_Column_ID,OrderByClause,Processing,TabLevel,IsSortTab,EntityType,IsInsertRecord,IsAdvancedTab,AD_Tab_UU) VALUES (200371,'Test UU Based Table Trl',200138,30,'Y',200401,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:45:27','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:45:27','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','N',216122,'TestUU_Trl.AD_Language','N',1,'N','D','N','N','6eb8bbc8-8eae-4eb3-8b6d-9822e23ee57c')
+;
+
+-- Nov 26, 2023, 3:45:28 PM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (207950,'Tenant','Tenant for this installation.','A Tenant is a company or a legal entity. You cannot share data between Tenants.',200371,216115,'Y',10,10,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-11-26 15:45:28','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:45:28','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','89695be2-6d4f-4e9f-8ae5-bb31149269f3','Y',10,2)
+;
+
+-- Nov 26, 2023, 3:45:29 PM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsAllowCopy,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan) VALUES (207951,'Organization','Organizational entity within tenant','An organization is a unit of your tenant or legal entity - examples are store, department. You can share data between organizations.',200371,216116,'Y',10,20,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-11-26 15:45:28','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:45:28','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','e256cee8-00ac-48ac-b1e4-22bae6ad4188','Y','Y',20,4,2)
+;
+
+-- Nov 26, 2023, 3:45:29 PM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (207952,'Test UU',200371,216122,'Y',36,30,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-11-26 15:45:29','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:45:29','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','7c6645af-8d3f-497f-bc66-612e53186386','Y',30,2)
+;
+
+-- Nov 26, 2023, 3:45:30 PM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (207953,'Language','Language for this entity','The Language identifies the language to use for display and formatting',200371,216124,'Y',6,40,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-11-26 15:45:29','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:45:29','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','e986bf2e-21df-41db-b606-a24900a74f93','Y',40,2)
+;
+
+-- Nov 26, 2023, 3:45:30 PM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (207954,'Name','Alphanumeric identifier of the entity','The name of an entity (record) is used as an default search option in addition to the search key. The name is up to 60 characters in length.',200371,216126,'Y',60,50,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-11-26 15:45:30','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:45:30','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','8b5421ac-c314-48ad-b3f1-bfab1ea6ed8a','Y',50,5)
+;
+
+-- Nov 26, 2023, 3:45:30 PM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (207955,'Description','Optional short description of the record','A description is limited to 255 characters.',200371,216127,'Y',255,60,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-11-26 15:45:30','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:45:30','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','8cdde0c5-37ae-4ae5-8d57-702a40527a9a','Y',60,5)
+;
+
+-- Nov 26, 2023, 3:45:31 PM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (207956,'Comment/Help','Comment or Hint','The Help field contains a hint, comment or help about the use of this item.',200371,216128,'Y',2000,70,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-11-26 15:45:30','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:45:30','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','294b6600-250a-48f0-9502-21a2b2961085','Y',70,5)
+;
+
+-- Nov 26, 2023, 3:45:31 PM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,ColumnSpan) VALUES (207957,'TestUU_Trl_UU',200371,216123,'N',36,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-11-26 15:45:31','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:45:31','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','7581c45a-2510-4d92-9a47-c160f0edcf0b','N',2)
+;
+
+-- Nov 26, 2023, 3:45:31 PM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan) VALUES (207958,'Translated','This column is translated','The Translated checkbox indicates if this column is translated.',200371,216125,'Y',1,80,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-11-26 15:45:31','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:45:31','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','fc51a42a-234f-42a2-8689-ca5e4d751f7b','Y',80,2,2)
+;
+
+-- Nov 26, 2023, 3:45:32 PM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan) VALUES (207959,'Active','The record is active in the system','There are two methods of making records unavailable in the system: One is to delete the record, the other is to de-activate the record. A de-activated record is not available for selection, but available for reports.
+There are two reasons for de-activating and not deleting records:
+(1) The system requires the record for audit purposes.
+(2) The record is referenced by other records. E.g., you cannot delete a Business Partner, if there are invoices for this partner record existing. You de-activate the Business Partner and prevent that this record is used for future entries.',200371,216121,'Y',1,90,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-11-26 15:45:31','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:45:31','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','14d0bc41-1c29-4bd3-af25-030040ed1524','Y',90,2,2)
+;
+
+-- Nov 26, 2023, 3:45:32 PM CET
+UPDATE AD_Table SET AD_Window_ID=200138,Updated=TO_TIMESTAMP('2023-11-26 15:45:32','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Table_ID=200401
+;
+
+-- Nov 26, 2023, 3:45:48 PM CET
+UPDATE AD_Tab SET SeqNo=30,Updated=TO_TIMESTAMP('2023-11-26 15:45:48','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Tab_ID=200349
+;
+
+-- Nov 26, 2023, 3:45:52 PM CET
+UPDATE AD_Tab SET SeqNo=20,Updated=TO_TIMESTAMP('2023-11-26 15:45:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Tab_ID=200371
+;
+
+INSERT INTO testuu_trl (ad_client_id, ad_language, ad_org_id, created, createdby, description, help, isactive, istranslated, name, testuu_trl_uu, testuu_uu, updated, updatedby) VALUES(0, 'es_CO', 0, TO_TIMESTAMP('2023-11-26 15:52:23','YYYY-MM-DD HH24:MI:SS'), 100, NULL, NULL, 'Y', 'N', 'Test Record in System', 'c0becbd2-08bc-4c8a-9c03-1895647c16a8', '4e148b89-bdd9-48a6-8a8a-7609092f965c', TO_TIMESTAMP('2023-11-26 15:52:23','YYYY-MM-DD HH24:MI:SS'), 100);
+
+INSERT INTO testuu_trl (ad_client_id, ad_language, ad_org_id, created, createdby, description, help, isactive, istranslated, name, testuu_trl_uu, testuu_uu, updated, updatedby) VALUES(11, 'es_CO', 0, TO_TIMESTAMP('2023-11-26 15:52:23','YYYY-MM-DD HH24:MI:SS'), 100, 'Lorem ipsum dolor sit amet', 'consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut', 'Y', 'N', 'Test Record in GardenWorld', 'a7ed6616-fe23-4883-a33c-37d05a954acb', '8858ecc2-cf1d-405f-987f-793536037e76', TO_TIMESTAMP('2023-11-26 15:52:23','YYYY-MM-DD HH24:MI:SS'), 100);
+

--- a/migration/iD11/oracle/202311261658_IDEMPIERE-5567-PackInDetail.sql
+++ b/migration/iD11/oracle/202311261658_IDEMPIERE-5567-PackInDetail.sql
@@ -1,0 +1,117 @@
+-- IDEMPIERE-5567 AD_Package_Imp_Detail
+SELECT register_migration_script('202311261658_IDEMPIERE-5567-PackInDetail.sql') FROM dual;
+
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Nov 26, 2023, 4:58:59 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,IsToolbarButton,IsSecure,FKConstraintType,IsHtml) VALUES (216129,0,'Record UUID',50004,'Record_UU',36,'N','N','N','N','N',0,'N',200240,0,0,'Y',TO_TIMESTAMP('2023-11-26 16:58:58','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 16:58:58','YYYY-MM-DD HH24:MI:SS'),100,203804,'N','N','D','N','N','N','Y','a0f0e5fb-ecaf-4954-8b91-05d9eb8359b3','Y','N','N','M','N')
+;
+
+-- Nov 26, 2023, 4:59:24 PM CET
+UPDATE AD_Column SET FieldLength=36, IsUpdateable='Y', IsAlwaysUpdateable='Y', IsAllowLogging='N', FKConstraintType='D',Updated=TO_TIMESTAMP('2023-11-26 16:59:24','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216129
+;
+
+-- Nov 26, 2023, 4:59:32 PM CET
+ALTER TABLE AD_Package_Imp_Detail ADD Record_UU VARCHAR2(36 CHAR) DEFAULT NULL 
+;
+
+-- Nov 26, 2023, 5:00:50 PM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (207960,'Record UUID',50004,216129,'Y',36,130,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-11-26 17:00:50','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 17:00:50','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','3eac3574-410a-4882-948b-c8a7ccef6a01','Y',100,2)
+;
+
+-- Nov 26, 2023, 5:01:52 PM CET
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=40, XPosition=4, ColumnSpan=2,Updated=TO_TIMESTAMP('2023-11-26 17:01:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=50059
+;
+
+-- Nov 26, 2023, 5:01:52 PM CET
+UPDATE AD_Field SET SeqNo=50,Updated=TO_TIMESTAMP('2023-11-26 17:01:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=50062
+;
+
+-- Nov 26, 2023, 5:01:52 PM CET
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=60, XPosition=4, ColumnSpan=2,Updated=TO_TIMESTAMP('2023-11-26 17:01:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=50060
+;
+
+-- Nov 26, 2023, 5:01:52 PM CET
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=70, XPosition=4,Updated=TO_TIMESTAMP('2023-11-26 17:01:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207960
+;
+
+-- Nov 26, 2023, 5:01:52 PM CET
+UPDATE AD_Field SET SeqNo=80,Updated=TO_TIMESTAMP('2023-11-26 17:01:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=50058
+;
+
+-- Nov 26, 2023, 5:01:52 PM CET
+UPDATE AD_Field SET SeqNo=90,Updated=TO_TIMESTAMP('2023-11-26 17:01:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=50064
+;
+
+-- Nov 26, 2023, 5:01:52 PM CET
+UPDATE AD_Field SET SeqNo=100,Updated=TO_TIMESTAMP('2023-11-26 17:01:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=50061
+;
+
+-- Nov 26, 2023, 5:01:52 PM CET
+UPDATE AD_Field SET SeqNo=110,Updated=TO_TIMESTAMP('2023-11-26 17:01:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=50057
+;
+
+-- Nov 26, 2023, 5:01:52 PM CET
+UPDATE AD_Field SET SeqNo=120,Updated=TO_TIMESTAMP('2023-11-26 17:01:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206751
+;
+
+-- Nov 26, 2023, 5:01:52 PM CET
+UPDATE AD_Field SET SeqNo=130,Updated=TO_TIMESTAMP('2023-11-26 17:01:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206752
+;
+
+-- Nov 26, 2023, 5:02:11 PM CET
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=60, XPosition=4,Updated=TO_TIMESTAMP('2023-11-26 17:02:11','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207960
+;
+
+-- Nov 26, 2023, 5:02:11 PM CET
+UPDATE AD_Field SET SeqNo=70,Updated=TO_TIMESTAMP('2023-11-26 17:02:11','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=50060
+;
+
+-- Nov 26, 2023, 5:02:45 PM CET
+UPDATE AD_Field SET DisplayLogic='@Record_UU@!'''' & @AD_Table_ID@!0',Updated=TO_TIMESTAMP('2023-11-26 17:02:45','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207960
+;
+
+-- Nov 26, 2023, 5:03:25 PM CET
+UPDATE AD_Field SET DisplayLogic='@Record_UU@=''''',Updated=TO_TIMESTAMP('2023-11-26 17:03:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=50060
+;
+
+-- Nov 26, 2023, 5:03:41 PM CET
+UPDATE AD_Field SET DisplayLogic='@AD_Table_ID@!0',Updated=TO_TIMESTAMP('2023-11-26 17:03:41','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=50062
+;
+
+-- Nov 26, 2023, 5:07:20 PM CET
+UPDATE AD_Field SET SeqNo=50, ColumnSpan=2,Updated=TO_TIMESTAMP('2023-11-26 17:07:20','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=204348
+;
+
+
+SET SERVEROUTPUT on;
+
+-- Set Record_UU for existing records
+DECLARE
+  cmd varchar2(2000);
+  v_cnt numeric;
+BEGIN
+  FOR r IN (
+    SELECT DISTINCT t.TableName, a.AD_Table_ID
+      FROM AD_Package_Imp_Detail a
+	JOIN AD_Table t ON (a.AD_Table_ID=t.AD_Table_ID)
+      WHERE a.Record_UU IS NULL
+	AND a.AD_Table_ID > 0
+	AND a.Record_ID > 0
+  ) LOOP
+    cmd := 'UPDATE AD_Package_Imp_Detail SET Record_UU=(SELECT '
+      || r.TableName
+      || '_UU FROM '
+      || r.TableName
+      || ' WHERE '
+      || r.TableName
+      || '_ID=AD_Package_Imp_Detail.Record_ID) WHERE AD_Table_ID='
+      || r.AD_Table_ID
+      || ' AND Record_ID IS NOT NULL AND Record_UU IS NULL';
+    EXECUTE IMMEDIATE cmd;
+    DBMS_OUTPUT.PUT_LINE(SQL%ROWCOUNT || ' AD_Package_Imp_Detail.Record_UU set in ' || r.TableName);
+  END LOOP;
+END;
+/
+

--- a/migration/iD11/postgresql/202311261544_IDEMPIERE-5567_TestUU_Trl.sql
+++ b/migration/iD11/postgresql/202311261544_IDEMPIERE-5567_TestUU_Trl.sql
@@ -1,0 +1,217 @@
+-- IDEMPIERE-5567 Trl
+SELECT register_migration_script('202311261544_IDEMPIERE-5567_TestUU_Trl.sql') FROM dual;
+
+-- Nov 26, 2023, 3:44:34 PM CET
+UPDATE AD_Column SET IsTranslated='Y',Updated=TO_TIMESTAMP('2023-11-26 15:44:34','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=215787
+;
+
+-- Nov 26, 2023, 3:44:34 PM CET
+UPDATE AD_Column SET IsTranslated='Y',Updated=TO_TIMESTAMP('2023-11-26 15:44:34','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=215788
+;
+
+-- Nov 26, 2023, 3:44:34 PM CET
+UPDATE AD_Column SET IsTranslated='Y',Updated=TO_TIMESTAMP('2023-11-26 15:44:34','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=215789
+;
+
+-- Nov 26, 2023, 3:44:34 PM CET
+INSERT INTO AD_Table (AD_Table_ID,Name,TableName,AccessLevel,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsSecurityEnabled,IsDeleteable,IsHighVolume,IsView,EntityType,IsChangeLog,ReplicationType,AD_Table_UU,Processing) VALUES (200401,'Test UU Based Table Trl','TestUU_Trl','7',0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:34','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:34','YYYY-MM-DD HH24:MI:SS'),100,'N','N','N','N','D','Y','L','f9550679-8ca3-41b0-9cde-e0a548dcf810','N')
+;
+
+-- Nov 26, 2023, 3:44:35 PM CET
+INSERT INTO AD_Sequence (Name,CurrentNext,IsAudited,StartNewYear,Description,IsActive,IsTableID,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,AD_Sequence_ID,IsAutoSequence,StartNo,IncrementNo,CurrentNextSys,AD_Sequence_UU) VALUES ('TestUU_Trl',1000000,'N','N','Table TestUU_Trl','Y','Y',0,0,TO_TIMESTAMP('2023-11-26 15:44:34','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:34','YYYY-MM-DD HH24:MI:SS'),100,200472,'Y',1000000,1,200000,'92fb41f9-331d-4347-be48-bab548899ea6')
+;
+
+-- Nov 26, 2023, 3:44:35 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,ReadOnlyLogic,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216115,0.0,'Tenant','Tenant for this installation.','A Tenant is a company or a legal entity. You cannot share data between Tenants.',200401,'AD_Client_ID','@#AD_Client_ID@',10,'N','N','Y','N','N','N',30,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:35','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:35','YYYY-MM-DD HH24:MI:SS'),100,102,'N','N','1=1','D','N','9dba4404-cab0-45d0-a3cd-110254048910','N')
+;
+
+-- Nov 26, 2023, 3:44:35 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216116,0.0,'Organization','Organizational entity within tenant','An organization is a unit of your tenant or legal entity - examples are store, department. You can share data between organizations.',200401,'AD_Org_ID','@AD_Org_ID@',10,'N','N','Y','N','N','N',19,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:35','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:35','YYYY-MM-DD HH24:MI:SS'),100,113,'N','N','D','N','1780d388-3915-4a54-a45a-ce91aa060628','N')
+;
+
+-- Nov 26, 2023, 3:44:36 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216117,0.0,'Created','Date this record was created','The Created field indicates the date that this record was created.',200401,'Created',7,'N','N','Y','N','N','N',16,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:35','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:35','YYYY-MM-DD HH24:MI:SS'),100,245,'N','N','D','N','e60eecc7-e025-411a-b021-937f67576e3c','N')
+;
+
+-- Nov 26, 2023, 3:44:36 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Reference_Value_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216118,0.0,'Created By','User who created this records','The Created By field indicates the user who created this record.',200401,'CreatedBy',10,'N','N','Y','N','N','N',30,110,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:36','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:36','YYYY-MM-DD HH24:MI:SS'),100,246,'N','N','D','N','16dc5467-d3bf-42d9-997c-9ef3810e9a93','N')
+;
+
+-- Nov 26, 2023, 3:44:36 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216119,0.0,'Updated','Date this record was updated','The Updated field indicates the date that this record was updated.',200401,'Updated',7,'N','N','Y','N','N','N',16,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:36','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:36','YYYY-MM-DD HH24:MI:SS'),100,607,'N','N','D','N','2b729e86-ad3c-4903-9351-97ac067dc7c4','N')
+;
+
+-- Nov 26, 2023, 3:44:37 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Reference_Value_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216120,0.0,'Updated By','User who updated this records','The Updated By field indicates the user who updated this record.',200401,'UpdatedBy',10,'N','N','Y','N','N','N',30,110,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:36','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:36','YYYY-MM-DD HH24:MI:SS'),100,608,'N','N','D','N','3530e79f-8bd4-4e00-9dc7-79552f4b1000','N')
+;
+
+-- Nov 26, 2023, 3:44:37 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216121,0.0,'Active','The record is active in the system','There are two methods of making records unavailable in the system: One is to delete the record, the other is to de-activate the record. A de-activated record is not available for selection, but available for reports.
+There are two reasons for de-activating and not deleting records:
+(1) The system requires the record for audit purposes.
+(2) The record is referenced by other records. E.g., you cannot delete a Business Partner, if there are invoices for this partner record existing. You de-activate the Business Partner and prevent that this record is used for future entries.',200401,'IsActive','Y',1,'N','N','Y','N','N','N',20,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:37','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:37','YYYY-MM-DD HH24:MI:SS'),100,348,'Y','N','D','N','afb9d90e-74b1-40a6-836b-81ed1dd0c880','N')
+;
+
+-- Nov 26, 2023, 3:44:38 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton,FKConstraintType) VALUES (216122,0.0,'Test UU',200401,'TestUU_UU',36,'N','Y','Y','N','N','N',200235,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:37','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:37','YYYY-MM-DD HH24:MI:SS'),100,203793,'N','N','D','N','8a59d366-92fd-49be-88c2-e6849ada566e','N','C')
+;
+
+-- Nov 26, 2023, 3:44:38 PM CET
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,ColumnName,Name,PrintName,EntityType,AD_Element_UU) VALUES (203861,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:38','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:38','YYYY-MM-DD HH24:MI:SS'),100,'TestUU_Trl_UU','TestUU_Trl_UU','TestUU_Trl_UU','D','da895afb-ec26-46f9-b070-1e2272eb5c40')
+;
+
+-- Nov 26, 2023, 3:44:38 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216123,0.0,'TestUU_Trl_UU',200401,'TestUU_Trl_UU',36,'N','N','N','N','N','N',200231,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:38','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:38','YYYY-MM-DD HH24:MI:SS'),100,203861,'Y','N','D','N','09d73322-2a14-4dc9-b7db-f64eb77082ea','N')
+;
+
+-- Nov 26, 2023, 3:44:39 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Reference_Value_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216124,0.0,'Language','Language for this entity','The Language identifies the language to use for display and formatting',200401,'AD_Language',6,'N','Y','Y','N','N','N',18,106,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:38','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:38','YYYY-MM-DD HH24:MI:SS'),100,109,'N','N','D','N','6237c307-ae64-46af-ab3b-c1f96fa1a04c','N')
+;
+
+-- Nov 26, 2023, 3:44:39 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216125,0.0,'Translated','This column is translated','The Translated checkbox indicates if this column is translated.',200401,'IsTranslated','N',1,'N','N','Y','N','N','N',20,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:39','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:39','YYYY-MM-DD HH24:MI:SS'),100,420,'Y','N','D','N','26987a3f-db4e-4ad0-9670-7a5a51a279b8','N')
+;
+
+-- Nov 26, 2023, 3:44:39 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,SeqNoSelection,IsToolbarButton) VALUES (216126,0.0,'Name','Alphanumeric identifier of the entity','The name of an entity (record) is used as an default search option in addition to the search key. The name is up to 60 characters in length.',200401,'Name',60,'N','N','Y','N','Y','N',10,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:39','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:39','YYYY-MM-DD HH24:MI:SS'),100,469,'Y','Y','D','N','4c71cec2-96c2-489c-b160-208fb8c775b7',10,'N')
+;
+
+-- Nov 26, 2023, 3:44:40 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216127,0.0,'Description','Optional short description of the record','A description is limited to 255 characters.',200401,'Description',255,'N','N','N','N','N','N',10,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:39','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:39','YYYY-MM-DD HH24:MI:SS'),100,275,'Y','N','D','N','c752348d-c243-473f-bec4-ff3698edb3da','N')
+;
+
+-- Nov 26, 2023, 3:44:40 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216128,0.0,'Comment/Help','Comment or Hint','The Help field contains a hint, comment or help about the use of this item.',200401,'Help',2000,'N','N','N','N','N','N',10,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:44:40','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:44:40','YYYY-MM-DD HH24:MI:SS'),100,326,'Y','N','D','N','e6f341ee-bb79-425c-acf3-dc333084834e','N')
+;
+
+-- Nov 26, 2023, 3:44:40 PM CET
+INSERT INTO AD_TableIndex (AD_Client_ID,AD_Org_ID,AD_TableIndex_ID,AD_TableIndex_UU,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,AD_Table_ID,IsCreateConstraint,IsUnique,Processing,IsKey) VALUES (0,0,201264,'340c302a-9e94-4580-b0fa-2483f12c1f28',TO_TIMESTAMP('2023-11-26 15:44:40','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','TestUU_Trl_pkey',TO_TIMESTAMP('2023-11-26 15:44:40','YYYY-MM-DD HH24:MI:SS'),100,200401,'Y','Y','N','Y')
+;
+
+-- Nov 26, 2023, 3:44:41 PM CET
+INSERT INTO AD_IndexColumn (AD_Client_ID,AD_Org_ID,AD_IndexColumn_ID,AD_IndexColumn_UU,Created,CreatedBy,EntityType,IsActive,Updated,UpdatedBy,AD_Column_ID,AD_TableIndex_ID,SeqNo) VALUES (0,0,201712,'b8e0052c-2844-4fad-831f-b73dc1446f0e',TO_TIMESTAMP('2023-11-26 15:44:41','YYYY-MM-DD HH24:MI:SS'),100,'D','Y',TO_TIMESTAMP('2023-11-26 15:44:41','YYYY-MM-DD HH24:MI:SS'),100,216124,201264,10)
+;
+
+-- Nov 26, 2023, 3:44:41 PM CET
+INSERT INTO AD_IndexColumn (AD_Client_ID,AD_Org_ID,AD_IndexColumn_ID,AD_IndexColumn_UU,Created,CreatedBy,EntityType,IsActive,Updated,UpdatedBy,AD_Column_ID,AD_TableIndex_ID,SeqNo) VALUES (0,0,201713,'0661b58b-f207-48d3-af48-ebb85049adab',TO_TIMESTAMP('2023-11-26 15:44:41','YYYY-MM-DD HH24:MI:SS'),100,'D','Y',TO_TIMESTAMP('2023-11-26 15:44:41','YYYY-MM-DD HH24:MI:SS'),100,216122,201264,20)
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+UPDATE AD_Column SET IsAllowCopy='N', FKConstraintName='ADClient_TestUUTrl', FKConstraintType='N',Updated=TO_TIMESTAMP('2023-11-26 15:44:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216115
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+UPDATE AD_Column SET IsUpdateable='N', FKConstraintName='ADLanguage_TestUUTrl', FKConstraintType='N',Updated=TO_TIMESTAMP('2023-11-26 15:44:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216124
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+UPDATE AD_Column SET IsAllowCopy='N', FKConstraintName='ADOrg_TestUUTrl', FKConstraintType='N',Updated=TO_TIMESTAMP('2023-11-26 15:44:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216116
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+UPDATE AD_Column SET IsAllowCopy='N', FKConstraintName='CreatedBy_TestUUTrl', FKConstraintType='N',Updated=TO_TIMESTAMP('2023-11-26 15:44:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216118
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+UPDATE AD_Column SET FieldLength=36, IsUpdateable='N', FKConstraintName='TestUUUU_TestUUTrl', FKConstraintType='C',Updated=TO_TIMESTAMP('2023-11-26 15:44:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216122
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+UPDATE AD_Column SET IsAllowCopy='N', FKConstraintName='UpdatedBy_TestUUTrl', FKConstraintType='N',Updated=TO_TIMESTAMP('2023-11-26 15:44:57','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216120
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+CREATE TABLE TestUU_Trl (AD_Client_ID NUMERIC(10) NOT NULL, AD_Language VARCHAR(6) NOT NULL, AD_Org_ID NUMERIC(10) NOT NULL, Created TIMESTAMP NOT NULL, CreatedBy NUMERIC(10) NOT NULL, Description VARCHAR(255) DEFAULT NULL , Help VARCHAR(2000) DEFAULT NULL , IsActive CHAR(1) DEFAULT 'Y' CHECK (IsActive IN ('Y','N')) NOT NULL, IsTranslated CHAR(1) DEFAULT 'N' CHECK (IsTranslated IN ('Y','N')) NOT NULL, Name VARCHAR(60) NOT NULL, TestUU_Trl_UU VARCHAR(36) DEFAULT NULL , TestUU_UU VARCHAR(36) NOT NULL, Updated TIMESTAMP NOT NULL, UpdatedBy NUMERIC(10) NOT NULL, CONSTRAINT TestUU_Trl_UU_idx UNIQUE (TestUU_Trl_UU))
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+ALTER TABLE TestUU_Trl ADD CONSTRAINT ADClient_TestUUTrl FOREIGN KEY (AD_Client_ID) REFERENCES ad_client(ad_client_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+ALTER TABLE TestUU_Trl ADD CONSTRAINT ADLanguage_TestUUTrl FOREIGN KEY (AD_Language) REFERENCES ad_language(ad_language) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+ALTER TABLE TestUU_Trl ADD CONSTRAINT ADOrg_TestUUTrl FOREIGN KEY (AD_Org_ID) REFERENCES ad_org(ad_org_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+ALTER TABLE TestUU_Trl ADD CONSTRAINT CreatedBy_TestUUTrl FOREIGN KEY (CreatedBy) REFERENCES ad_user(ad_user_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+ALTER TABLE TestUU_Trl ADD CONSTRAINT TestUUUU_TestUUTrl FOREIGN KEY (TestUU_UU) REFERENCES TestUU(TestUU_UU) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Nov 26, 2023, 3:44:57 PM CET
+ALTER TABLE TestUU_Trl ADD CONSTRAINT UpdatedBy_TestUUTrl FOREIGN KEY (UpdatedBy) REFERENCES ad_user(ad_user_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Nov 26, 2023, 3:45:03 PM CET
+ALTER TABLE TestUU_Trl ADD CONSTRAINT TestUU_Trl_pkey PRIMARY KEY (AD_Language,TestUU_UU)
+;
+
+-- Nov 26, 2023, 3:45:28 PM CET
+INSERT INTO AD_Tab (AD_Tab_ID,Name,AD_Window_ID,SeqNo,IsSingleRow,AD_Table_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,HasTree,IsTranslationTab,IsReadOnly,AD_Column_ID,OrderByClause,Processing,TabLevel,IsSortTab,EntityType,IsInsertRecord,IsAdvancedTab,AD_Tab_UU) VALUES (200371,'Test UU Based Table Trl',200138,30,'Y',200401,0,0,'Y',TO_TIMESTAMP('2023-11-26 15:45:27','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:45:27','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','N',216122,'TestUU_Trl.AD_Language','N',1,'N','D','N','N','6eb8bbc8-8eae-4eb3-8b6d-9822e23ee57c')
+;
+
+-- Nov 26, 2023, 3:45:28 PM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (207950,'Tenant','Tenant for this installation.','A Tenant is a company or a legal entity. You cannot share data between Tenants.',200371,216115,'Y',10,10,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-11-26 15:45:28','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:45:28','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','89695be2-6d4f-4e9f-8ae5-bb31149269f3','Y',10,2)
+;
+
+-- Nov 26, 2023, 3:45:29 PM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsAllowCopy,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan) VALUES (207951,'Organization','Organizational entity within tenant','An organization is a unit of your tenant or legal entity - examples are store, department. You can share data between organizations.',200371,216116,'Y',10,20,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-11-26 15:45:28','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:45:28','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','e256cee8-00ac-48ac-b1e4-22bae6ad4188','Y','Y',20,4,2)
+;
+
+-- Nov 26, 2023, 3:45:29 PM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (207952,'Test UU',200371,216122,'Y',36,30,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-11-26 15:45:29','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:45:29','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','7c6645af-8d3f-497f-bc66-612e53186386','Y',30,2)
+;
+
+-- Nov 26, 2023, 3:45:30 PM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (207953,'Language','Language for this entity','The Language identifies the language to use for display and formatting',200371,216124,'Y',6,40,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-11-26 15:45:29','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:45:29','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','e986bf2e-21df-41db-b606-a24900a74f93','Y',40,2)
+;
+
+-- Nov 26, 2023, 3:45:30 PM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (207954,'Name','Alphanumeric identifier of the entity','The name of an entity (record) is used as an default search option in addition to the search key. The name is up to 60 characters in length.',200371,216126,'Y',60,50,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-11-26 15:45:30','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:45:30','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','8b5421ac-c314-48ad-b3f1-bfab1ea6ed8a','Y',50,5)
+;
+
+-- Nov 26, 2023, 3:45:30 PM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (207955,'Description','Optional short description of the record','A description is limited to 255 characters.',200371,216127,'Y',255,60,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-11-26 15:45:30','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:45:30','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','8cdde0c5-37ae-4ae5-8d57-702a40527a9a','Y',60,5)
+;
+
+-- Nov 26, 2023, 3:45:31 PM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (207956,'Comment/Help','Comment or Hint','The Help field contains a hint, comment or help about the use of this item.',200371,216128,'Y',2000,70,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-11-26 15:45:30','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:45:30','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','294b6600-250a-48f0-9502-21a2b2961085','Y',70,5)
+;
+
+-- Nov 26, 2023, 3:45:31 PM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,ColumnSpan) VALUES (207957,'TestUU_Trl_UU',200371,216123,'N',36,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-11-26 15:45:31','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:45:31','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','7581c45a-2510-4d92-9a47-c160f0edcf0b','N',2)
+;
+
+-- Nov 26, 2023, 3:45:31 PM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan) VALUES (207958,'Translated','This column is translated','The Translated checkbox indicates if this column is translated.',200371,216125,'Y',1,80,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-11-26 15:45:31','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:45:31','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','fc51a42a-234f-42a2-8689-ca5e4d751f7b','Y',80,2,2)
+;
+
+-- Nov 26, 2023, 3:45:32 PM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan) VALUES (207959,'Active','The record is active in the system','There are two methods of making records unavailable in the system: One is to delete the record, the other is to de-activate the record. A de-activated record is not available for selection, but available for reports.
+There are two reasons for de-activating and not deleting records:
+(1) The system requires the record for audit purposes.
+(2) The record is referenced by other records. E.g., you cannot delete a Business Partner, if there are invoices for this partner record existing. You de-activate the Business Partner and prevent that this record is used for future entries.',200371,216121,'Y',1,90,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-11-26 15:45:31','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 15:45:31','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','14d0bc41-1c29-4bd3-af25-030040ed1524','Y',90,2,2)
+;
+
+-- Nov 26, 2023, 3:45:32 PM CET
+UPDATE AD_Table SET AD_Window_ID=200138,Updated=TO_TIMESTAMP('2023-11-26 15:45:32','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Table_ID=200401
+;
+
+-- Nov 26, 2023, 3:45:48 PM CET
+UPDATE AD_Tab SET SeqNo=30,Updated=TO_TIMESTAMP('2023-11-26 15:45:48','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Tab_ID=200349
+;
+
+-- Nov 26, 2023, 3:45:52 PM CET
+UPDATE AD_Tab SET SeqNo=20,Updated=TO_TIMESTAMP('2023-11-26 15:45:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Tab_ID=200371
+;
+
+INSERT INTO testuu_trl (ad_client_id, ad_language, ad_org_id, created, createdby, description, help, isactive, istranslated, name, testuu_trl_uu, testuu_uu, updated, updatedby) VALUES(0, 'es_CO', 0, TO_TIMESTAMP('2023-11-26 15:52:23','YYYY-MM-DD HH24:MI:SS'), 100, NULL, NULL, 'Y', 'N', 'Test Record in System', 'c0becbd2-08bc-4c8a-9c03-1895647c16a8', '4e148b89-bdd9-48a6-8a8a-7609092f965c', TO_TIMESTAMP('2023-11-26 15:52:23','YYYY-MM-DD HH24:MI:SS'), 100);
+
+INSERT INTO testuu_trl (ad_client_id, ad_language, ad_org_id, created, createdby, description, help, isactive, istranslated, name, testuu_trl_uu, testuu_uu, updated, updatedby) VALUES(11, 'es_CO', 0, TO_TIMESTAMP('2023-11-26 15:52:23','YYYY-MM-DD HH24:MI:SS'), 100, 'Lorem ipsum dolor sit amet', 'consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut', 'Y', 'N', 'Test Record in GardenWorld', 'a7ed6616-fe23-4883-a33c-37d05a954acb', '8858ecc2-cf1d-405f-987f-793536037e76', TO_TIMESTAMP('2023-11-26 15:52:23','YYYY-MM-DD HH24:MI:SS'), 100);
+

--- a/migration/iD11/postgresql/202311261658_IDEMPIERE-5567-PackInDetail.sql
+++ b/migration/iD11/postgresql/202311261658_IDEMPIERE-5567-PackInDetail.sql
@@ -1,0 +1,115 @@
+-- IDEMPIERE-5567 AD_Package_Imp_Detail
+SELECT register_migration_script('202311261658_IDEMPIERE-5567-PackInDetail.sql') FROM dual;
+
+-- Nov 26, 2023, 4:58:59 PM CET
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,IsToolbarButton,IsSecure,FKConstraintType,IsHtml) VALUES (216129,0,'Record UUID',50004,'Record_UU',36,'N','N','N','N','N',0,'N',200240,0,0,'Y',TO_TIMESTAMP('2023-11-26 16:58:58','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 16:58:58','YYYY-MM-DD HH24:MI:SS'),100,203804,'N','N','D','N','N','N','Y','a0f0e5fb-ecaf-4954-8b91-05d9eb8359b3','Y','N','N','M','N')
+;
+
+-- Nov 26, 2023, 4:59:24 PM CET
+UPDATE AD_Column SET FieldLength=36, IsUpdateable='Y', IsAlwaysUpdateable='Y', IsAllowLogging='N', FKConstraintType='D',Updated=TO_TIMESTAMP('2023-11-26 16:59:24','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216129
+;
+
+-- Nov 26, 2023, 4:59:32 PM CET
+ALTER TABLE AD_Package_Imp_Detail ADD COLUMN Record_UU VARCHAR(36) DEFAULT NULL 
+;
+
+-- Nov 26, 2023, 5:00:50 PM CET
+INSERT INTO AD_Field (AD_Field_ID,Name,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (207960,'Record UUID',50004,216129,'Y',36,130,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2023-11-26 17:00:50','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-11-26 17:00:50','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','3eac3574-410a-4882-948b-c8a7ccef6a01','Y',100,2)
+;
+
+-- Nov 26, 2023, 5:01:52 PM CET
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=40, XPosition=4, ColumnSpan=2,Updated=TO_TIMESTAMP('2023-11-26 17:01:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=50059
+;
+
+-- Nov 26, 2023, 5:01:52 PM CET
+UPDATE AD_Field SET SeqNo=50,Updated=TO_TIMESTAMP('2023-11-26 17:01:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=50062
+;
+
+-- Nov 26, 2023, 5:01:52 PM CET
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=60, XPosition=4, ColumnSpan=2,Updated=TO_TIMESTAMP('2023-11-26 17:01:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=50060
+;
+
+-- Nov 26, 2023, 5:01:52 PM CET
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=70, XPosition=4,Updated=TO_TIMESTAMP('2023-11-26 17:01:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207960
+;
+
+-- Nov 26, 2023, 5:01:52 PM CET
+UPDATE AD_Field SET SeqNo=80,Updated=TO_TIMESTAMP('2023-11-26 17:01:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=50058
+;
+
+-- Nov 26, 2023, 5:01:52 PM CET
+UPDATE AD_Field SET SeqNo=90,Updated=TO_TIMESTAMP('2023-11-26 17:01:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=50064
+;
+
+-- Nov 26, 2023, 5:01:52 PM CET
+UPDATE AD_Field SET SeqNo=100,Updated=TO_TIMESTAMP('2023-11-26 17:01:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=50061
+;
+
+-- Nov 26, 2023, 5:01:52 PM CET
+UPDATE AD_Field SET SeqNo=110,Updated=TO_TIMESTAMP('2023-11-26 17:01:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=50057
+;
+
+-- Nov 26, 2023, 5:01:52 PM CET
+UPDATE AD_Field SET SeqNo=120,Updated=TO_TIMESTAMP('2023-11-26 17:01:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206751
+;
+
+-- Nov 26, 2023, 5:01:52 PM CET
+UPDATE AD_Field SET SeqNo=130,Updated=TO_TIMESTAMP('2023-11-26 17:01:52','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206752
+;
+
+-- Nov 26, 2023, 5:02:11 PM CET
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=60, XPosition=4,Updated=TO_TIMESTAMP('2023-11-26 17:02:11','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207960
+;
+
+-- Nov 26, 2023, 5:02:11 PM CET
+UPDATE AD_Field SET SeqNo=70,Updated=TO_TIMESTAMP('2023-11-26 17:02:11','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=50060
+;
+
+-- Nov 26, 2023, 5:02:45 PM CET
+UPDATE AD_Field SET DisplayLogic='@Record_UU@!'''' & @AD_Table_ID@!0',Updated=TO_TIMESTAMP('2023-11-26 17:02:45','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207960
+;
+
+-- Nov 26, 2023, 5:03:25 PM CET
+UPDATE AD_Field SET DisplayLogic='@Record_UU@=''''',Updated=TO_TIMESTAMP('2023-11-26 17:03:25','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=50060
+;
+
+-- Nov 26, 2023, 5:03:41 PM CET
+UPDATE AD_Field SET DisplayLogic='@AD_Table_ID@!0',Updated=TO_TIMESTAMP('2023-11-26 17:03:41','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=50062
+;
+
+-- Nov 26, 2023, 5:07:20 PM CET
+UPDATE AD_Field SET SeqNo=50, ColumnSpan=2,Updated=TO_TIMESTAMP('2023-11-26 17:07:20','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=204348
+;
+
+-- Set Record_UU for existing records
+DO $$
+DECLARE
+  cmd varchar(2000);
+  r record;
+  v_cnt numeric;
+BEGIN
+  FOR r IN
+    SELECT DISTINCT t.TableName, a.AD_Table_ID
+      FROM AD_Package_Imp_Detail a
+	JOIN AD_Table t ON (a.AD_Table_ID=t.AD_Table_ID)
+      WHERE a.Record_UU IS NULL
+	AND a.AD_Table_ID > 0
+	AND a.Record_ID > 0
+  LOOP
+    cmd := 'UPDATE AD_Package_Imp_Detail SET Record_UU=(SELECT '
+      || r.TableName
+      || '_UU FROM '
+      || r.TableName
+      || ' WHERE '
+      || r.TableName
+      || '_ID=AD_Package_Imp_Detail.Record_ID) WHERE AD_Table_ID='
+      || r.AD_Table_ID
+      || ' AND Record_ID IS NOT NULL AND Record_UU IS NULL';
+    EXECUTE cmd;
+    GET DIAGNOSTICS v_cnt = ROW_COUNT;
+    RAISE NOTICE '% AD_Package_Imp_Detail.Record_UU set in %', v_cnt, r.TableName;
+  END LOOP;
+END;
+$$
+;
+

--- a/org.adempiere.base.process/src/org/compiere/process/TranslationDocSync.java
+++ b/org.adempiere.base.process/src/org/compiere/process/TranslationDocSync.java
@@ -104,9 +104,10 @@ public class TranslationDocSync extends SvrProcess
 			}
 		}
 		String trlTable = table.getTableName();
-		String baseTable = trlTable.substring(0, trlTable.length()-4);
-		
-		if (log.isLoggable(Level.CONFIG)) log.config(baseTable + ": " + columnNames);
+		String baseTableName = trlTable.substring(0, trlTable.length()-4);
+		MTable baseTable = MTable.get(getCtx(), baseTableName);
+
+		if (log.isLoggable(Level.CONFIG)) log.config(baseTableName + ": " + columnNames);
 
 	  try {
 		if (client.isMultiLingualDocument()) {
@@ -117,25 +118,25 @@ public class TranslationDocSync extends SvrProcess
 			} else {
 				// tenant language <> base language
 				// auto update translation for tenant language
-				StringBuilder sql = new StringBuilder("UPDATE ").append(trlTable).append(" SET (")
-						.append(columnNames).append(",IsTranslated) = (SELECT ").append(columnNames)
-						.append(",'Y' FROM ").append(baseTable).append(" b WHERE ").append(trlTable).append(".")
-						.append(baseTable).append("_ID=b.").append(baseTable).append("_ID) WHERE AD_Client_ID=")
+				StringBuilder sql = new StringBuilder("UPDATE ").append(trlTable)
+						.append(" SET (").append(columnNames).append(",IsTranslated) = (SELECT ").append(columnNames)
+						.append(",'Y' FROM ").append(baseTableName).append(" b WHERE ").append(trlTable).append(".")
+						.append(baseTable.getKeyColumns()[0]).append("=b.").append(baseTable.getKeyColumns()[0]).append(") WHERE AD_Client_ID=")
 						.append(getAD_Client_ID()).append(" AND AD_Language=").append(DB.TO_STRING(client.getAD_Language()));
 
 				int no = DB.executeUpdateEx(sql.toString(), get_TrxName());
-				addBufferLog(0, null, new BigDecimal(no), baseTable, 0, 0);
+				addBufferLog(0, null, new BigDecimal(no), baseTableName, 0, 0);
 			}
 		} else {
 			// auto update all translations
 			StringBuilder sql = new StringBuilder("UPDATE ").append(trlTable).append(" SET (")
 					.append(columnNames).append(",IsTranslated) = (SELECT ").append(columnNames)
-					.append(",'Y' FROM ").append(baseTable).append(" b WHERE ").append(trlTable).append(".")
-					.append(baseTable).append("_ID=b.").append(baseTable).append("_ID) WHERE AD_Client_ID=")
+					.append(",'Y' FROM ").append(baseTableName).append(" b WHERE ").append(trlTable).append(".")
+					.append(baseTable.getKeyColumns()[0]).append("=b.").append(baseTable.getKeyColumns()[0]).append(") WHERE AD_Client_ID=")
 					.append(getAD_Client_ID());
 
 			int no = DB.executeUpdateEx(sql.toString(), get_TrxName());
-			addBufferLog(0, null, new BigDecimal(no), baseTable, 0, 0);
+			addBufferLog(0, null, new BigDecimal(no), baseTableName, 0, 0);
 		}
 	  } catch (DBException e) {
 		String msg = trlTable + " -> ";

--- a/org.adempiere.base.process/src/org/idempiere/process/CreateTable.java
+++ b/org.adempiere.base.process/src/org/idempiere/process/CreateTable.java
@@ -214,9 +214,6 @@ public class CreateTable extends SvrProcess {
 	 */
 	protected String doIt() {
 
-		if (!p_isCreateKeyColumn && p_isCreateTranslationTable)
-			return ("@Error@ Main table must have a key column if you want to handle translations");
-
 		if (Util.isEmpty(p_name))
 			p_name = p_tableName;
 
@@ -323,6 +320,8 @@ public class CreateTable extends SvrProcess {
 			int colElementID = 0;
 			if (elementID != null)
 				colElementID = createColumn(tableTrl, elementID.getColumnName()); // <TableName>_ID (ID of parent table)
+			else
+				colElementID = createColumn(tableTrl, elementUU.getColumnName()); // <TableName>_UU (UUID of parent table)
 
 			M_Element elementTrlUU = M_Element.get(getCtx(), tableTrl.getTableName() + "_UU");
 			if (elementTrlUU == null) {
@@ -610,6 +609,13 @@ public class CreateTable extends SvrProcess {
 			column.setIsParent(true);
 			column.setIsMandatory(true);
 			column.setFKConstraintType(MColumn.FKCONSTRAINTTYPE_Cascade);
+		}
+		else if (element.getColumnName().equalsIgnoreCase(PO.getUUIDColumnName(table.getTableName().substring(0, table.getTableName().length()-4)))) { // UUID of parent table (for translation tables)
+			column.setAD_Reference_ID(DisplayType.SearchUU);
+			column.setIsParent(true);
+			column.setIsMandatory(true);
+			column.setFKConstraintType(MColumn.FKCONSTRAINTTYPE_Cascade);
+			column.setFieldLength(LENGTH_36);
 		}
 
 		column.saveEx();

--- a/org.adempiere.base/src/org/compiere/model/I_AD_Package_Imp_Detail.java
+++ b/org.adempiere.base/src/org/compiere/model/I_AD_Package_Imp_Detail.java
@@ -192,6 +192,15 @@ public interface I_AD_Package_Imp_Detail
 	  */
 	public int getRecord_ID();
 
+    /** Column name Record_UU */
+    public static final String COLUMNNAME_Record_UU = "Record_UU";
+
+	/** Set Record UUID	  */
+	public void setRecord_UU (String Record_UU);
+
+	/** Get Record UUID	  */
+	public String getRecord_UU();
+
     /** Column name Result */
     public static final String COLUMNNAME_Result = "Result";
 

--- a/org.adempiere.base/src/org/compiere/model/PO.java
+++ b/org.adempiere.base/src/org/compiere/model/PO.java
@@ -4357,7 +4357,7 @@ public abstract class PO
 		//	Not a translation table
 		if (m_IDs.length > 1
 			|| m_IDs[0].equals(I_ZERO)
-			|| !(m_IDs[0] instanceof Integer)
+			|| !(m_IDs[0] instanceof Integer || m_IDs[0] instanceof String)
 			|| !p_info.isTranslated())
 			return true;
 		//
@@ -4409,8 +4409,13 @@ public abstract class PO
 			sql.append(" ");
 		sql.append("FROM AD_Language l, ").append(tableName).append(" t, AD_Client c ")
 			.append("WHERE t.AD_Client_ID=c.AD_Client_ID AND l.IsActive='Y' AND l.IsSystemLanguage='Y' AND l.IsBaseLanguage='N' AND t.")
-			.append(keyColumn).append("=").append(get_ID())
-			.append(" AND NOT EXISTS (SELECT * FROM ").append(tableName)
+			.append(keyColumn).append("=");
+		MTable table = MTable.get(getCtx(), tableName);
+		if (table.isUUIDKeyTable())
+			sql.append(DB.TO_STRING(get_UUID()));
+		else
+			sql.append(get_ID());
+		sql.append(" AND NOT EXISTS (SELECT * FROM ").append(tableName)
 			.append("_Trl tt WHERE tt.AD_Language=l.AD_Language AND tt.")
 			.append(keyColumn).append("=t.").append(keyColumn).append(")");
 		int no = -1;
@@ -4441,7 +4446,7 @@ public abstract class PO
 		//	Not a translation table
 		if (m_IDs.length > 1
 			|| m_IDs[0].equals(I_ZERO)
-			|| !(m_IDs[0] instanceof Integer)
+			|| !(m_IDs[0] instanceof Integer || m_IDs[0] instanceof String)
 			|| !p_info.isTranslated())
 			return true;
 
@@ -4487,7 +4492,12 @@ public abstract class PO
 				}
 			}
 		}
-		StringBuilder whereid = new StringBuilder(" WHERE ").append(keyColumn).append("=").append(get_ID());
+		MTable table = MTable.get(getCtx(), tableName);
+		StringBuilder whereid = new StringBuilder(" WHERE ").append(keyColumn).append("=");
+		if (table.isUUIDKeyTable())
+			whereid.append(DB.TO_STRING(get_UUID()));
+		else
+			whereid.append(get_ID());
 		StringBuilder andClientLang = new StringBuilder(" AND AD_Language=").append(DB.TO_STRING(client.getAD_Language()));
 		StringBuilder andNotClientLang = new StringBuilder(" AND AD_Language!=").append(DB.TO_STRING(client.getAD_Language()));
 		String baselang = Language.getBaseAD_Language();
@@ -4566,15 +4576,20 @@ public abstract class PO
 		//	Not a translation table
 		if (m_IDs.length > 1
 			|| m_IDs[0].equals(I_ZERO)
-			|| !(m_IDs[0] instanceof Integer)
+			|| !(m_IDs[0] instanceof Integer || m_IDs[0] instanceof String)
 			|| !p_info.isTranslated())
 			return true;
 		//
 		String tableName = p_info.getTableName();
+		MTable table = MTable.get(getCtx(), tableName);
 		String keyColumn = m_KeyColumns[0];
 		StringBuilder sql = new StringBuilder ("DELETE FROM ")
 			.append(tableName).append("_Trl WHERE ")
-			.append(keyColumn).append("=").append(get_ID());
+			.append(keyColumn).append("=");
+		if (table.isUUIDKeyTable())
+			sql.append(DB.TO_STRING(get_UUID()));
+		else
+			sql.append(get_ID());
 		int no = DB.executeUpdate(sql.toString(), trxName);
 		if (log.isLoggable(Level.FINE)) log.fine("#" + no);
 		return no >= 0;

--- a/org.adempiere.base/src/org/compiere/model/X_AD_Package_Imp_Detail.java
+++ b/org.adempiere.base/src/org/compiere/model/X_AD_Package_Imp_Detail.java
@@ -30,7 +30,7 @@ public class X_AD_Package_Imp_Detail extends PO implements I_AD_Package_Imp_Deta
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20230409L;
+	private static final long serialVersionUID = 20231126L;
 
     /** Standard Constructor */
     public X_AD_Package_Imp_Detail (Properties ctx, int AD_Package_Imp_Detail_ID, String trxName)
@@ -287,6 +287,21 @@ public class X_AD_Package_Imp_Detail extends PO implements I_AD_Package_Imp_Deta
 		if (ii == null)
 			 return 0;
 		return ii.intValue();
+	}
+
+	/** Set Record UUID.
+		@param Record_UU Record UUID
+	*/
+	public void setRecord_UU (String Record_UU)
+	{
+		set_Value (COLUMNNAME_Record_UU, Record_UU);
+	}
+
+	/** Get Record UUID.
+		@return Record UUID	  */
+	public String getRecord_UU()
+	{
+		return (String)get_Value(COLUMNNAME_Record_UU);
 	}
 
 	/** Set Result.

--- a/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/IndexColumnElementHandler.java
+++ b/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/IndexColumnElementHandler.java
@@ -54,8 +54,8 @@ public class IndexColumnElementHandler extends AbstractElementHandler {
 			MIndexColumn mIndexColumn = findPO(ctx, element);
 			if (mIndexColumn == null) {
 				int parentId = 0;
-				if (getParentId(element, MTableIndex.Table_Name) > 0) {
-					parentId = getParentId(element, MTableIndex.Table_Name);
+				if ((Integer)getParentId(element, MTableIndex.Table_Name) > 0) {
+					parentId = (Integer)getParentId(element, MTableIndex.Table_Name);
 				} else {
 					Element pfElement = element.properties.get(MIndexColumn.COLUMNNAME_AD_TableIndex_ID);
 					parentId = ReferenceUtils.resolveReferenceAsInt(ctx.ctx, pfElement, getTrxName(ctx));

--- a/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/ViewColumnElementHandler.java
+++ b/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/ViewColumnElementHandler.java
@@ -54,8 +54,8 @@ public class ViewColumnElementHandler extends AbstractElementHandler {
 			MViewColumn mViewColumn = findPO(ctx, element);
 			if (mViewColumn == null) {
 				int parentId = 0;
-				if (getParentId(element, MViewComponent.Table_Name) > 0) {
-					parentId = getParentId(element, MViewComponent.Table_Name);
+				if ((Integer)getParentId(element, MViewComponent.Table_Name) > 0) {
+					parentId = (Integer)getParentId(element, MViewComponent.Table_Name);
 				} else {
 					Element pfElement = element.properties.get(MViewColumn.COLUMNNAME_AD_ViewComponent_ID);
 					parentId = ReferenceUtils.resolveReferenceAsInt(ctx.ctx, pfElement, getTrxName(ctx));

--- a/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/WorkflowElementHandler.java
+++ b/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/WorkflowElementHandler.java
@@ -110,11 +110,11 @@ public class WorkflowElementHandler extends AbstractElementHandler {
 	 * @param element
 	 */
 	public void endElement(PIPOContext ctx, Element element) throws SAXException {
-		if (!element.defer && !element.skip && element.recordId > 0) {
+		if (!element.defer && !element.skip && (Integer)element.recordId > 0) {
 			//set start node
 			String value = getStringValue(element, "AD_WF_Node_ID");
 			if (value != null && value.trim().length() > 0) {
-				MWorkflow m_Workflow = new MWorkflow(ctx.ctx, element.recordId, getTrxName(ctx));
+				MWorkflow m_Workflow = new MWorkflow(ctx.ctx, (Integer)element.recordId, getTrxName(ctx));
 				PoFiller filler = new PoFiller(ctx, m_Workflow, element, this);
 				int id = ((Number)filler.setTableReference("AD_WF_Node_ID")).intValue();
 				if (id <= 0) {

--- a/org.adempiere.pipo/src/org/adempiere/pipo2/AbstractElementHandler.java
+++ b/org.adempiere.pipo/src/org/adempiere/pipo2/AbstractElementHandler.java
@@ -90,7 +90,25 @@ public abstract class AbstractElementHandler implements ElementHandler {
      */
     public void logImportDetail (PIPOContext ctx, X_AD_Package_Imp_Detail detail, int success, String objectName, int objectID,
     		String action) throws SAXException{
-    	logImportDetail (ctx, detail, success, objectName, objectID, action, null, null);
+    	logImportDetail (ctx, detail, success, objectName, objectID, null, action, null, null);
+    }
+
+	/**
+     *	Write results to log and records in history table
+     *
+     *		@param ctx
+     *      @param success
+     *      @param detail
+     *      @param objectName
+     *      @param objectID
+     *      @param objectUU
+     *      @param action
+     * 		@throws SAXException
+     *
+     */
+    public void logImportDetail (PIPOContext ctx, X_AD_Package_Imp_Detail detail, int success, String objectName, int objectID, String objectUU,
+    		String action) throws SAXException{
+    	logImportDetail (ctx, detail, success, objectName, objectID, objectUU, action, null, null);
     }
 
 	/**
@@ -109,7 +127,34 @@ public abstract class AbstractElementHandler implements ElementHandler {
      */
     public void logImportDetail (PIPOContext ctx, X_AD_Package_Imp_Detail detail, int success, String objectName, int objectID,
     		String action, String execCode, String result) throws SAXException{
+    	logImportDetail (ctx, detail, success, objectName, objectID, null, action, execCode, result);
+    }
+
+	/**
+     *	Write results to log and records in history table
+     *
+     *		@param ctx
+     *      @param success
+     *      @param detail
+     *      @param objectName
+     *      @param objectID
+     *      @param objectUU
+     *      @param action
+     *      @param execCode
+     *      @param result
+     * 		@throws SAXException
+     *
+     */
+    public void logImportDetail (PIPOContext ctx, X_AD_Package_Imp_Detail detail, int success, String objectName, int objectID, String objectUU,
+    		String action, String execCode, String result) throws SAXException{
 		String msgSuccess = success == 1 ? "Success" : "Failure";
+
+		// try to figure out the UUID when empty
+		if (Util.isEmpty(objectUU) && objectID > 0 && detail.getAD_Table_ID() > 0) {
+			MTable table = MTable.get(ctx.ctx, detail.getAD_Table_ID(), getTrxName(ctx));
+			PO po = table.getPO(objectID, getTrxName(ctx));
+			objectUU = po.get_UUID();
+		}
 
 		detail.setName(objectName);
 		detail.setAction(action);
@@ -120,6 +165,8 @@ public abstract class AbstractElementHandler implements ElementHandler {
 			detail.setResult(result);
 		if (objectID >= 0)
 			detail.setRecord_ID(objectID);
+		if (!Util.isEmpty(objectUU))
+			detail.setRecord_UU(objectUU);
 		ctx.packIn.addImportDetail(detail);
 		StringBuilder msg = new StringBuilder(action).append(" ");
 		if (detail.getTableName() != null)
@@ -411,9 +458,10 @@ public abstract class AbstractElementHandler implements ElementHandler {
      * @param expectedName
      * @return Parent element record id
      */
-    protected int getParentId(Element element, String expectedName) {
+    protected Object getParentId(Element element, String expectedName) {
     	if (element.parent != null && element.parent.getElementValue().equals(expectedName) &&
-    			element.parent.recordId > 0)
+    			(   (element.parent.recordId instanceof Integer && (Integer)element.parent.recordId > 0)
+    			 || (element.parent.recordId instanceof String && !Util.isEmpty((String)element.parent.recordId))))
     		return element.parent.recordId;
     	else
     		return 0;

--- a/org.adempiere.pipo/src/org/adempiere/pipo2/Element.java
+++ b/org.adempiere.pipo/src/org/adempiere/pipo2/Element.java
@@ -42,7 +42,7 @@ public class Element {
 	//parent element
 	public Element parent;
 	//resolved db recordid, store for reference by child element
-	public int recordId = 0;
+	public Object recordId = null;
 	//unresolved dependency
 	public String unresolved = "";
 	//number of pass


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5567

- Manage translation for UUID based tables
- Enable 2Pack Import UUID based tables with translation
- Create ad_package_imp_detail.Record_UU
- Create test table TestUU_Trl

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [x] I have made corresponding changes to the documentation as follows:
- - [x] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [x] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

