### PR TITLE
IDEMPIERE-5503 Product Costs > Cost Movement > Field AMOUNT has incon…

### DIFF
--- a/org.adempiere.base/src/org/compiere/acct/DocLine.java
+++ b/org.adempiere.base/src/org/compiere/acct/DocLine.java
@@ -771,7 +771,7 @@ public class DocLine
 			MCostDetail cd = MCostDetail.get (Env.getCtx(), whereClause, 
 					get_ID(), getM_AttributeSetInstance_ID(), as.getC_AcctSchema_ID(), p_po.get_TrxName());
 			if (cd != null)
-				return cd.getAmt();
+				return cd.getAmt().abs();
 		}
 		return getProductCosts(as, AD_Org_ID, zeroCostsOK);
 	}   //  getProductCosts

--- a/org.adempiere.base/src/org/compiere/acct/DocLine.java
+++ b/org.adempiere.base/src/org/compiere/acct/DocLine.java
@@ -771,7 +771,14 @@ public class DocLine
 			MCostDetail cd = MCostDetail.get (Env.getCtx(), whereClause, 
 					get_ID(), getM_AttributeSetInstance_ID(), as.getC_AcctSchema_ID(), p_po.get_TrxName());
 			if (cd != null)
-				return cd.getAmt().abs();
+			{
+				BigDecimal amt = cd.getAmt();
+				BigDecimal pcost = getProductCosts(as, AD_Org_ID, zeroCostsOK);
+				if (amt.signum() != 0 && pcost.signum() != 0 && amt.signum() != pcost.signum())
+					return amt.negate();
+				else
+					return amt;
+			}
 		}
 		return getProductCosts(as, AD_Org_ID, zeroCostsOK);
 	}   //  getProductCosts


### PR DESCRIPTION
…sistent +/- signs

https://idempiere.atlassian.net/browse/IDEMPIERE-5503

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [x] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

