### PR TITLE
IDEMPIERE-6095 Organization window: The lookup drop down inside the w…

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/TreeSearchPanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/TreeSearchPanel.java
@@ -23,7 +23,6 @@ import java.util.TreeMap;
 
 import org.adempiere.webui.ClientInfo;
 import org.adempiere.webui.adwindow.ADTreePanel;
-import org.adempiere.webui.apps.AEnv;
 import org.adempiere.webui.component.AutoComplete;
 import org.adempiere.webui.component.Label;
 import org.adempiere.webui.component.Panel;
@@ -182,13 +181,12 @@ public class TreeSearchPanel extends Panel implements EventListener<Event>, Tree
         		}				
 			}
 		});
+
+        ZKUpdateUtil.setHflex(cmbSearch, "1");
+        ZKUpdateUtil.setHflex(lblSearch, "0");
         
         addEventListener(ON_COMBO_SELECT_ECHO_EVENT, this);
         addEventListener(ON_POST_SELECT_TREEITEM_EVENT, this);
-        if (AEnv.isInternetExplorer())
-        {
-        	ZKUpdateUtil.setWidth(cmbSearch, "200px");
-        }
 
         layout.appendChild(lblSearch);
         layout.appendChild(cmbSearch);


### PR DESCRIPTION
…est tree panel doesn't resize when you resize the tree panel

https://idempiere.atlassian.net/browse/IDEMPIERE-6095

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

