### PR TITLE
IDEMPIERE-6087 Users cannot delete their own User Queries

### DIFF
--- a/migration/iD11/oracle/202404041759_IDEMPIERE-6087.sql
+++ b/migration/iD11/oracle/202404041759_IDEMPIERE-6087.sql
@@ -1,0 +1,34 @@
+-- IDEMPIERE-6087 Users cannot delete their own User Queries
+SELECT register_migration_script('202404041759_IDEMPIERE-6087.sql') FROM dual;
+
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Apr 4, 2024, 5:59:29 PM CEST
+UPDATE AD_Tab SET WhereClause='(''@#ShowAdvanced:N@''=''Y'' OR AD_User_ID=@#AD_User_ID@)', OrderByClause='AD_UserQuery.Name', ReadOnlyLogic=NULL,Updated=TO_TIMESTAMP('2024-04-04 17:59:29','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Tab_ID=200275
+;
+
+-- Apr 4, 2024, 6:00:09 PM CEST
+UPDATE AD_Field SET ReadOnlyLogic='@#ShowAdvanced@=N',Updated=TO_TIMESTAMP('2024-04-04 18:00:09','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206303
+;
+
+-- Apr 4, 2024, 6:00:13 PM CEST
+UPDATE AD_Field SET ReadOnlyLogic='@#ShowAdvanced@=N',Updated=TO_TIMESTAMP('2024-04-04 18:00:13','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206309
+;
+
+-- Apr 4, 2024, 6:00:17 PM CEST
+UPDATE AD_Field SET ReadOnlyLogic='@#ShowAdvanced@=N',Updated=TO_TIMESTAMP('2024-04-04 18:00:17','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206308
+;
+
+-- Apr 4, 2024, 6:00:20 PM CEST
+UPDATE AD_Field SET ReadOnlyLogic='@#ShowAdvanced@=N',Updated=TO_TIMESTAMP('2024-04-04 18:00:20','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206306
+;
+
+-- Apr 4, 2024, 6:00:26 PM CEST
+UPDATE AD_Field SET ReadOnlyLogic='@#ShowAdvanced@=N',Updated=TO_TIMESTAMP('2024-04-04 18:00:26','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206304
+;
+
+-- Apr 4, 2024, 6:00:35 PM CEST
+UPDATE AD_Field SET IsAdvancedField='Y',Updated=TO_TIMESTAMP('2024-04-04 18:00:35','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206305
+;
+

--- a/migration/iD11/postgresql/202404041759_IDEMPIERE-6087.sql
+++ b/migration/iD11/postgresql/202404041759_IDEMPIERE-6087.sql
@@ -1,0 +1,31 @@
+-- IDEMPIERE-6087 Users cannot delete their own User Queries
+SELECT register_migration_script('202404041759_IDEMPIERE-6087.sql') FROM dual;
+
+-- Apr 4, 2024, 5:59:29 PM CEST
+UPDATE AD_Tab SET WhereClause='(''@#ShowAdvanced:N@''=''Y'' OR AD_User_ID=@#AD_User_ID@)', OrderByClause='AD_UserQuery.Name', ReadOnlyLogic=NULL,Updated=TO_TIMESTAMP('2024-04-04 17:59:29','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Tab_ID=200275
+;
+
+-- Apr 4, 2024, 6:00:09 PM CEST
+UPDATE AD_Field SET ReadOnlyLogic='@#ShowAdvanced@=N',Updated=TO_TIMESTAMP('2024-04-04 18:00:09','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206303
+;
+
+-- Apr 4, 2024, 6:00:13 PM CEST
+UPDATE AD_Field SET ReadOnlyLogic='@#ShowAdvanced@=N',Updated=TO_TIMESTAMP('2024-04-04 18:00:13','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206309
+;
+
+-- Apr 4, 2024, 6:00:17 PM CEST
+UPDATE AD_Field SET ReadOnlyLogic='@#ShowAdvanced@=N',Updated=TO_TIMESTAMP('2024-04-04 18:00:17','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206308
+;
+
+-- Apr 4, 2024, 6:00:20 PM CEST
+UPDATE AD_Field SET ReadOnlyLogic='@#ShowAdvanced@=N',Updated=TO_TIMESTAMP('2024-04-04 18:00:20','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206306
+;
+
+-- Apr 4, 2024, 6:00:26 PM CEST
+UPDATE AD_Field SET ReadOnlyLogic='@#ShowAdvanced@=N',Updated=TO_TIMESTAMP('2024-04-04 18:00:26','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206304
+;
+
+-- Apr 4, 2024, 6:00:36 PM CEST
+UPDATE AD_Field SET IsAdvancedField='Y',Updated=TO_TIMESTAMP('2024-04-04 18:00:35','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206305
+;
+

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/FindWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/FindWindow.java
@@ -766,7 +766,7 @@ public class FindWindow extends Window implements EventListener<Event>, ValueCha
         tabPanel.setStyle("height: 100%; width: 100%");
         tabPanel.appendChild(winAdvanced);
         tabPanel.setId("advancedSearch");
-        winMain.addTab(tabPanel, Msg.getMsg(Env.getCtx(), "Advanced").replaceAll("&", ""), false, false);
+        winMain.addTab(tabPanel, Msg.getMsg(Env.getCtx(), "Advanced"), false, false);
         initSimple();
         initAdvanced();
 
@@ -2053,11 +2053,13 @@ public class FindWindow extends Window implements EventListener<Event>, ValueCha
 
     	String code = userQuery.getCode();
     	if (code.startsWith(MColumn.VIRTUAL_UI_COLUMN_PREFIX)) {
+			winMain.getComponent().getTabpanel(1) .getLinkedTab().setLabel(Msg.getMsg(Env.getCtx(), "SQL"));
 			m_whereUserQuery = "(" + code.substring(code.indexOf("=")+1, code.length()) + ")";
 			if (log.isLoggable(Level.INFO))
 				log.log(Level.INFO, m_whereUserQuery);
 			hideAdvanced();
     	} else {
+			winMain.getComponent().getTabpanel(1) .getLinkedTab().setLabel(Msg.getMsg(Env.getCtx(), "Advanced"));
         	String[] segments = code.split(Pattern.quote(SEGMENT_SEPARATOR));
 
             List<?> rowList = advancedPanel.getChildren();


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-6087

With these changes the non-advanced users are able to delete or make default their assigned queries.

Advanced users still can do anything.

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
