### PR TITLE
IDEMPIERE-5567 Support of UUID as Key (FHCA-4195) - Fixes #TestDay2023

### DIFF
--- a/org.adempiere.base.process/src/org/idempiere/process/CleanOrphanCascade.java
+++ b/org.adempiere.base.process/src/org/idempiere/process/CleanOrphanCascade.java
@@ -139,7 +139,7 @@ public class CleanOrphanCascade extends SvrProcess
 					String colRef = refTable.getKeyColumns()[0];
 					String colRefUU = PO.getUUIDColumnName(refTableName);
 
-					if (colRecordID != null && ! refTable.isUUIDKeyTable()) {
+					if (colRecordID != null && refTable.isIDKeyTable()) {
 						StringBuilder whereClause = new StringBuilder("AD_Table_ID=").append(refTableID)
 								.append(" AND Record_ID>0")
 								.append(" AND NOT EXISTS (SELECT ").append(colRef)

--- a/org.adempiere.base/src/org/idempiere/process/MoveClient.java
+++ b/org.adempiere.base/src/org/idempiere/process/MoveClient.java
@@ -1170,8 +1170,10 @@ public class MoveClient extends SvrProcess {
 				return true;
 			}
 		}
-		if ("AD_ChangeLog".equalsIgnoreCase(tableName) || "AD_PInstance_Log".equalsIgnoreCase(tableName)) {
-			// skip orphan records in AD_ChangeLog and AD_PInstance_Log, can be log of deleted records, skip
+		if (   "AD_ChangeLog".equalsIgnoreCase(tableName)
+			|| "AD_PInstance".equalsIgnoreCase(tableName)
+			|| "AD_PInstance_Log".equalsIgnoreCase(tableName)) {
+			// skip orphan records in AD_ChangeLog, AD_PInstance and AD_PInstance_Log, can be log of deleted records, skip
 			return true;
 		}
 		return false;


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5567

- CleanOrphanCascade is failing when there are orphan change log records for M_InOutLineMA or other non-ID tables
- MoveClient is failing when there are AD_PInstance orphan records (because of the recently added AD_Table_ID reference)

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
