### PR TITLE
IDEMPIERE-6032 MPInstanceLog ResultSet constructor not getting all va…

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MPInstanceLog.java
+++ b/org.adempiere.base/src/org/compiere/model/MPInstanceLog.java
@@ -119,12 +119,16 @@ public class MPInstanceLog
 	 */
 	public MPInstanceLog (ResultSet rs) throws SQLException
 	{
-		setAD_PInstance_ID(rs.getInt("AD_PInstance_ID"));
-		setLog_ID(rs.getInt("Log_ID"));
-		setP_Date(rs.getTimestamp("P_Date"));
-		setP_ID(rs.getInt("P_ID"));
-		setP_Number(rs.getBigDecimal("P_Number"));
-		setP_Msg(rs.getString("P_Msg"));
+		setAD_PInstance_ID(rs.getInt(X_AD_PInstance_Log.COLUMNNAME_AD_PInstance_ID));
+		setLog_ID(rs.getInt(X_AD_PInstance_Log.COLUMNNAME_Log_ID));
+		setP_Date(rs.getTimestamp(X_AD_PInstance_Log.COLUMNNAME_P_Date));
+		setP_ID(rs.getInt(X_AD_PInstance_Log.COLUMNNAME_P_ID));
+		setP_Number(rs.getBigDecimal(X_AD_PInstance_Log.COLUMNNAME_P_Number));
+		setP_Msg(rs.getString(X_AD_PInstance_Log.COLUMNNAME_P_Msg));
+		setAD_Table_ID(rs.getInt(X_AD_PInstance_Log.COLUMNNAME_AD_Table_ID));
+		setRecord_ID(rs.getInt(X_AD_PInstance_Log.COLUMNNAME_Record_ID));
+		setPInstanceLogType(rs.getString(X_AD_PInstance_Log.COLUMNNAME_PInstanceLogType));
+		setAD_PInstance_Log_UU(rs.getString(X_AD_PInstance_Log.COLUMNNAME_AD_PInstance_Log_UU));
 	}	//	MPInstance_Log
 
 	private int m_AD_PInstance_ID;

--- a/org.adempiere.base/src/org/compiere/model/SystemIDs.java
+++ b/org.adempiere.base/src/org/compiere/model/SystemIDs.java
@@ -93,6 +93,7 @@ public class SystemIDs
 	public final static int PROCESS_AD_CHANGELOG_REDO = 307;
 	public final static int PROCESS_AD_NATIVE_SEQUENCE_ENABLE = 53156;
 	public final static int PROCESS_AD_TAB_CREATEFIELDS = 174;
+	public final static int PROCESS_C_BPARTNER_VALIDATE = 314;
 	public final static int PROCESS_C_INVOICE_GENERATE = 119;
 	public final static int PROCESS_C_INVOICE_GENERATE_MANUAL = 134;
 	public final static int PROCESS_C_INVOICE_GENERATERMA_MANUAL = 52002;

--- a/org.idempiere.test/src/org/idempiere/test/model/ProcessTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/ProcessTest.java
@@ -40,10 +40,14 @@ import org.compiere.model.MInOutConfirm;
 import org.compiere.model.MInOutLine;
 import org.compiere.model.MOrder;
 import org.compiere.model.MOrderLine;
+import org.compiere.model.MPInstance;
+import org.compiere.model.MPInstanceLog;
+import org.compiere.model.MPInstancePara;
 import org.compiere.model.MProcess;
 import org.compiere.model.MProduct;
 import org.compiere.model.Query;
 import org.compiere.model.SystemIDs;
+import org.compiere.model.X_AD_PInstance_Log;
 import org.compiere.process.DocAction;
 import org.compiere.process.ProcessCall;
 import org.compiere.process.ProcessInfo;
@@ -293,4 +297,31 @@ public class ProcessTest extends AbstractTestCase {
 			assertNotNull(pc, "Failed to load ProcessCall instance for " + process.toString() + ", " + process.getClassname());
 		}
 	}	
+	
+	@Test
+	public void testGetInstanceLog() {
+		// Run the validate business partner process
+		MProcess process = MProcess.get(SystemIDs.PROCESS_C_BPARTNER_VALIDATE);
+		MPInstance pinstance = new MPInstance(process, 0, 0, null);
+		MPInstancePara[] paras = pinstance.getParameters();
+		for (MPInstancePara para : paras) {
+			if (para.getParameterName().equals("C_BPartner_ID")) {
+				para.setP_Number(DictionaryIDs.C_BPartner.JOE_BLOCK.id);
+				para.saveEx();
+				break;
+			}
+		}
+		
+		ProcessInfo pi = new ProcessInfo(process.getName(), SystemIDs.PROCESS_C_BPARTNER_VALIDATE);
+		pi.setAD_PInstance_ID(pinstance.getAD_PInstance_ID());
+		//use local process trx to create pinstance log immediately
+		process.processIt(pi, null, true);
+		assertTrue(!pi.isError(), pi.getSummary());
+		
+		MPInstanceLog[] logs = pinstance.getLog();
+		assertTrue(logs != null && logs.length > 0, "Failed to retrieve process instance logs");
+		assertEquals(pinstance.getAD_PInstance_ID(), logs[0].getAD_PInstance_ID(), "Invalid MPInstanceLog.AD_PInstance_ID value");
+		assertTrue(logs[0].getAD_PInstance_Log_UU() != null && logs[0].getAD_PInstance_Log_UU().length() == 36, "Invalid MPInstanceLog.AD_PInstance_Log_UU value");
+		assertEquals(X_AD_PInstance_Log.PINSTANCELOGTYPE_Result, logs[0].getPInstanceLogType(), "Invalid MPInstanceLog.PInstanceLogType value");
+	}
 }


### PR DESCRIPTION
…lue from result set

https://idempiere.atlassian.net/browse/IDEMPIERE-6032

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [x] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

