### PR TITLE
IDEMPIERE-2981 Fixes to failing unit tests

### DIFF
--- a/org.adempiere.base/src/org/compiere/dbPort/Convert.java
+++ b/org.adempiere.base/src/org/compiere/dbPort/Convert.java
@@ -83,10 +83,12 @@ public abstract class Convert
 	/**	Logger	*/
 	private static final CLogger	log	= CLogger.getCLogger (Convert.class);
 	
+    private static File fileOr = null;
     private static FileOutputStream fosScriptOr = null;
-    private static Writer writerOr;
+    private static Writer writerOr = null;
+    private static File filePg = null;
     private static FileOutputStream fosScriptPg = null;
-    private static Writer writerPg;
+    private static Writer writerPg = null;
 
     /**
 	 *  Set Verbose
@@ -471,7 +473,7 @@ public abstract class Convert
 					Files.createDirectories(Paths.get(folderPg));
 				}
 				if (fosScriptOr == null) {
-					File fileOr = new File(folderOr + fileName);
+					fileOr = new File(folderOr + fileName);
 					fosScriptOr = new FileOutputStream(fileOr, true);
 					writerOr = new BufferedWriter(new OutputStreamWriter(fosScriptOr, "UTF8"));
 					writerOr.append("-- ");
@@ -488,7 +490,7 @@ public abstract class Convert
 					pgStatement = r[0];
 				}
 				if (fosScriptPg == null) {
-					File filePg = new File(folderPg + fileName);
+					filePg = new File(folderPg + fileName);
 					fosScriptPg = new FileOutputStream(filePg, true);
 					writerPg = new BufferedWriter(new OutputStreamWriter(fosScriptPg, "UTF8"));
 					writerPg.append("-- ");
@@ -686,6 +688,50 @@ public abstract class Convert
 		w.append("\n;\n\n");
 		// flush stream - teo_sarca BF [ 1894474 ]
 		w.flush();
+	}
+
+	/**
+	 * Close the files for migration scripts, used just on Tests
+	 */
+	public static void closeLogMigrationScript() {
+		try {
+			if (writerOr != null) {
+				writerOr.flush();
+				writerOr.close();
+				writerOr = null;
+			}
+			if (writerPg != null) {
+				writerPg.flush();
+				writerPg.close();
+				writerPg = null;
+			}
+			if (fosScriptOr != null) {
+				fosScriptOr.flush();
+				fosScriptOr.close();
+				fosScriptOr = null;
+			}
+			if (fosScriptPg != null) {
+				fosScriptPg.flush();
+				fosScriptPg.close();
+				fosScriptPg = null;
+			}
+			fileOr = null;
+			filePg = null;
+		} catch (IOException e) {
+			// ignore
+			e.printStackTrace();
+		}
+	}
+
+	/**
+	 * Get the name of the migration script file
+	 * @return
+	 */
+	public static String getGeneratedMigrationScriptFileName() {
+		if (filePg != null) {
+			return filePg.getName();
+		}
+		return null;
 	}
 
 }   //  Convert

--- a/org.idempiere.test/src/org/idempiere/test/base/JsonFieldTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/base/JsonFieldTest.java
@@ -6,12 +6,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.File;
 
 import org.compiere.dbPort.Convert;
+import org.compiere.model.I_AD_UserPreference;
 import org.compiere.model.MTest;
 import org.compiere.util.Env;
 import org.compiere.util.Ini;
 import org.idempiere.test.AbstractTestCase;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
+/**
+ * Tests for JSON data type
+ * Run Isolated because of migration script file management
+ */
+@Isolated
 public class JsonFieldTest extends AbstractTestCase {
 
 	/**
@@ -42,13 +49,10 @@ public class JsonFieldTest extends AbstractTestCase {
 		testPO.setJsonData(null);
 		updated = testPO.save();
 		assertTrue(updated);
-		
-		String fileName = Convert.getMigrationScriptFileName("testLogMigrationScript");
-		String folderPg = Convert.getMigrationScriptFolder("postgresql");
-		String folderOr = Convert.getMigrationScriptFolder("oracle");
-		
+
 		//Test inserting/updating with Values
 		Env.getCtx().setProperty(Ini.P_LOGMIGRATIONSCRIPT, "Y");
+		Env.setContext(Env.getCtx(), I_AD_UserPreference.COLUMNNAME_MigrationScriptComment, "IDEMPIERE-02981 JsonFieldTest");
 		testPO.setJsonData(validJsonString);
 		updated = testPO.save();
 		assertTrue(updated);
@@ -59,7 +63,10 @@ public class JsonFieldTest extends AbstractTestCase {
 		
 		Env.getCtx().setProperty(Ini.P_LOGMIGRATIONSCRIPT, "");
 
-		rollback();
+		String fileName = Convert.getGeneratedMigrationScriptFileName();
+		String folderPg = Convert.getMigrationScriptFolder("postgresql");
+		String folderOr = Convert.getMigrationScriptFolder("oracle");
+		Convert.closeLogMigrationScript();
 		File file = new File(folderPg + fileName);
 		assertTrue(file.exists(), "Not found: " + folderPg + fileName);
 		file.delete();

--- a/org.idempiere.test/src/org/idempiere/test/base/POTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/base/POTest.java
@@ -58,12 +58,16 @@ import org.compiere.util.Trx;
 import org.idempiere.test.AbstractTestCase;
 import org.idempiere.test.DictionaryIDs;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 /**
  * Tests for {@link org.compiere.model.PO} class.
  * @author Teo Sarca, SC ARHIPAC SERVICE SRL
  * @author hengsin
+ * 
+ * Run Isolated because of migration script file management
  */
+@Isolated
 public class POTest extends AbstractTestCase
 {
 	public static class MyTestPO extends MTest
@@ -512,9 +516,6 @@ public class POTest extends AbstractTestCase
 		Env.getCtx().setProperty(Ini.P_LOGMIGRATIONSCRIPT, "Y");
 		Env.setContext(Env.getCtx(), I_AD_UserPreference.COLUMNNAME_MigrationScriptComment, "testLogMigrationScript");
 		assertTrue(Env.isLogMigrationScript(MProduct.Table_Name), "Unexpected Log Migration Script Y/N value for MProduct");
-		String fileName = Convert.getMigrationScriptFileName("testLogMigrationScript");
-		String folderPg = Convert.getMigrationScriptFolder("postgresql");
-		String folderOr = Convert.getMigrationScriptFolder("oracle");
 		
 		MProductCategory lotLevel = new MProductCategory(Env.getCtx(), 0, null);
 		lotLevel.setName("testLogMigrationScript");
@@ -548,6 +549,10 @@ public class POTest extends AbstractTestCase
 			lotLevel.deleteEx(true);
 		}
 		
+		String fileName = Convert.getGeneratedMigrationScriptFileName();
+		String folderPg = Convert.getMigrationScriptFolder("postgresql");
+		String folderOr = Convert.getMigrationScriptFolder("oracle");
+		Convert.closeLogMigrationScript();
 		File file = new File(folderPg + fileName);
 		assertTrue(file.exists(), "Not found: " + folderPg + fileName);
 		file.delete();


### PR DESCRIPTION
Hi @hengsin - the last run on iDempiereDaily showed one failure:
https://jenkins.idempiere.org/job/iDempiereDaily/1067/console
```
16:36:10 Failures: 
16:36:10   POTest.testLogMigrationScript:552 Not found: ../migration/iD12/postgresql/202403071034_PlaceholderForTicket.sql ==> expected: <true> but was: <false>
```

I added some methods in Convert to make it more usable in unit tests in case we keep using that in future.
