### PR TITLE
IDEMPIERE-6054 Create Lines From checkboxes behave erratically

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
@@ -372,6 +372,14 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 				prepareTable();
 				processQueryValue();
 			}	
+			
+			if (!isLookup() && p_multipleSelection && hasEditable) 
+			{
+				//use only checkmark for selection of row
+				//with the default of select by clicking on any cell, the text selection mouse gesture will de-select a selected row
+				//note that this also disable the selection of text within the listbox
+				contentPanel.setNonselectableTags("*");
+			}
 		}
 		
 		if (ClientInfo.isMobile()) {

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoPanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoPanel.java
@@ -2273,7 +2273,7 @@ public abstract class InfoPanel extends Window implements EventListener<Event>, 
         	if (event.getClass().equals(MouseEvent.class)){
         		return;
         	}
-        	if (contentPanel.isMultiple() && m_lastSelectedIndex >= 0) {
+        	if (contentPanel.isMultiple() && m_lastSelectedIndex >= 0 && isLookup()) {
 				
         		contentPanel.setSelectedIndex(m_lastSelectedIndex);
 				
@@ -2298,9 +2298,13 @@ public abstract class InfoPanel extends Window implements EventListener<Event>, 
 					}
 				}
         	}
-        	onDoubleClick();
-        	contentPanel.repaint();
-        	m_lastSelectedIndex = -1;
+        	
+        	if (isLookup() || hasZoom()) 
+        	{
+	        	onDoubleClick();
+	        	contentPanel.repaint();
+	        	m_lastSelectedIndex = -1;
+        	}
         }
         else if (event.getTarget().equals(confirmPanel.getButton(ConfirmPanel.A_REFRESH)))
         {


### PR DESCRIPTION
- Fix issue with double click and drag to select text mouse gesture.

https://idempiere.atlassian.net/browse/IDEMPIERE-6054

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

