### PR TITLE
IDEMPIERE-6152 - Fix error when opening an Info Window with subquery on same table as main query

### DIFF
--- a/migration/iD12/oracle/202404261129_IDEMPIERE-6129.sql
+++ b/migration/iD12/oracle/202404261129_IDEMPIERE-6129.sql
@@ -1,0 +1,4 @@
+-- IDEMPIERE-6129
+SELECT register_migration_script('202404261129_IDEMPIERE-6129.sql') FROM dual;
+
+ALTER TABLE t_selection_infowindow MODIFY value_string VARCHAR2(4000 CHAR);

--- a/migration/iD12/postgresql/202404261129_IDEMPIERE-6129.sql
+++ b/migration/iD12/postgresql/202404261129_IDEMPIERE-6129.sql
@@ -1,0 +1,4 @@
+-- IDEMPIERE-6129
+SELECT register_migration_script('202404261129_IDEMPIERE-6129.sql') FROM dual;
+
+ALTER TABLE t_selection_infowindow ALTER COLUMN value_string TYPE VARCHAR(4000);

--- a/org.adempiere.base/src/org/compiere/model/MLookupFactory.java
+++ b/org.adempiere.base/src/org/compiere/model/MLookupFactory.java
@@ -1024,9 +1024,9 @@ public class MLookupFactory
 		//
 		StringBuilder embedSQL = new StringBuilder("SELECT ");
 
-		StringBuilder displayColumn = getDisplayColumn(language, TableName, list, BaseTable);
+		StringBuilder displayColumn = getDisplayColumn(language, "a", list, BaseTable);
 		embedSQL.append(displayColumn.toString());
-		embedSQL.append(" FROM ").append(TableName);
+		embedSQL.append(" FROM ").append(TableName).append(" a");
 		//  Translation
 		if (   isTranslated && !Env.isBaseLanguage(language, TableName)
 			&& !(TableName+"_Trl").equalsIgnoreCase(BaseTable))  // IDEMPIERE-1070
@@ -1044,7 +1044,7 @@ public class MLookupFactory
 		} else {
 			embedSQL.append(BaseColumn);
 		}
-		embedSQL.append("=").append(TableName).append(".").append(ColumnName);
+		embedSQL.append("=").append("a").append(".").append(ColumnName);
 		//
 		return embedSQL.toString();
 	}	//  getLookup_TableDirEmbed


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-6152

* Adjustment for the use of aliases in the MLookupFactory class.

# Pull Request Checklist

- [ ] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [ ] My code follows the best practices of this project
- [ ] I have performed a self-review of my own code
- [ ] My code is easy to understand and review. 
- [ ] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [ ] My changes generate no new warnings
### Tests
- [ ] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

