### PR TITLE
IDEMPIERE-6112 New API to MSession to temporary disable update loggin…

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MSession.java
+++ b/org.adempiere.base/src/org/compiere/model/MSession.java
@@ -20,6 +20,8 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.sql.ResultSet;
 import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
 import org.compiere.Adempiere;
@@ -439,6 +441,35 @@ public class MSession extends X_AD_Session implements ImmutablePOSupport
 
 		makeImmutable();
 		return this;
+	}
+	
+	/** Set of table name to disable capture of update change log */
+	private Set<String> skipChangeLogForUpdateSet = ConcurrentHashMap.newKeySet();
+
+	/**
+	 * Add session flag to disable the capture of update change log for a table
+	 * @param tableName table name, case insensitive
+	 */
+	public void addSkipChangeLogForUpdate(String tableName) {
+		skipChangeLogForUpdateSet.add(tableName.toUpperCase());
+	}
+	
+	/**
+	 * Remove the session flag that disable the capture of update change log for a table.<br/>
+	 * After removal of the session flag, the logging decision is back to what have been configured at AD_Table and AD_Column level. 
+	 * @param tableName table name, case insensitive
+	 */
+	public void removeSkipChangeLogForUpdate(String tableName) {
+		skipChangeLogForUpdateSet.remove(tableName.toUpperCase());
+	}
+	
+	/**
+	 * Is skip the capture of update change log for this session
+	 * @param tableName table name, case insensitive
+	 * @return true if it is to skip the capture of update change log for this session
+	 */
+	public boolean isSkipChangeLogForUpdate(String tableName) {
+		return skipChangeLogForUpdateSet.contains(tableName.toUpperCase());
 	}
 }	//	MSession
 

--- a/org.adempiere.base/src/org/compiere/model/PO.java
+++ b/org.adempiere.base/src/org/compiere/model/PO.java
@@ -3107,6 +3107,7 @@ public abstract class PO
 				&& !p_info.isEncrypted(i)		//	not encrypted
 				&& !p_info.isVirtualColumn(i)	//	no virtual column
 				&& !"Password".equals(columnName)
+				&& !session.isSkipChangeLogForUpdate(get_TableName())
 				)
 			{
 				Object oldV = m_oldValues[i];


### PR DESCRIPTION
…g of a table for the current MSession

https://idempiere.atlassian.net/browse/IDEMPIERE-6112

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [x] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

