### PR TITLE
IDEMPIERE-5567 - Parallel unit tests fail frequently with deadlock

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MTestUU.java
+++ b/org.adempiere.base/src/org/compiere/model/MTestUU.java
@@ -57,9 +57,6 @@ public class MTestUU extends X_TestUU {
 	 */
 	public MTestUU(Properties ctx, String Test_UU, String trxName, String... virtualColumns) {
 		super(ctx, Test_UU, trxName, virtualColumns);
-		if ("".equals(Test_UU)) {
-			setName(null);
-		}
 	} // MTestUU
 
 	/**

--- a/org.idempiere.test/src/org/idempiere/test/model/MTestUUTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/MTestUUTest.java
@@ -38,12 +38,15 @@ import org.compiere.util.Env;
 import org.compiere.util.Util;
 import org.idempiere.test.AbstractTestCase;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 /**
  *
  * @author Carlos Ruiz - globalqss - bxservice
  *
  */
+@Execution(ExecutionMode.SAME_THREAD)
 public class MTestUUTest extends AbstractTestCase {
 
 	private static final String TestRecordInGardenWorld = "8858ecc2-cf1d-405f-987f-793536037e76";
@@ -82,20 +85,10 @@ public class MTestUUTest extends AbstractTestCase {
 	public void testDeletingTestUU() {
 		Properties ctx = Env.getCtx();
 		String trxName = getTrxName();
-
-		// deleting the TestRecordInGardenWorld is creating a deadlock with testReadingUpdatingTestUU in parallel execution
-		// insert a new record
-		MTestUU testuu = new MTestUU(ctx, PO.UUID_NEW_RECORD, trxName);
-		testuu.setName("Test UU record created on JUnit test");
-		testuu.saveEx();
-		testuu.load(trxName);
-	    assertEquals("Test UU record created on JUnit test", testuu.getName());
-	    String uukey = testuu.getTestUU_UU();
-
-		MTestUU testuuToDelete = new MTestUU(ctx, uukey, trxName);
-		testuuToDelete.deleteEx(true);
-		MTestUU testuu2 = new MTestUU(ctx, uukey, trxName);
-	    assertFalse(testuu2.get_UUID().equals(uukey));
+		MTestUU testuu = new MTestUU(ctx, TestRecordInGardenWorld, trxName);
+		testuu.deleteEx(true);
+		MTestUU testuu2 = new MTestUU(ctx, TestRecordInGardenWorld, trxName);
+	    assertFalse(testuu2.get_UUID().equals(TestRecordInGardenWorld));
 	}
 
 	@Test

--- a/org.idempiere.test/src/org/idempiere/test/model/MTestUUTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/MTestUUTest.java
@@ -82,10 +82,20 @@ public class MTestUUTest extends AbstractTestCase {
 	public void testDeletingTestUU() {
 		Properties ctx = Env.getCtx();
 		String trxName = getTrxName();
-		MTestUU testuu = new MTestUU(ctx, TestRecordInGardenWorld, trxName);
-		testuu.deleteEx(true);
-		MTestUU testuu2 = new MTestUU(ctx, TestRecordInGardenWorld, trxName);
-	    assertFalse(testuu2.get_UUID().equals(TestRecordInGardenWorld));
+
+		// deleting the TestRecordInGardenWorld is creating a deadlock with testReadingUpdatingTestUU in parallel execution
+		// insert a new record
+		MTestUU testuu = new MTestUU(ctx, PO.UUID_NEW_RECORD, trxName);
+		testuu.setName("Test UU record created on JUnit test");
+		testuu.saveEx();
+		testuu.load(trxName);
+	    assertEquals("Test UU record created on JUnit test", testuu.getName());
+	    String uukey = testuu.getTestUU_UU();
+
+		MTestUU testuuToDelete = new MTestUU(ctx, uukey, trxName);
+		testuuToDelete.deleteEx(true);
+		MTestUU testuu2 = new MTestUU(ctx, uukey, trxName);
+	    assertFalse(testuu2.get_UUID().equals(uukey));
 	}
 
 	@Test


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5567

when executing unit tests in parallel, MTestUUTest fails frequently with error detected deadlock this can be caused by testReadingUpdatingTestUU trying to update translations and at the same time the testDeletingTestUU is deleting the same record and deleting the same translations

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
