### PR TITLE
 IDEMPIERE-6017 Move/Copy Client failing when there are Record_ID references for AD_ClientInfo or AD_OrgInfo

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MTable.java
+++ b/org.adempiere.base/src/org/compiere/model/MTable.java
@@ -504,7 +504,7 @@ public class MTable extends X_AD_Table implements ImmutablePOSupport
 	}	//	getKeyColumns
 	
 	/**
-	 * @return true if table has single key column and the key column name ends with _ID.
+	 * @return true if table has single key column and the key column name is the same as the table name plus _ID.
 	 */
 	public boolean isIDKeyTable()
 	{

--- a/org.adempiere.base/src/org/idempiere/process/MoveClient.java
+++ b/org.adempiere.base/src/org/idempiere/process/MoveClient.java
@@ -534,8 +534,8 @@ public class MoveClient extends SvrProcess {
 			p_errorList.add("Column " + tableName + "." + columnName +  " has different type in dictionary, external: " + refID + ", local: " + localColumn.getAD_Reference_ID());
 		}
 
-		// inform blocking if lengths are different
-		if (length != localColumn.getFieldLength()) {
+		// inform blocking if external length is bigger than local
+		if (length > localColumn.getFieldLength()) {
 			p_errorList.add("Column " + tableName + "." + columnName +  " has different length in dictionary, external: " + length + ", local: " + localColumn.getFieldLength());
 		}
 
@@ -1353,7 +1353,7 @@ public class MoveClient extends SvrProcess {
 		String uuidCol = PO.getUUIDColumnName(tableName);
 		MTable table = MTable.get(getCtx(), tableName);
 		String remoteUUID = null;
-		if (table.isUUIDKeyTable()) {
+		if (! table.isIDKeyTable()) {
 			remoteUUID = foreign_Key.toString();
 		} else {
 			StringBuilder sqlRemoteUUSB = new StringBuilder()


### PR DESCRIPTION

https://idempiere.atlassian.net/browse/IDEMPIERE-6017

- improve discovery of key column
- improve avoiding block when the target column is bigger and can hold the source column

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
