### PR TITLE
IDEMPIERE-6033 Zoom for WPAttributeDialog Lot field is partially impl…

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WPAttributeDialog.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WPAttributeDialog.java
@@ -65,7 +65,6 @@ import org.compiere.model.MAttributeValue;
 import org.compiere.model.MDocType;
 import org.compiere.model.MLot;
 import org.compiere.model.MLotCtl;
-import org.compiere.model.MQuery;
 import org.compiere.model.MRole;
 import org.compiere.model.MSerNoCtl;
 import org.compiere.model.MSysConfig;
@@ -86,8 +85,6 @@ import org.zkoss.zk.ui.event.Events;
 import org.zkoss.zul.Borderlayout;
 import org.zkoss.zul.Cell;
 import org.zkoss.zul.Center;
-import org.zkoss.zul.Menuitem;
-import org.zkoss.zul.Menupopup;
 import org.zkoss.zul.North;
 import org.zkoss.zul.South;
 import org.zkoss.zul.Space;
@@ -194,9 +191,6 @@ public class WPAttributeDialog extends Window implements EventListener<Event>
 	protected Textbox fieldLotString = new Textbox();
 	protected Listbox fieldLot = new Listbox();
 	protected Button bLot = new Button(Msg.getMsg (Env.getCtx(), "New"));
-	//	Lot Popup
-	protected Menupopup 		popupMenu = new Menupopup();
-	protected Menuitem 			mZoom;
 	//	Ser No
 	protected Textbox fieldSerNo = new Textbox();
 	protected Button bSerNo = new Button(Msg.getMsg (Env.getCtx(), "New"));
@@ -463,16 +457,6 @@ public class WPAttributeDialog extends Window implements EventListener<Event>
 					LayoutUtils.addSclass("txt-btn", bLot);
 				}
 			}
-			//	Popup 
-			mZoom = new Menuitem(Msg.getMsg(Env.getCtx(), "Zoom"), ThemeManager.getThemeResource("images/Zoom16.png"));
-			if(ThemeManager.isUseFontIconForImage()) {
-				mZoom.setIconSclass("z-icon-Zoom");
-				mZoom.setImage("");
-			}
-
-			mZoom.addEventListener(Events.ON_CLICK, this);
-			popupMenu.appendChild(mZoom);
-			this.appendChild(popupMenu);
 		}	//	Lot
 
 		//	SerNo
@@ -902,11 +886,6 @@ public class WPAttributeDialog extends Window implements EventListener<Event>
 		{
 			onCancel();
 		}
-		//	Zoom M_Lot
-		else if (e.getTarget() == mZoom)
-		{
-			cmd_zoom();
-		}
 		else
 			log.log(Level.SEVERE, "not found - " + e);
 	}	//	actionPerformed
@@ -1070,22 +1049,6 @@ public class WPAttributeDialog extends Window implements EventListener<Event>
 			editor.setReadWrite(rw);
 		}	
 	}	//	cmd_newEdit
-
-	/**
-	 * 	Zoom M_Lot
-	 */
-	private void cmd_zoom()
-	{
-		int M_Lot_ID = 0;
-		ListItem pp = fieldLot.getSelectedItem();
-		if (pp != null)
-			M_Lot_ID = (Integer) pp.getValue();
-		MQuery zoomQuery = new MQuery("M_Lot");
-		zoomQuery.addRestriction("M_Lot_ID", MQuery.EQUAL, M_Lot_ID);
-		log.info(zoomQuery.toString());
-		//
-		//TODO: to port
-	}	//	cmd_zoom
 
 	/**
 	 *	Save Selection


### PR DESCRIPTION
…emented

- remove partially implemented code

https://idempiere.atlassian.net/browse/IDEMPIERE-6033

# Pull Request Checklist

- [ ] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [ ] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [ ] My code is easy to understand and review. 
- [ ] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

