### PR TITLE
IDEMPIERE-6102 Performance: avoid SQL on AD_TreeNode when the table doesn't have a custom tree

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MTable.java
+++ b/org.adempiere.base/src/org/compiere/model/MTable.java
@@ -67,7 +67,7 @@ public class MTable extends X_AD_Table implements ImmutablePOSupport
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = -167824144142429242L;
+	private static final long serialVersionUID = 6774131577483620665L;
 
 	public final static int MAX_OFFICIAL_ID = 999999;
 
@@ -1087,6 +1087,20 @@ public class MTable extends X_AD_Table implements ImmutablePOSupport
 			indexName = new StringBuilder().append(PO.getUUIDColumnName(tableName).substring(0, AdempiereDatabase.MAX_OBJECT_NAME_LENGTH - 5)).append("uuidx");
 
 		return indexName.toString();
+	}
+
+	private Boolean hasCustomTree = null;
+
+	/**
+	 * If the table has a custom tree defined
+	 * @return
+	 */
+	public boolean hasCustomTree() {
+		if (hasCustomTree == null) {
+			int exists = DB.getSQLValueEx(get_TrxName(), "SELECT 1 FROM AD_Tree WHERE TreeType=? AND AD_Table_ID=? AND IsActive='Y'", MTree_Base.TREETYPE_CustomTable, getAD_Table_ID());
+			hasCustomTree = Boolean.valueOf(exists == 1);
+		}
+		return hasCustomTree.booleanValue();
 	}
 
 }	//	MTable

--- a/org.adempiere.base/src/org/compiere/model/PO.java
+++ b/org.adempiere.base/src/org/compiere/model/PO.java
@@ -2649,10 +2649,10 @@ public abstract class PO
 
 			// table with potential tree
 			if (get_ColumnIndex("IsSummary") >= 0) {
-				if (newRecord)
+				if (newRecord && getTable().hasCustomTree())
 					insert_Tree(MTree_Base.TREETYPE_CustomTable);
 				int idxValue = get_ColumnIndex("Value");
-				if (newRecord || (idxValue >= 0 && is_ValueChanged(idxValue)))
+				if (getTable().hasCustomTree() && (newRecord || (idxValue >= 0 && is_ValueChanged(idxValue))))
 					update_Tree(MTree_Base.TREETYPE_CustomTable);
 			}
 		}
@@ -2755,6 +2755,14 @@ public abstract class PO
 		
 		return success;
 	}	//	saveFinish
+
+	/**
+	 * Get the MTable object associated to this PO
+	 * @return MTable
+	 */
+	private MTable getTable() {
+		return MTable.get(getCtx(), get_TableName());
+	}
 
 	/**
 	 *  Update or insert new record.<br/>
@@ -4102,7 +4110,7 @@ public abstract class PO
 			{
 				//
 				deleteTranslations(localTrxName);
-				if (get_ColumnIndex("IsSummary") >= 0) {
+				if (get_ColumnIndex("IsSummary") >= 0 && getTable().hasCustomTree()) {
 					delete_Tree(MTree_Base.TREETYPE_CustomTable);
 				}
 


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-6102

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
