### PR TITLE
IDEMPIERE-5859 Support Attribute Set Instance for Reference=>Multi-Ch…

### DIFF
--- a/migration/iD12/oracle/202402271613_IDEMPIERE-5859.sql
+++ b/migration/iD12/oracle/202402271613_IDEMPIERE-5859.sql
@@ -1,0 +1,145 @@
+-- IDEMPIERE-5859 Support Attribute Set Instance for Reference=>Multi-Chosen fieldtypes
+SELECT register_migration_script('202402271613_IDEMPIERE-5859.sql') FROM dual;
+
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Feb 27, 2024, 4:13:28 PM MYT
+INSERT INTO AD_Table (AD_Table_ID,Name,Description,TableName,LoadSeq,AccessLevel,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsSecurityEnabled,IsDeleteable,IsHighVolume,IsView,EntityType,ImportTable,IsChangeLog,ReplicationType,CopyColumnsFromTable,IsCentrallyMaintained,AD_Table_UU,Processing,DatabaseViewDrop,CopyComponentsFromView,CreateWindowFromTable,IsShowInDrillOptions,IsPartition,CreatePartition) VALUES (200416,'Attribute Instance Values','Selected attribute values of an attribute instance','M_AttributeInstanceLine',0,'3',0,0,'Y',TO_TIMESTAMP('2024-02-27 16:13:27','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:13:27','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','N','N','D','N','Y','L','N','Y','055f08ea-e553-4b62-b66b-476ddb2ce36e','N','N','N','N','N','N','N')
+;
+
+-- Feb 27, 2024, 4:13:29 PM MYT
+INSERT INTO AD_Sequence (Name,CurrentNext,IsAudited,StartNewYear,Description,IsActive,IsTableID,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,AD_Sequence_ID,IsAutoSequence,StartNo,IncrementNo,CurrentNextSys,AD_Sequence_UU) VALUES ('M_AttributeInstanceLine',1000000,'N','N','Table M_AttributeInstanceLine','Y','Y',0,0,TO_TIMESTAMP('2024-02-27 16:13:28','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:13:28','YYYY-MM-DD HH24:MI:SS'),100,200487,'Y',1000000,1,200000,'e292c3e4-caf8-4418-b377-ec5437ce5635')
+;
+
+-- Feb 27, 2024, 4:14:23 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,ReadOnlyLogic,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216571,0.0,'Tenant','Tenant for this installation.','A Tenant is a company or a legal entity. You cannot share data between Tenants.',200416,'AD_Client_ID','@#AD_Client_ID@',10,'N','N','Y','N','N','N',30,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:14:23','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:14:23','YYYY-MM-DD HH24:MI:SS'),100,102,'N','N','1=1','D','N','01a158c0-031f-4a2e-bbc6-df402ac5182a','N')
+;
+
+-- Feb 27, 2024, 4:14:24 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216572,0.0,'Organization','Organizational entity within tenant','An organization is a unit of your tenant or legal entity - examples are store, department. You can share data between organizations.',200416,'AD_Org_ID','@AD_Org_ID@',10,'N','N','Y','N','N','N',19,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:14:23','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:14:23','YYYY-MM-DD HH24:MI:SS'),100,113,'N','N','D','N','4b1de05d-c6d3-4081-b201-5533da60cb36','N')
+;
+
+-- Feb 27, 2024, 4:14:24 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216573,0.0,'Created','Date this record was created','The Created field indicates the date that this record was created.',200416,'Created',7,'N','N','Y','N','N','N',16,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:14:24','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:14:24','YYYY-MM-DD HH24:MI:SS'),100,245,'N','N','D','N','2a9355b3-7ad2-4017-9e72-c1d1be5f289c','N')
+;
+
+-- Feb 27, 2024, 4:14:25 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Reference_Value_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216574,0.0,'Created By','User who created this records','The Created By field indicates the user who created this record.',200416,'CreatedBy',10,'N','N','Y','N','N','N',30,110,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:14:24','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:14:24','YYYY-MM-DD HH24:MI:SS'),100,246,'N','N','D','N','3246db86-cf99-4acf-8c6d-1979256d316e','N')
+;
+
+-- Feb 27, 2024, 4:14:26 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216575,0.0,'Updated','Date this record was updated','The Updated field indicates the date that this record was updated.',200416,'Updated',7,'N','N','Y','N','N','N',16,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:14:25','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:14:25','YYYY-MM-DD HH24:MI:SS'),100,607,'N','N','D','N','87d315c3-cd12-449c-9979-754d73d3eeef','N')
+;
+
+-- Feb 27, 2024, 4:14:26 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Reference_Value_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216576,0.0,'Updated By','User who updated this records','The Updated By field indicates the user who updated this record.',200416,'UpdatedBy',10,'N','N','Y','N','N','N',30,110,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:14:26','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:14:26','YYYY-MM-DD HH24:MI:SS'),100,608,'N','N','D','N','fa6af04b-0d7e-4d35-9fcb-cffdc39fe290','N')
+;
+
+-- Feb 27, 2024, 4:14:27 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216577,0.0,'Active','The record is active in the system','There are two methods of making records unavailable in the system: One is to delete the record, the other is to de-activate the record. A de-activated record is not available for selection, but available for reports.
+There are two reasons for de-activating and not deleting records:
+(1) The system requires the record for audit purposes.
+(2) The record is referenced by other records. E.g., you cannot delete a Business Partner, if there are invoices for this partner record existing. You de-activate the Business Partner and prevent that this record is used for future entries.',200416,'IsActive','Y',1,'N','N','Y','N','N','N',20,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:14:26','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:14:26','YYYY-MM-DD HH24:MI:SS'),100,348,'Y','N','D','N','ea152a49-5d8e-4625-a3c0-0977a131105a','N')
+;
+
+-- Feb 27, 2024, 4:14:27 PM MYT
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,ColumnName,Name,Description,PrintName,EntityType,AD_Element_UU) VALUES (203925,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:14:27','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:14:27','YYYY-MM-DD HH24:MI:SS'),100,'M_AttributeInstanceLine_ID','Attribute Instance Values','Selected attribute values of an attribute instance','Attribute Instance Values','D','da748052-0b46-46b3-9fce-ace05c956237')
+;
+
+-- Feb 27, 2024, 4:14:28 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216578,0.0,'Attribute Instance Values','Selected attribute values of an attribute instance',200416,'M_AttributeInstanceLine_ID',22,'Y','N','Y','N','N','N',13,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:14:27','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:14:27','YYYY-MM-DD HH24:MI:SS'),100,203925,'N','N','D','N','c34503ee-9e51-4556-ba3c-304b7c6b6e37','N')
+;
+
+-- Feb 27, 2024, 4:14:29 PM MYT
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,ColumnName,Name,PrintName,EntityType,AD_Element_UU) VALUES (203926,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:14:28','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:14:28','YYYY-MM-DD HH24:MI:SS'),100,'M_AttributeInstanceLine_UU','M_AttributeInstanceLine_UU','M_AttributeInstanceLine_UU','D','c61b71d5-d686-4126-a4e9-5c62546612cf')
+;
+
+-- Feb 27, 2024, 4:14:29 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216579,0.0,'M_AttributeInstanceLine_UU',200416,'M_AttributeInstanceLine_UU',36,'N','N','N','N','N','N',200231,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:14:29','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:14:29','YYYY-MM-DD HH24:MI:SS'),100,203926,'Y','N','D','N','c45c6493-e9fc-4a1a-8fb3-0a3bf8713a6a','N')
+;
+
+-- Feb 27, 2024, 4:14:30 PM MYT
+INSERT INTO AD_TableIndex (AD_Client_ID,AD_Org_ID,AD_TableIndex_ID,AD_TableIndex_UU,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,AD_Table_ID,IsCreateConstraint,IsUnique,Processing,IsKey) VALUES (0,0,201271,'ac117825-7390-4782-95f3-b82a5e863cd8',TO_TIMESTAMP('2024-02-27 16:14:29','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','M_AttributeInstanceLine_uu_idx',TO_TIMESTAMP('2024-02-27 16:14:29','YYYY-MM-DD HH24:MI:SS'),100,200416,'Y','Y','N','N')
+;
+
+-- Feb 27, 2024, 4:14:30 PM MYT
+INSERT INTO AD_IndexColumn (AD_Client_ID,AD_Org_ID,AD_IndexColumn_ID,AD_IndexColumn_UU,Created,CreatedBy,EntityType,IsActive,Updated,UpdatedBy,AD_Column_ID,AD_TableIndex_ID,SeqNo) VALUES (0,0,201727,'a7dd953a-ffb8-4473-883f-3123c5ff2931',TO_TIMESTAMP('2024-02-27 16:14:30','YYYY-MM-DD HH24:MI:SS'),100,'D','Y',TO_TIMESTAMP('2024-02-27 16:14:30','YYYY-MM-DD HH24:MI:SS'),100,216579,201271,10)
+;
+
+-- Feb 27, 2024, 4:17:13 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,FKConstraintType,IsHtml,IsPartitionKey) VALUES (216580,0,'M_AttributeInstance_UU',200416,'M_AttributeInstance_UU',36,'N','Y','Y','N','N',0,'N',200234,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:17:12','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:17:12','YYYY-MM-DD HH24:MI:SS'),100,54959,'N','N','D','N','N','N','Y','6d1acedd-e16a-4fc1-85ca-68727830a3b7','N',0,'N','N','C','N','N')
+;
+
+-- Feb 27, 2024, 4:18:50 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,IsHtml,IsPartitionKey) VALUES (216581,0,'Line No','Unique line for this document','Indicates the unique line for a document.  It will also control the display order of the lines within a document.',200416,'Line',22,'N','N','Y','N','N',0,'N',11,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:18:49','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:18:49','YYYY-MM-DD HH24:MI:SS'),100,439,'Y','N','D','N','N','N','Y','5a9c4ac9-8e66-4fbb-805e-640a6619faf5','N',0,'N','N','N','N')
+;
+
+-- Feb 27, 2024, 4:19:26 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,IsHtml,IsPartitionKey) VALUES (216582,0,'Attribute Value','Product Attribute Value','Individual value of a product attribute (e.g. green, large, ..)',200416,'M_AttributeValue_ID',22,'N','N','Y','N','N',0,'N',19,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:19:25','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:19:25','YYYY-MM-DD HH24:MI:SS'),100,2020,'N','N','D','N','N','N','Y','11bd3ec8-6b4c-4045-aa8c-93a3881231ba','N',0,'N','N','N','N')
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+UPDATE AD_Column SET IsAllowCopy='N', FKConstraintName='ADClient_MAttributeInstanceLin', FKConstraintType='N',Updated=TO_TIMESTAMP('2024-02-27 16:19:33','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216571
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+UPDATE AD_Column SET IsAllowCopy='N', FKConstraintName='ADOrg_MAttributeInstanceLine', FKConstraintType='N',Updated=TO_TIMESTAMP('2024-02-27 16:19:33','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216572
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+UPDATE AD_Column SET IsAllowCopy='N', FKConstraintName='CreatedBy_MAttributeInstanceLi', FKConstraintType='N',Updated=TO_TIMESTAMP('2024-02-27 16:19:33','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216574
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+UPDATE AD_Column SET FieldLength=36, IsUpdateable='N', FKConstraintName='MAttributeInstanceUU_MAttribut', FKConstraintType='C',Updated=TO_TIMESTAMP('2024-02-27 16:19:33','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216580
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+UPDATE AD_Column SET FKConstraintName='MAttributeValue_MAttributeInst', FKConstraintType='N',Updated=TO_TIMESTAMP('2024-02-27 16:19:33','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216582
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+UPDATE AD_Column SET IsAllowCopy='N', FKConstraintName='UpdatedBy_MAttributeInstanceLi', FKConstraintType='N',Updated=TO_TIMESTAMP('2024-02-27 16:19:33','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216576
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+CREATE TABLE M_AttributeInstanceLine (AD_Client_ID NUMBER(10) NOT NULL, AD_Org_ID NUMBER(10) NOT NULL, Created DATE NOT NULL, CreatedBy NUMBER(10) NOT NULL, IsActive CHAR(1) DEFAULT 'Y' CHECK (IsActive IN ('Y','N')) NOT NULL, Line NUMBER(10) NOT NULL, M_AttributeInstanceLine_ID NUMBER(10) NOT NULL, M_AttributeInstanceLine_UU VARCHAR2(36 CHAR) DEFAULT NULL , M_AttributeInstance_UU VARCHAR2(36 CHAR) NOT NULL, M_AttributeValue_ID NUMBER(10) NOT NULL, Updated DATE NOT NULL, UpdatedBy NUMBER(10) NOT NULL, CONSTRAINT M_AttributeInstanceLine_Key PRIMARY KEY (M_AttributeInstanceLine_ID), CONSTRAINT M_AttributeInstanceLine_UU_idx UNIQUE (M_AttributeInstanceLine_UU))
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+ALTER TABLE M_AttributeInstanceLine ADD CONSTRAINT ADClient_MAttributeInstanceLin FOREIGN KEY (AD_Client_ID) REFERENCES ad_client(ad_client_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+ALTER TABLE M_AttributeInstanceLine ADD CONSTRAINT ADOrg_MAttributeInstanceLine FOREIGN KEY (AD_Org_ID) REFERENCES ad_org(ad_org_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+ALTER TABLE M_AttributeInstanceLine ADD CONSTRAINT CreatedBy_MAttributeInstanceLi FOREIGN KEY (CreatedBy) REFERENCES ad_user(ad_user_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+ALTER TABLE M_AttributeInstanceLine ADD CONSTRAINT MAttributeInstanceUU_MAttribut FOREIGN KEY (M_AttributeInstance_UU) REFERENCES M_AttributeInstance(M_AttributeInstance_UU) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+ALTER TABLE M_AttributeInstanceLine ADD CONSTRAINT MAttributeValue_MAttributeInst FOREIGN KEY (M_AttributeValue_ID) REFERENCES m_attributevalue(m_attributevalue_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+ALTER TABLE M_AttributeInstanceLine ADD CONSTRAINT UpdatedBy_MAttributeInstanceLi FOREIGN KEY (UpdatedBy) REFERENCES ad_user(ad_user_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Feb 27, 2024, 4:22:24 PM MYT
+UPDATE AD_Column SET FieldLength=36, IsMandatory='Y', IsUpdateable='N', IsAllowCopy='N',Updated=TO_TIMESTAMP('2024-02-27 16:22:24','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216579
+;
+
+-- Feb 27, 2024, 4:22:36 PM MYT
+ALTER TABLE M_AttributeInstanceLine MODIFY M_AttributeInstanceLine_UU VARCHAR2(36 CHAR)
+;
+
+-- Feb 27, 2024, 4:22:36 PM MYT
+ALTER TABLE M_AttributeInstanceLine MODIFY M_AttributeInstanceLine_UU NOT NULL
+;
+

--- a/migration/iD12/postgresql/202402271613_IDEMPIERE-5859.sql
+++ b/migration/iD12/postgresql/202402271613_IDEMPIERE-5859.sql
@@ -1,0 +1,142 @@
+-- IDEMPIERE-5859 Support Attribute Set Instance for Reference=>Multi-Chosen fieldtypes
+SELECT register_migration_script('202402271613_IDEMPIERE-5859.sql') FROM dual;
+
+-- Feb 27, 2024, 4:13:28 PM MYT
+INSERT INTO AD_Table (AD_Table_ID,Name,Description,TableName,LoadSeq,AccessLevel,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsSecurityEnabled,IsDeleteable,IsHighVolume,IsView,EntityType,ImportTable,IsChangeLog,ReplicationType,CopyColumnsFromTable,IsCentrallyMaintained,AD_Table_UU,Processing,DatabaseViewDrop,CopyComponentsFromView,CreateWindowFromTable,IsShowInDrillOptions,IsPartition,CreatePartition) VALUES (200416,'Attribute Instance Values','Selected attribute values of an attribute instance','M_AttributeInstanceLine',0,'3',0,0,'Y',TO_TIMESTAMP('2024-02-27 16:13:27','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:13:27','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','N','N','D','N','Y','L','N','Y','055f08ea-e553-4b62-b66b-476ddb2ce36e','N','N','N','N','N','N','N')
+;
+
+-- Feb 27, 2024, 4:13:29 PM MYT
+INSERT INTO AD_Sequence (Name,CurrentNext,IsAudited,StartNewYear,Description,IsActive,IsTableID,AD_Client_ID,AD_Org_ID,Created,CreatedBy,Updated,UpdatedBy,AD_Sequence_ID,IsAutoSequence,StartNo,IncrementNo,CurrentNextSys,AD_Sequence_UU) VALUES ('M_AttributeInstanceLine',1000000,'N','N','Table M_AttributeInstanceLine','Y','Y',0,0,TO_TIMESTAMP('2024-02-27 16:13:28','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:13:28','YYYY-MM-DD HH24:MI:SS'),100,200487,'Y',1000000,1,200000,'e292c3e4-caf8-4418-b377-ec5437ce5635')
+;
+
+-- Feb 27, 2024, 4:14:23 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,ReadOnlyLogic,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216571,0.0,'Tenant','Tenant for this installation.','A Tenant is a company or a legal entity. You cannot share data between Tenants.',200416,'AD_Client_ID','@#AD_Client_ID@',10,'N','N','Y','N','N','N',30,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:14:23','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:14:23','YYYY-MM-DD HH24:MI:SS'),100,102,'N','N','1=1','D','N','01a158c0-031f-4a2e-bbc6-df402ac5182a','N')
+;
+
+-- Feb 27, 2024, 4:14:24 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216572,0.0,'Organization','Organizational entity within tenant','An organization is a unit of your tenant or legal entity - examples are store, department. You can share data between organizations.',200416,'AD_Org_ID','@AD_Org_ID@',10,'N','N','Y','N','N','N',19,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:14:23','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:14:23','YYYY-MM-DD HH24:MI:SS'),100,113,'N','N','D','N','4b1de05d-c6d3-4081-b201-5533da60cb36','N')
+;
+
+-- Feb 27, 2024, 4:14:24 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216573,0.0,'Created','Date this record was created','The Created field indicates the date that this record was created.',200416,'Created',7,'N','N','Y','N','N','N',16,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:14:24','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:14:24','YYYY-MM-DD HH24:MI:SS'),100,245,'N','N','D','N','2a9355b3-7ad2-4017-9e72-c1d1be5f289c','N')
+;
+
+-- Feb 27, 2024, 4:14:25 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Reference_Value_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216574,0.0,'Created By','User who created this records','The Created By field indicates the user who created this record.',200416,'CreatedBy',10,'N','N','Y','N','N','N',30,110,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:14:24','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:14:24','YYYY-MM-DD HH24:MI:SS'),100,246,'N','N','D','N','3246db86-cf99-4acf-8c6d-1979256d316e','N')
+;
+
+-- Feb 27, 2024, 4:14:26 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216575,0.0,'Updated','Date this record was updated','The Updated field indicates the date that this record was updated.',200416,'Updated',7,'N','N','Y','N','N','N',16,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:14:25','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:14:25','YYYY-MM-DD HH24:MI:SS'),100,607,'N','N','D','N','87d315c3-cd12-449c-9979-754d73d3eeef','N')
+;
+
+-- Feb 27, 2024, 4:14:26 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Reference_Value_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216576,0.0,'Updated By','User who updated this records','The Updated By field indicates the user who updated this record.',200416,'UpdatedBy',10,'N','N','Y','N','N','N',30,110,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:14:26','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:14:26','YYYY-MM-DD HH24:MI:SS'),100,608,'N','N','D','N','fa6af04b-0d7e-4d35-9fcb-cffdc39fe290','N')
+;
+
+-- Feb 27, 2024, 4:14:27 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216577,0.0,'Active','The record is active in the system','There are two methods of making records unavailable in the system: One is to delete the record, the other is to de-activate the record. A de-activated record is not available for selection, but available for reports.
+There are two reasons for de-activating and not deleting records:
+(1) The system requires the record for audit purposes.
+(2) The record is referenced by other records. E.g., you cannot delete a Business Partner, if there are invoices for this partner record existing. You de-activate the Business Partner and prevent that this record is used for future entries.',200416,'IsActive','Y',1,'N','N','Y','N','N','N',20,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:14:26','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:14:26','YYYY-MM-DD HH24:MI:SS'),100,348,'Y','N','D','N','ea152a49-5d8e-4625-a3c0-0977a131105a','N')
+;
+
+-- Feb 27, 2024, 4:14:27 PM MYT
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,ColumnName,Name,Description,PrintName,EntityType,AD_Element_UU) VALUES (203925,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:14:27','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:14:27','YYYY-MM-DD HH24:MI:SS'),100,'M_AttributeInstanceLine_ID','Attribute Instance Values','Selected attribute values of an attribute instance','Attribute Instance Values','D','da748052-0b46-46b3-9fce-ace05c956237')
+;
+
+-- Feb 27, 2024, 4:14:28 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216578,0.0,'Attribute Instance Values','Selected attribute values of an attribute instance',200416,'M_AttributeInstanceLine_ID',22,'Y','N','Y','N','N','N',13,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:14:27','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:14:27','YYYY-MM-DD HH24:MI:SS'),100,203925,'N','N','D','N','c34503ee-9e51-4556-ba3c-304b7c6b6e37','N')
+;
+
+-- Feb 27, 2024, 4:14:29 PM MYT
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,ColumnName,Name,PrintName,EntityType,AD_Element_UU) VALUES (203926,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:14:28','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:14:28','YYYY-MM-DD HH24:MI:SS'),100,'M_AttributeInstanceLine_UU','M_AttributeInstanceLine_UU','M_AttributeInstanceLine_UU','D','c61b71d5-d686-4126-a4e9-5c62546612cf')
+;
+
+-- Feb 27, 2024, 4:14:29 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsAlwaysUpdateable,AD_Column_UU,IsToolbarButton) VALUES (216579,0.0,'M_AttributeInstanceLine_UU',200416,'M_AttributeInstanceLine_UU',36,'N','N','N','N','N','N',200231,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:14:29','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:14:29','YYYY-MM-DD HH24:MI:SS'),100,203926,'Y','N','D','N','c45c6493-e9fc-4a1a-8fb3-0a3bf8713a6a','N')
+;
+
+-- Feb 27, 2024, 4:14:30 PM MYT
+INSERT INTO AD_TableIndex (AD_Client_ID,AD_Org_ID,AD_TableIndex_ID,AD_TableIndex_UU,Created,CreatedBy,EntityType,IsActive,Name,Updated,UpdatedBy,AD_Table_ID,IsCreateConstraint,IsUnique,Processing,IsKey) VALUES (0,0,201271,'ac117825-7390-4782-95f3-b82a5e863cd8',TO_TIMESTAMP('2024-02-27 16:14:29','YYYY-MM-DD HH24:MI:SS'),100,'D','Y','M_AttributeInstanceLine_uu_idx',TO_TIMESTAMP('2024-02-27 16:14:29','YYYY-MM-DD HH24:MI:SS'),100,200416,'Y','Y','N','N')
+;
+
+-- Feb 27, 2024, 4:14:30 PM MYT
+INSERT INTO AD_IndexColumn (AD_Client_ID,AD_Org_ID,AD_IndexColumn_ID,AD_IndexColumn_UU,Created,CreatedBy,EntityType,IsActive,Updated,UpdatedBy,AD_Column_ID,AD_TableIndex_ID,SeqNo) VALUES (0,0,201727,'a7dd953a-ffb8-4473-883f-3123c5ff2931',TO_TIMESTAMP('2024-02-27 16:14:30','YYYY-MM-DD HH24:MI:SS'),100,'D','Y',TO_TIMESTAMP('2024-02-27 16:14:30','YYYY-MM-DD HH24:MI:SS'),100,216579,201271,10)
+;
+
+-- Feb 27, 2024, 4:17:13 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,FKConstraintType,IsHtml,IsPartitionKey) VALUES (216580,0,'M_AttributeInstance_UU',200416,'M_AttributeInstance_UU',36,'N','Y','Y','N','N',0,'N',200234,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:17:12','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:17:12','YYYY-MM-DD HH24:MI:SS'),100,54959,'N','N','D','N','N','N','Y','6d1acedd-e16a-4fc1-85ca-68727830a3b7','N',0,'N','N','C','N','N')
+;
+
+-- Feb 27, 2024, 4:18:50 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,IsHtml,IsPartitionKey) VALUES (216581,0,'Line No','Unique line for this document','Indicates the unique line for a document.  It will also control the display order of the lines within a document.',200416,'Line',22,'N','N','Y','N','N',0,'N',11,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:18:49','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:18:49','YYYY-MM-DD HH24:MI:SS'),100,439,'Y','N','D','N','N','N','Y','5a9c4ac9-8e66-4fbb-805e-640a6619faf5','N',0,'N','N','N','N')
+;
+
+-- Feb 27, 2024, 4:19:26 PM MYT
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,IsHtml,IsPartitionKey) VALUES (216582,0,'Attribute Value','Product Attribute Value','Individual value of a product attribute (e.g. green, large, ..)',200416,'M_AttributeValue_ID',22,'N','N','Y','N','N',0,'N',19,0,0,'Y',TO_TIMESTAMP('2024-02-27 16:19:25','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2024-02-27 16:19:25','YYYY-MM-DD HH24:MI:SS'),100,2020,'N','N','D','N','N','N','Y','11bd3ec8-6b4c-4045-aa8c-93a3881231ba','N',0,'N','N','N','N')
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+UPDATE AD_Column SET IsAllowCopy='N', FKConstraintName='ADClient_MAttributeInstanceLin', FKConstraintType='N',Updated=TO_TIMESTAMP('2024-02-27 16:19:33','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216571
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+UPDATE AD_Column SET IsAllowCopy='N', FKConstraintName='ADOrg_MAttributeInstanceLine', FKConstraintType='N',Updated=TO_TIMESTAMP('2024-02-27 16:19:33','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216572
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+UPDATE AD_Column SET IsAllowCopy='N', FKConstraintName='CreatedBy_MAttributeInstanceLi', FKConstraintType='N',Updated=TO_TIMESTAMP('2024-02-27 16:19:33','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216574
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+UPDATE AD_Column SET FieldLength=36, IsUpdateable='N', FKConstraintName='MAttributeInstanceUU_MAttribut', FKConstraintType='C',Updated=TO_TIMESTAMP('2024-02-27 16:19:33','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216580
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+UPDATE AD_Column SET FKConstraintName='MAttributeValue_MAttributeInst', FKConstraintType='N',Updated=TO_TIMESTAMP('2024-02-27 16:19:33','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216582
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+UPDATE AD_Column SET IsAllowCopy='N', FKConstraintName='UpdatedBy_MAttributeInstanceLi', FKConstraintType='N',Updated=TO_TIMESTAMP('2024-02-27 16:19:33','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216576
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+CREATE TABLE M_AttributeInstanceLine (AD_Client_ID NUMERIC(10) NOT NULL, AD_Org_ID NUMERIC(10) NOT NULL, Created TIMESTAMP NOT NULL, CreatedBy NUMERIC(10) NOT NULL, IsActive CHAR(1) DEFAULT 'Y' CHECK (IsActive IN ('Y','N')) NOT NULL, Line NUMERIC(10) NOT NULL, M_AttributeInstanceLine_ID NUMERIC(10) NOT NULL, M_AttributeInstanceLine_UU VARCHAR(36) DEFAULT NULL , M_AttributeInstance_UU VARCHAR(36) NOT NULL, M_AttributeValue_ID NUMERIC(10) NOT NULL, Updated TIMESTAMP NOT NULL, UpdatedBy NUMERIC(10) NOT NULL, CONSTRAINT M_AttributeInstanceLine_Key PRIMARY KEY (M_AttributeInstanceLine_ID), CONSTRAINT M_AttributeInstanceLine_UU_idx UNIQUE (M_AttributeInstanceLine_UU))
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+ALTER TABLE M_AttributeInstanceLine ADD CONSTRAINT ADClient_MAttributeInstanceLin FOREIGN KEY (AD_Client_ID) REFERENCES ad_client(ad_client_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+ALTER TABLE M_AttributeInstanceLine ADD CONSTRAINT ADOrg_MAttributeInstanceLine FOREIGN KEY (AD_Org_ID) REFERENCES ad_org(ad_org_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+ALTER TABLE M_AttributeInstanceLine ADD CONSTRAINT CreatedBy_MAttributeInstanceLi FOREIGN KEY (CreatedBy) REFERENCES ad_user(ad_user_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+ALTER TABLE M_AttributeInstanceLine ADD CONSTRAINT MAttributeInstanceUU_MAttribut FOREIGN KEY (M_AttributeInstance_UU) REFERENCES M_AttributeInstance(M_AttributeInstance_UU) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+ALTER TABLE M_AttributeInstanceLine ADD CONSTRAINT MAttributeValue_MAttributeInst FOREIGN KEY (M_AttributeValue_ID) REFERENCES m_attributevalue(m_attributevalue_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Feb 27, 2024, 4:19:33 PM MYT
+ALTER TABLE M_AttributeInstanceLine ADD CONSTRAINT UpdatedBy_MAttributeInstanceLi FOREIGN KEY (UpdatedBy) REFERENCES ad_user(ad_user_id) DEFERRABLE INITIALLY DEFERRED
+;
+
+-- Feb 27, 2024, 4:22:24 PM MYT
+UPDATE AD_Column SET FieldLength=36, IsMandatory='Y', IsUpdateable='N', IsAllowCopy='N',Updated=TO_TIMESTAMP('2024-02-27 16:22:24','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Column_ID=216579
+;
+
+-- Feb 27, 2024, 4:22:36 PM MYT
+INSERT INTO t_alter_column values('m_attributeinstanceline','M_AttributeInstanceLine_UU','VARCHAR(36)',null,null)
+;
+
+-- Feb 27, 2024, 4:22:36 PM MYT
+INSERT INTO t_alter_column values('m_attributeinstanceline','M_AttributeInstanceLine_UU',null,'NOT NULL',null)
+;
+

--- a/org.adempiere.base/src/org/adempiere/base/event/delegate/AttributeInstanceEventDelegate.java
+++ b/org.adempiere.base/src/org/adempiere/base/event/delegate/AttributeInstanceEventDelegate.java
@@ -1,0 +1,118 @@
+/***********************************************************************
+ * This file is part of iDempiere ERP Open Source                      *
+ * http://www.idempiere.org                                            *
+ *                                                                     *
+ * Copyright (C) Contributors                                          *
+ *                                                                     *
+ * This program is free software; you can redistribute it and/or       *
+ * modify it under the terms of the GNU General Public License         *
+ * as published by the Free Software Foundation; either version 2      *
+ * of the License, or (at your option) any later version.              *
+ *                                                                     *
+ * This program is distributed in the hope that it will be useful,     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of      *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the        *
+ * GNU General Public License for more details.                        *
+ *                                                                     *
+ * You should have received a copy of the GNU General Public License   *
+ * along with this program; if not, write to the Free Software         *
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,          *
+ * MA 02110-1301, USA.                                                 *
+ **********************************************************************/
+package org.adempiere.base.event.delegate;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.adempiere.base.annotation.EventTopicDelegate;
+import org.adempiere.base.annotation.ModelEventTopic;
+import org.adempiere.base.event.annotations.ModelEventDelegate;
+import org.adempiere.base.event.annotations.po.AfterChange;
+import org.adempiere.base.event.annotations.po.AfterNew;
+import org.compiere.model.MAttribute;
+import org.compiere.model.MAttributeInstance;
+import org.compiere.model.MAttributeInstanceLine;
+import org.compiere.util.Env;
+import org.compiere.util.Util;
+import org.osgi.service.event.Event;
+
+@EventTopicDelegate
+@ModelEventTopic(modelClass = MAttributeInstance.class)
+public class AttributeInstanceEventDelegate extends ModelEventDelegate<MAttributeInstance> {
+
+	public AttributeInstanceEventDelegate(MAttributeInstance po, Event event) {
+		super(po, event);
+	}
+
+	/**
+	 * Create new MAttributeInstanceLine records for ATTRIBUTEVALUETYPE_ChosenMultipleSelectionList
+	 */
+	@AfterNew
+	public void afterNew() {
+		MAttributeInstance mai = getModel();
+		MAttribute attribute = MAttribute.get(Env.getCtx(), mai.getM_Attribute_ID());
+		if (attribute.getAttributeValueType().equals(MAttribute.ATTRIBUTEVALUETYPE_ChosenMultipleSelectionList)) {
+			if (!Util.isEmpty(mai.getValueMultipleSelection(), true)) {
+				String[] selectedIds = mai.getValueMultipleSelection().split("[,]");
+				int lineNo = 0;
+				for(String id : selectedIds) {
+					lineNo += 10;
+					MAttributeInstanceLine line = new MAttributeInstanceLine(Env.getCtx(), 0, mai.get_TrxName());
+					line.setLine(lineNo);
+					line.setM_AttributeInstance_UU(mai.getM_AttributeInstance_UU());
+					line.setM_AttributeValue_ID(Integer.parseInt(id));
+					line.setIsActive(true);
+					line.saveEx();
+				}
+			}
+		}
+	}
+	
+	/**
+	 * Update MAttributeInstanceLine records for ATTRIBUTEVALUETYPE_ChosenMultipleSelectionList
+	 */
+	@AfterChange
+	public void afterChange() {
+		MAttributeInstance mai = getModel();
+		MAttribute attribute = MAttribute.get(Env.getCtx(), mai.getM_Attribute_ID());
+		if (attribute.getAttributeValueType().equals(MAttribute.ATTRIBUTEVALUETYPE_ChosenMultipleSelectionList)) {
+			List<MAttributeInstanceLine> existing = MAttributeInstanceLine.getOfAttributeInstance(mai);
+			List<MAttributeInstanceLine> selectedLines = new ArrayList<MAttributeInstanceLine>();
+			List<Integer> selectedList = new ArrayList<Integer>();
+			if (!Util.isEmpty(mai.getValueMultipleSelection(), true)) {
+				String[] selectedIds = mai.getValueMultipleSelection().split("[,]");
+				Arrays.stream(selectedIds).forEach(e -> selectedList.add(Integer.parseInt(e)));
+			}
+			for(Integer selectedId : selectedList) {
+				int existingIndex = -1;
+				for(int i = 0; i < existing.size(); i++) {
+					if (existing.get(i).getM_AttributeValue_ID() == selectedId.intValue()) {
+						existingIndex = i;
+						break;
+					}
+				}
+				if (existingIndex >= 0) {
+					selectedLines.add(existing.remove(existingIndex));
+				} else {
+					MAttributeInstanceLine line = new MAttributeInstanceLine(Env.getCtx(), 0, mai.get_TrxName());
+					line.setLine(0);
+					line.setM_AttributeInstance_UU(mai.getM_AttributeInstance_UU());
+					line.setM_AttributeValue_ID(selectedId);
+					line.setIsActive(true);
+					selectedLines.add(line);
+				}
+			}
+			for(MAttributeInstanceLine il : existing) {
+				il.deleteEx(true);
+			}
+			int lineNo = 0;
+			for(MAttributeInstanceLine il : selectedLines) {
+				lineNo += 10;
+				il.setLine(lineNo);
+				if (il.is_new() || il.is_Changed())
+					il.saveEx();
+			}
+		}
+	}
+}

--- a/org.adempiere.base/src/org/compiere/model/I_M_AttributeInstanceLine.java
+++ b/org.adempiere.base/src/org/compiere/model/I_M_AttributeInstanceLine.java
@@ -1,0 +1,168 @@
+/******************************************************************************
+ * Product: iDempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2012 ComPiere, Inc. All Rights Reserved.                *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
+ * or via info@compiere.org or http://www.compiere.org/license.html           *
+ *****************************************************************************/
+package org.compiere.model;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import org.compiere.util.KeyNamePair;
+
+/** Generated Interface for M_AttributeInstanceLine
+ *  @author iDempiere (generated) 
+ *  @version Release 12
+ */
+public interface I_M_AttributeInstanceLine 
+{
+
+    /** TableName=M_AttributeInstanceLine */
+    public static final String Table_Name = "M_AttributeInstanceLine";
+
+    /** AD_Table_ID=200416 */
+    public static final int Table_ID = 200416;
+
+    KeyNamePair Model = new KeyNamePair(Table_ID, Table_Name);
+
+    /** AccessLevel = 3 - Client - Org 
+     */
+    BigDecimal accessLevel = BigDecimal.valueOf(3);
+
+    /** Load Meta Data */
+
+    /** Column name AD_Client_ID */
+    public static final String COLUMNNAME_AD_Client_ID = "AD_Client_ID";
+
+	/** Get Tenant.
+	  * Tenant for this installation.
+	  */
+	public int getAD_Client_ID();
+
+    /** Column name AD_Org_ID */
+    public static final String COLUMNNAME_AD_Org_ID = "AD_Org_ID";
+
+	/** Set Organization.
+	  * Organizational entity within tenant
+	  */
+	public void setAD_Org_ID (int AD_Org_ID);
+
+	/** Get Organization.
+	  * Organizational entity within tenant
+	  */
+	public int getAD_Org_ID();
+
+    /** Column name Created */
+    public static final String COLUMNNAME_Created = "Created";
+
+	/** Get Created.
+	  * Date this record was created
+	  */
+	public Timestamp getCreated();
+
+    /** Column name CreatedBy */
+    public static final String COLUMNNAME_CreatedBy = "CreatedBy";
+
+	/** Get Created By.
+	  * User who created this records
+	  */
+	public int getCreatedBy();
+
+    /** Column name IsActive */
+    public static final String COLUMNNAME_IsActive = "IsActive";
+
+	/** Set Active.
+	  * The record is active in the system
+	  */
+	public void setIsActive (boolean IsActive);
+
+	/** Get Active.
+	  * The record is active in the system
+	  */
+	public boolean isActive();
+
+    /** Column name Line */
+    public static final String COLUMNNAME_Line = "Line";
+
+	/** Set Line No.
+	  * Unique line for this document
+	  */
+	public void setLine (int Line);
+
+	/** Get Line No.
+	  * Unique line for this document
+	  */
+	public int getLine();
+
+    /** Column name M_AttributeInstanceLine_ID */
+    public static final String COLUMNNAME_M_AttributeInstanceLine_ID = "M_AttributeInstanceLine_ID";
+
+	/** Set Attribute Instance Values.
+	  * Selected attribute values of an attribute instance
+	  */
+	public void setM_AttributeInstanceLine_ID (int M_AttributeInstanceLine_ID);
+
+	/** Get Attribute Instance Values.
+	  * Selected attribute values of an attribute instance
+	  */
+	public int getM_AttributeInstanceLine_ID();
+
+    /** Column name M_AttributeInstanceLine_UU */
+    public static final String COLUMNNAME_M_AttributeInstanceLine_UU = "M_AttributeInstanceLine_UU";
+
+	/** Set M_AttributeInstanceLine_UU	  */
+	public void setM_AttributeInstanceLine_UU (String M_AttributeInstanceLine_UU);
+
+	/** Get M_AttributeInstanceLine_UU	  */
+	public String getM_AttributeInstanceLine_UU();
+
+    /** Column name M_AttributeInstance_UU */
+    public static final String COLUMNNAME_M_AttributeInstance_UU = "M_AttributeInstance_UU";
+
+	/** Set M_AttributeInstance_UU	  */
+	public void setM_AttributeInstance_UU (String M_AttributeInstance_UU);
+
+	/** Get M_AttributeInstance_UU	  */
+	public String getM_AttributeInstance_UU();
+
+    /** Column name M_AttributeValue_ID */
+    public static final String COLUMNNAME_M_AttributeValue_ID = "M_AttributeValue_ID";
+
+	/** Set Attribute Value.
+	  * Product Attribute Value
+	  */
+	public void setM_AttributeValue_ID (int M_AttributeValue_ID);
+
+	/** Get Attribute Value.
+	  * Product Attribute Value
+	  */
+	public int getM_AttributeValue_ID();
+
+	public org.compiere.model.I_M_AttributeValue getM_AttributeValue() throws RuntimeException;
+
+    /** Column name Updated */
+    public static final String COLUMNNAME_Updated = "Updated";
+
+	/** Get Updated.
+	  * Date this record was updated
+	  */
+	public Timestamp getUpdated();
+
+    /** Column name UpdatedBy */
+    public static final String COLUMNNAME_UpdatedBy = "UpdatedBy";
+
+	/** Get Updated By.
+	  * User who updated this records
+	  */
+	public int getUpdatedBy();
+}

--- a/org.adempiere.base/src/org/compiere/model/MAttributeInstanceLine.java
+++ b/org.adempiere.base/src/org/compiere/model/MAttributeInstanceLine.java
@@ -1,0 +1,100 @@
+/***********************************************************************
+ * This file is part of iDempiere ERP Open Source                      *
+ * http://www.idempiere.org                                            *
+ *                                                                     *
+ * Copyright (C) Contributors                                          *
+ *                                                                     *
+ * This program is free software; you can redistribute it and/or       *
+ * modify it under the terms of the GNU General Public License         *
+ * as published by the Free Software Foundation; either version 2      *
+ * of the License, or (at your option) any later version.              *
+ *                                                                     *
+ * This program is distributed in the hope that it will be useful,     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of      *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the        *
+ * GNU General Public License for more details.                        *
+ *                                                                     *
+ * You should have received a copy of the GNU General Public License   *
+ * along with this program; if not, write to the Free Software         *
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,          *
+ * MA 02110-1301, USA.                                                 *
+ **********************************************************************/
+package org.compiere.model;
+
+import java.sql.ResultSet;
+import java.util.List;
+import java.util.Properties;
+
+import org.compiere.util.Env;
+
+/**
+ * Extended model class of M_AttributeInstanceLine 
+ */
+public class MAttributeInstanceLine extends X_M_AttributeInstanceLine {
+
+	/**
+	 * generated serial id
+	 */
+	private static final long serialVersionUID = -8228055830143742344L;
+
+	/**
+	 * @param ctx
+	 * @param M_AttributeInstanceLine_ID
+	 * @param trxName
+	 */
+	public MAttributeInstanceLine(Properties ctx, int M_AttributeInstanceLine_ID, String trxName) {
+		super(ctx, M_AttributeInstanceLine_ID, trxName);
+	}
+
+	/**
+	 * @param ctx
+	 * @param M_AttributeInstanceLine_ID
+	 * @param trxName
+	 * @param virtualColumns
+	 */
+	public MAttributeInstanceLine(Properties ctx, int M_AttributeInstanceLine_ID, String trxName,
+			String... virtualColumns) {
+		super(ctx, M_AttributeInstanceLine_ID, trxName, virtualColumns);
+	}
+
+	/**
+	 * @param ctx
+	 * @param M_AttributeInstanceLine_UU
+	 * @param trxName
+	 */
+	public MAttributeInstanceLine(Properties ctx, String M_AttributeInstanceLine_UU, String trxName) {
+		super(ctx, M_AttributeInstanceLine_UU, trxName);
+	}
+
+	/**
+	 * @param ctx
+	 * @param M_AttributeInstanceLine_UU
+	 * @param trxName
+	 * @param virtualColumns
+	 */
+	public MAttributeInstanceLine(Properties ctx, String M_AttributeInstanceLine_UU, String trxName,
+			String... virtualColumns) {
+		super(ctx, M_AttributeInstanceLine_UU, trxName, virtualColumns);
+	}
+
+	/**
+	 * @param ctx
+	 * @param rs
+	 * @param trxName
+	 */
+	public MAttributeInstanceLine(Properties ctx, ResultSet rs, String trxName) {
+		super(ctx, rs, trxName);
+	}
+
+	/**
+	 * Get active MAttributeInstanceLine records of a MAttributeInstance record.
+	 * @param mai
+	 * @return list of MAttributeInstanceLine records
+	 */
+	public static List<MAttributeInstanceLine> getOfAttributeInstance(MAttributeInstance mai) {
+		Query query = new Query(Env.getCtx(), MAttributeInstanceLine.Table_Name, MAttributeInstance.COLUMNNAME_M_AttributeInstance_UU+"=?", mai.get_TrxName());
+		return query.setOnlyActiveRecords(true)
+					.setParameters(mai.getM_AttributeInstance_UU())
+					.list();
+	}
+}

--- a/org.adempiere.base/src/org/compiere/model/X_M_AttributeInstanceLine.java
+++ b/org.adempiere.base/src/org/compiere/model/X_M_AttributeInstanceLine.java
@@ -1,0 +1,217 @@
+/******************************************************************************
+ * Product: iDempiere ERP & CRM Smart Business Solution                       *
+ * Copyright (C) 1999-2012 ComPiere, Inc. All Rights Reserved.                *
+ * This program is free software, you can redistribute it and/or modify it    *
+ * under the terms version 2 of the GNU General Public License as published   *
+ * by the Free Software Foundation. This program is distributed in the hope   *
+ * that it will be useful, but WITHOUT ANY WARRANTY, without even the implied *
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.           *
+ * See the GNU General Public License for more details.                       *
+ * You should have received a copy of the GNU General Public License along    *
+ * with this program, if not, write to the Free Software Foundation, Inc.,    *
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.                     *
+ * For the text or an alternative of this public license, you may reach us    *
+ * ComPiere, Inc., 2620 Augustine Dr. #245, Santa Clara, CA 95054, USA        *
+ * or via info@compiere.org or http://www.compiere.org/license.html           *
+ *****************************************************************************/
+/** Generated Model - DO NOT CHANGE */
+package org.compiere.model;
+
+import java.sql.ResultSet;
+import java.util.Properties;
+
+/** Generated Model for M_AttributeInstanceLine
+ *  @author iDempiere (generated)
+ *  @version Release 12 - $Id$ */
+@org.adempiere.base.Model(table="M_AttributeInstanceLine")
+public class X_M_AttributeInstanceLine extends PO implements I_M_AttributeInstanceLine, I_Persistent
+{
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = 20240227L;
+
+    /** Standard Constructor */
+    public X_M_AttributeInstanceLine (Properties ctx, int M_AttributeInstanceLine_ID, String trxName)
+    {
+      super (ctx, M_AttributeInstanceLine_ID, trxName);
+      /** if (M_AttributeInstanceLine_ID == 0)
+        {
+			setLine (0);
+			setM_AttributeInstanceLine_ID (0);
+			setM_AttributeInstanceLine_UU (null);
+			setM_AttributeInstance_UU (null);
+			setM_AttributeValue_ID (0);
+        } */
+    }
+
+    /** Standard Constructor */
+    public X_M_AttributeInstanceLine (Properties ctx, int M_AttributeInstanceLine_ID, String trxName, String ... virtualColumns)
+    {
+      super (ctx, M_AttributeInstanceLine_ID, trxName, virtualColumns);
+      /** if (M_AttributeInstanceLine_ID == 0)
+        {
+			setLine (0);
+			setM_AttributeInstanceLine_ID (0);
+			setM_AttributeInstanceLine_UU (null);
+			setM_AttributeInstance_UU (null);
+			setM_AttributeValue_ID (0);
+        } */
+    }
+
+    /** Standard Constructor */
+    public X_M_AttributeInstanceLine (Properties ctx, String M_AttributeInstanceLine_UU, String trxName)
+    {
+      super (ctx, M_AttributeInstanceLine_UU, trxName);
+      /** if (M_AttributeInstanceLine_UU == null)
+        {
+			setLine (0);
+			setM_AttributeInstanceLine_ID (0);
+			setM_AttributeInstanceLine_UU (null);
+			setM_AttributeInstance_UU (null);
+			setM_AttributeValue_ID (0);
+        } */
+    }
+
+    /** Standard Constructor */
+    public X_M_AttributeInstanceLine (Properties ctx, String M_AttributeInstanceLine_UU, String trxName, String ... virtualColumns)
+    {
+      super (ctx, M_AttributeInstanceLine_UU, trxName, virtualColumns);
+      /** if (M_AttributeInstanceLine_UU == null)
+        {
+			setLine (0);
+			setM_AttributeInstanceLine_ID (0);
+			setM_AttributeInstanceLine_UU (null);
+			setM_AttributeInstance_UU (null);
+			setM_AttributeValue_ID (0);
+        } */
+    }
+
+    /** Load Constructor */
+    public X_M_AttributeInstanceLine (Properties ctx, ResultSet rs, String trxName)
+    {
+      super (ctx, rs, trxName);
+    }
+
+    /** AccessLevel
+      * @return 3 - Client - Org
+      */
+    protected int get_AccessLevel()
+    {
+      return accessLevel.intValue();
+    }
+
+    /** Load Meta Data */
+    protected POInfo initPO (Properties ctx)
+    {
+      POInfo poi = POInfo.getPOInfo (ctx, Table_ID, get_TrxName());
+      return poi;
+    }
+
+    public String toString()
+    {
+      StringBuilder sb = new StringBuilder ("X_M_AttributeInstanceLine[")
+        .append(get_ID()).append("]");
+      return sb.toString();
+    }
+
+	/** Set Line No.
+		@param Line Unique line for this document
+	*/
+	public void setLine (int Line)
+	{
+		set_Value (COLUMNNAME_Line, Integer.valueOf(Line));
+	}
+
+	/** Get Line No.
+		@return Unique line for this document
+	  */
+	public int getLine()
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_Line);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set Attribute Instance Values.
+		@param M_AttributeInstanceLine_ID Selected attribute values of an attribute instance
+	*/
+	public void setM_AttributeInstanceLine_ID (int M_AttributeInstanceLine_ID)
+	{
+		if (M_AttributeInstanceLine_ID < 1)
+			set_ValueNoCheck (COLUMNNAME_M_AttributeInstanceLine_ID, null);
+		else
+			set_ValueNoCheck (COLUMNNAME_M_AttributeInstanceLine_ID, Integer.valueOf(M_AttributeInstanceLine_ID));
+	}
+
+	/** Get Attribute Instance Values.
+		@return Selected attribute values of an attribute instance
+	  */
+	public int getM_AttributeInstanceLine_ID()
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_M_AttributeInstanceLine_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+
+	/** Set M_AttributeInstanceLine_UU.
+		@param M_AttributeInstanceLine_UU M_AttributeInstanceLine_UU
+	*/
+	public void setM_AttributeInstanceLine_UU (String M_AttributeInstanceLine_UU)
+	{
+		set_ValueNoCheck (COLUMNNAME_M_AttributeInstanceLine_UU, M_AttributeInstanceLine_UU);
+	}
+
+	/** Get M_AttributeInstanceLine_UU.
+		@return M_AttributeInstanceLine_UU	  */
+	public String getM_AttributeInstanceLine_UU()
+	{
+		return (String)get_Value(COLUMNNAME_M_AttributeInstanceLine_UU);
+	}
+
+	/** Set M_AttributeInstance_UU.
+		@param M_AttributeInstance_UU M_AttributeInstance_UU
+	*/
+	public void setM_AttributeInstance_UU (String M_AttributeInstance_UU)
+	{
+		set_ValueNoCheck (COLUMNNAME_M_AttributeInstance_UU, M_AttributeInstance_UU);
+	}
+
+	/** Get M_AttributeInstance_UU.
+		@return M_AttributeInstance_UU	  */
+	public String getM_AttributeInstance_UU()
+	{
+		return (String)get_Value(COLUMNNAME_M_AttributeInstance_UU);
+	}
+
+	public org.compiere.model.I_M_AttributeValue getM_AttributeValue() throws RuntimeException
+	{
+		return (org.compiere.model.I_M_AttributeValue)MTable.get(getCtx(), org.compiere.model.I_M_AttributeValue.Table_ID)
+			.getPO(getM_AttributeValue_ID(), get_TrxName());
+	}
+
+	/** Set Attribute Value.
+		@param M_AttributeValue_ID Product Attribute Value
+	*/
+	public void setM_AttributeValue_ID (int M_AttributeValue_ID)
+	{
+		if (M_AttributeValue_ID < 1)
+			set_ValueNoCheck (COLUMNNAME_M_AttributeValue_ID, null);
+		else
+			set_ValueNoCheck (COLUMNNAME_M_AttributeValue_ID, Integer.valueOf(M_AttributeValue_ID));
+	}
+
+	/** Get Attribute Value.
+		@return Product Attribute Value
+	  */
+	public int getM_AttributeValue_ID()
+	{
+		Integer ii = (Integer)get_Value(COLUMNNAME_M_AttributeValue_ID);
+		if (ii == null)
+			 return 0;
+		return ii.intValue();
+	}
+}

--- a/org.idempiere.test/src/org/idempiere/test/model/MAttributeInstanceLineTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/MAttributeInstanceLineTest.java
@@ -1,0 +1,132 @@
+/***********************************************************************
+ * This file is part of iDempiere ERP Open Source                      *
+ * http://www.idempiere.org                                            *
+ *                                                                     *
+ * Copyright (C) Contributors                                          *
+ *                                                                     *
+ * This program is free software; you can redistribute it and/or       *
+ * modify it under the terms of the GNU General Public License         *
+ * as published by the Free Software Foundation; either version 2      *
+ * of the License, or (at your option) any later version.              *
+ *                                                                     *
+ * This program is distributed in the hope that it will be useful,     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of      *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the        *
+ * GNU General Public License for more details.                        *
+ *                                                                     *
+ * You should have received a copy of the GNU General Public License   *
+ * along with this program; if not, write to the Free Software         *
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,          *
+ * MA 02110-1301, USA.                                                 *
+ **********************************************************************/
+package org.idempiere.test.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.compiere.model.MAttribute;
+import org.compiere.model.MAttributeInstance;
+import org.compiere.model.MAttributeInstanceLine;
+import org.compiere.model.MAttributeSet;
+import org.compiere.model.MAttributeSetInstance;
+import org.compiere.model.MAttributeValue;
+import org.compiere.model.X_M_AttributeUse;
+import org.compiere.util.Env;
+import org.idempiere.test.AbstractTestCase;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for maintenance of MAttributeInstanceLine 
+ */
+public class MAttributeInstanceLineTest extends AbstractTestCase {
+
+	public MAttributeInstanceLineTest() {
+	}
+
+	@Test
+	public void testSyncByEventHandler() {
+		MAttribute attribute = new MAttribute(Env.getCtx(), 0, null);
+		attribute.setName("MAttributeInstanceLineTest Attribute");
+		attribute.setAttributeValueType(MAttribute.ATTRIBUTEVALUETYPE_ChosenMultipleSelectionList);
+		attribute.saveEx();
+		
+		try {
+			MAttributeSet as = new MAttributeSet(Env.getCtx(), 0, getTrxName());
+			as.setName("MAttributeInstanceLineTest");
+			as.saveEx();
+			
+			MAttributeValue av1 = new MAttributeValue(Env.getCtx(), 0, getTrxName());
+			av1.setValue("C");
+			av1.setName("Cotton");
+			av1.setM_Attribute_ID(attribute.get_ID());
+			av1.saveEx();
+			
+			MAttributeValue av2 = new MAttributeValue(Env.getCtx(), 0, getTrxName());
+			av2.setValue("P");
+			av2.setName("Polyester");
+			av2.setM_Attribute_ID(attribute.get_ID());
+			av2.saveEx();
+			
+			MAttributeValue av3 = new MAttributeValue(Env.getCtx(), 0, getTrxName());
+			av3.setValue("W");
+			av3.setName("Wool");
+			av3.setM_Attribute_ID(attribute.get_ID());
+			av3.saveEx();
+			
+			X_M_AttributeUse use = new X_M_AttributeUse(Env.getCtx(), 0, getTrxName());
+			use.setM_Attribute_ID(attribute.get_ID());
+			use.setM_AttributeSet_ID(as.get_ID());
+			use.setSeqNo(10);
+			use.saveEx();
+			
+			String selectedIds = String.join(",", Integer.toString(av1.get_ID()), Integer.toString(av2.get_ID()));
+			String selectedNames = String.join(", ", av1.getName(), av2.getName());
+					
+			MAttributeSetInstance masi = new MAttributeSetInstance(Env.getCtx(), 0, getTrxName());
+			masi.setM_AttributeSet_ID(as.get_ID());
+			masi.setDescription(selectedNames);
+			masi.saveEx();
+			
+			MAttributeInstance ai = new MAttributeInstance(Env.getCtx(), attribute.get_ID(), masi.get_ID(), selectedIds, selectedNames, getTrxName());
+			ai.saveEx();
+			
+			List<MAttributeInstanceLine> lines = MAttributeInstanceLine.getOfAttributeInstance(ai);
+			assertEquals(2, lines.size(), "List<MAttributeInstanceLine> not of expected size");
+			assertEquals(av1.get_ID(), lines.get(0).getM_AttributeValue_ID(), "MAttributeInstanceLine[0] not of expected attribute value");
+			assertEquals(av2.get_ID(), lines.get(1).getM_AttributeValue_ID(), "MAttributeInstanceLine[1] not of expected attribute value");
+			
+			selectedIds = String.join(",", Integer.toString(av1.get_ID()), Integer.toString(av3.get_ID()));
+			selectedNames = String.join(", ", av1.getName(), av3.getName());
+			
+			masi.setDescription(selectedNames);
+			masi.saveEx();
+			
+			ai.setMultiSelectValueAndDisplay(selectedIds, selectedNames);
+			ai.saveEx();
+			
+			lines = MAttributeInstanceLine.getOfAttributeInstance(ai);
+			assertEquals(2, lines.size(), "List<MAttributeInstanceLine> not of expected size");
+			assertEquals(av1.get_ID(), lines.get(0).getM_AttributeValue_ID(), "MAttributeInstanceLine[0] not of expected attribute value");
+			assertEquals(av3.get_ID(), lines.get(1).getM_AttributeValue_ID(), "MAttributeInstanceLine[1] not of expected attribute value");
+			
+			selectedIds = Integer.toString(av3.get_ID());
+			selectedNames = av3.getName();
+			
+			masi.setDescription(selectedNames);
+			masi.saveEx();
+			
+			ai.setMultiSelectValueAndDisplay(selectedIds, selectedNames);
+			ai.saveEx();
+			
+			lines = MAttributeInstanceLine.getOfAttributeInstance(ai);
+			assertEquals(1, lines.size(), "List<MAttributeInstanceLine> not of expected size");
+			assertEquals(av3.get_ID(), lines.get(0).getM_AttributeValue_ID(), "MAttributeInstanceLine[0] not of expected attribute value");
+			
+			masi.deleteEx(true);
+		} finally {
+			rollback();
+			attribute.deleteEx(true);
+		}
+	}
+}


### PR DESCRIPTION
…osen fieldtypes

Add M_AttributeInstanceLine table for selected M_AttributeValue records of a M_AttributeInstance record.

https://idempiere.atlassian.net/browse/IDEMPIERE-5859

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [x] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

