### PR TITLE
IDEMPIERE-5567 Support of UUID as Key (FHCA-4195)

### DIFF
--- a/org.adempiere.base/src/org/compiere/install/Translation.java
+++ b/org.adempiere.base/src/org/compiere/install/Translation.java
@@ -207,8 +207,9 @@ public class Translation implements IApplication
 				return "";
 		}
 
-		String keyColumn = Base_Table + "_ID";
-		String uuidColumn = MTable.getUUIDColumnName(Base_Table);
+		MTable baseTable = MTable.get(Env.getCtx(), Base_Table);
+		String keyColumn = baseTable.getKeyColumns()[0];
+		String uuidColumn = PO.getUUIDColumnName(Base_Table);
 		String[] trlColumns = getTrlColumns (Base_Table);
 		//
 		StringBuilder sql = null;
@@ -272,9 +273,11 @@ public class Translation implements IApplication
 			while (rs.next())
 			{
 				Element row = document.createElement (XML_ROW_TAG);
-				int keyid = rs.getInt(2);
+				int keyid = -1;
+				if (! baseTable.isUUIDKeyTable())
+					keyid = rs.getInt(2);
 				String uuid = rs.getString(3);
-				if (keyid <= MTable.MAX_OFFICIAL_ID || Util.isEmpty(uuid)) {
+				if ((keyid >= 0 && keyid <= MTable.MAX_OFFICIAL_ID) || Util.isEmpty(uuid)) {
 					row.setAttribute(XML_ROW_ATTRIBUTE_ID, String.valueOf(keyid));	//	KeyColumn
 				} else {
 					row.setAttribute(XML_ROW_ATTRIBUTE_UUID, String.valueOf(uuid));	//	UUIDColumn

--- a/org.adempiere.base/src/org/compiere/install/TranslationHandler.java
+++ b/org.adempiere.base/src/org/compiere/install/TranslationHandler.java
@@ -20,6 +20,7 @@ import java.sql.Timestamp;
 import java.util.logging.Level;
 
 import org.adempiere.exceptions.AdempiereException;
+import org.compiere.model.PO;
 import org.compiere.util.CLogger;
 import org.compiere.util.DB;
 import org.compiere.util.Language;
@@ -171,10 +172,7 @@ public class TranslationHandler extends DefaultHandler
 			//	Where section
 			m_sql.append(" WHERE ");
 			if (m_curUUID != null) {
-				StringBuilder sql = new StringBuilder("SELECT ").append(m_TableName).append("_ID").append(" FROM ").append(m_TableName)
-						.append(" WHERE ").append(m_TableName).append("_UU =?");
-				int ID = DB.getSQLValueEx(null, sql.toString(), m_curUUID);
-				m_sql.append(m_TableName).append("_ID=").append(ID);
+				m_sql.append(PO.getUUIDColumnName(m_TableName)).append("=").append(DB.TO_STRING(m_curUUID));
 			} else {
 				m_sql.append(m_TableName).append("_ID=").append(m_curID);
 			}

--- a/org.adempiere.base/src/org/compiere/model/MRecentItem.java
+++ b/org.adempiere.base/src/org/compiere/model/MRecentItem.java
@@ -357,13 +357,17 @@ public class MRecentItem extends X_AD_RecentItem implements ImmutablePOSupport
 			windowName = win.get_Translation("Name");
 		}
 		MTable table = MTable.get(getCtx(), getAD_Table_ID());
-		PO po = table.getPOByUU(getRecord_UU(), null);
+		PO po = null;
+		if (getRecord_UU() != null)
+			po = table.getPOByUU(getRecord_UU(), null);
+		else if (getRecord_ID() > 0)
+			po = table.getPO(getRecord_ID(), null);
 		if (po == null) {
 			String ii = getCacheKey(getAD_RecentItem_ID(), getCtx());
 			synchronized (MRecentItem.class) {
 				s_cache.remove(ii);
 			}
-			DB.executeUpdateEx("DELETE FROM AD_RecentItem WHERE AD_RecentItem=?", new Object[] {getAD_RecentItem_ID()}, null);
+			DB.executeUpdateEx("DELETE FROM AD_RecentItem WHERE AD_RecentItem_ID=?", new Object[] {getAD_RecentItem_ID()}, null);
 			return null;
 		}
 


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5567

- fix for import/export of TestUU_Trl
- fix for server stuck in loop when recent item doesn't have Record_UU
```
06:16:19.829===========> UiEngineImpl.handleError:  [131] java.lang.IllegalArgumentException: Invalid null or blank UU - Must pass valid UU
        at org.compiere.model.PO.loadByUU(PO.java:1486)
        at org.compiere.model.MTable.getPOByUU(MTable.java:684)
        at org.compiere.model.MRecentItem.getLabel(MRecentItem.java:360)
        at org.adempiere.webui.dashboard.DPRecentItems.refresh(DPRecentItems.java:275)
        at org.adempiere.webui.dashboard.DPRecentItems.updateUI(DPRecentItems.java:333)
```