### PR TITLE
IDEMPIERE-6085 HTMLExtension doesn't handle HTML_REPORT_THEME that st…

### DIFF
--- a/org.adempiere.base/src/org/compiere/print/IHTMLExtension.java
+++ b/org.adempiere.base/src/org/compiere/print/IHTMLExtension.java
@@ -24,17 +24,20 @@ import org.apache.ecs.xhtml.body;
 public interface IHTMLExtension {
 
 	/**
-	 * @return css class prefix for report element
+	 * Get CSS class prefix for HTML report element
+	 * @return CSS class prefix for HTML report element
 	 */
 	public String getClassPrefix();
 	
 	/**
-	 * @return url to report css
+	 * Get URL to report CSS
+	 * @return URL to report CSS
 	 */
 	public String getStyleURL();
 	
 	/**
-	 * @return url to report js
+	 * Get URL to report javascript
+	 * @return URL to report javascript
 	 */
 	public String getScriptURL();
 	
@@ -61,11 +64,13 @@ public interface IHTMLExtension {
 	public void setWebAttribute (body reportBody);
 	
 	/**
-	 * @return absolute path to css style file
+	 * Get absolute local file path to CSS file (typically for embedding the file content to HTML report)
+	 * @return absolute local file path to CSS file
 	 */
 	public String getFullPathStyle ();
 
 	/**
+	 * Get one or more links (&lt;link ... &gt;) to web font
 	 * @return one or more links for web font
 	 */
 	String getWebFontLinks();

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/report/HTMLExtension.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/report/HTMLExtension.java
@@ -65,14 +65,14 @@ public class HTMLExtension implements IHTMLExtension {
 
 		String theme = MSysConfig.getValue(MSysConfig.HTML_REPORT_THEME, "/", Env.getAD_Client_ID(Env.getCtx()));
 
-		if (! theme.startsWith("/") && !theme.startsWith("~./"))
+		if (!theme.startsWith("/") && !theme.startsWith(ThemeManager.ZK_URL_PREFIX_FOR_CLASSPATH_RESOURCE))
 			theme = "/" + theme;
 		if (! theme.endsWith("/"))
 			theme = theme + "/";
 
 		this.classPrefix = classPrefix;
 		this.componentId = componentId;
-		if (theme.startsWith("~./")) {
+		if (theme.startsWith(ThemeManager.ZK_URL_PREFIX_FOR_CLASSPATH_RESOURCE)) {
 			if (Executions.getCurrent() != null) {
 				this.styleURL = Executions.encodeURL(theme + "css/report.css");
 			}
@@ -197,11 +197,15 @@ public class HTMLExtension implements IHTMLExtension {
 	@Override
 	public String getFullPathStyle() {
 		String theme = MSysConfig.getValue(MSysConfig.HTML_REPORT_THEME, "/", Env.getAD_Client_ID(Env.getCtx()));
-		if (! theme.startsWith("/"))
+		if (!theme.startsWith("/") && !theme.startsWith(ThemeManager.ZK_URL_PREFIX_FOR_CLASSPATH_RESOURCE))
 			theme = "/" + theme;
-		if (! theme.endsWith("/"))
+		if (!theme.endsWith("/"))
 			theme = theme + "/";
 		String resFile = theme + "css/report.css";
+		
+		// translate ~./ url to classpath url
+		if (theme.startsWith(ThemeManager.ZK_URL_PREFIX_FOR_CLASSPATH_RESOURCE))
+			resFile = ThemeManager.toClassPathResourcePath(resFile);
 		
 		URL urlFile = this.getClass().getResource(resFile);
 		if (urlFile == null) {


### PR DESCRIPTION
…arts with "~./"

https://idempiere.atlassian.net/browse/IDEMPIERE-6085

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

