### PR TITLE
IDEMPIERE-5567 Support of UUID as Key (FHCA-4195) - fix oracle migration script

### DIFF
--- a/migration/iD11/oracle/202304060001_IDEMPIERE-5567.sql
+++ b/migration/iD11/oracle/202304060001_IDEMPIERE-5567.sql
@@ -8,7 +8,7 @@ SET DEFINE OFF
 INSERT INTO AD_Message (MsgType,MsgText,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Message_ID,Value,EntityType,AD_Message_UU) VALUES ('I','UUID based table is not compatible with Record_ID',0,0,'Y',TO_TIMESTAMP('2023-04-06 00:01:13','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2023-04-06 00:01:13','YYYY-MM-DD HH24:MI:SS'),100,200830,'UUTableNotCompatibleWithRecordID','D','5b220b22-2a21-493c-81f0-877dbc083874')
 ;
 
-ALTER TABLE t_selection ADD t_selection_uu VARCHAR2(36 CHAR) DEFAULT '' NOT NULL;
+ALTER TABLE t_selection ADD t_selection_uu VARCHAR2(36 CHAR) DEFAULT ' ' NOT NULL;
 
 ALTER TABLE T_SELECTION MODIFY T_SELECTION_ID DEFAULT 0;
 

--- a/migration/iD11/oracle/202304060001_IDEMPIERE-5567.sql
+++ b/migration/iD11/oracle/202304060001_IDEMPIERE-5567.sql
@@ -18,7 +18,7 @@ DROP INDEX t_selection_key;
 
 ALTER TABLE t_selection ADD CONSTRAINT t_selection_pkey PRIMARY KEY (ad_pinstance_id, t_selection_id, t_selection_uu);
 
-ALTER TABLE t_selection_infowindow ADD t_selection_uu VARCHAR2(36 CHAR) DEFAULT '' NOT NULL;
+ALTER TABLE t_selection_infowindow ADD t_selection_uu VARCHAR2(36 CHAR) DEFAULT ' ' NOT NULL;
 
 ALTER TABLE t_selection_infowindow MODIFY t_selection_id DEFAULT 0;
 


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-5567?focusedCommentId=50544

Fix issue reported by @nmicoud - oracle treats empty string '' as null

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [ ] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
