### PR TITLE
IDEMPIERE-6165 + IDEMPIERE-6168 More problems with jasper setting filename

### DIFF
--- a/org.adempiere.base/src/org/compiere/print/ServerReportCtl.java
+++ b/org.adempiere.base/src/org/compiere/print/ServerReportCtl.java
@@ -107,7 +107,10 @@ public class ServerReportCtl {
 			// ==============================
 			if(format.getJasperProcess_ID() > 0)	
 			{
-				boolean result = runJasperProcess(Record_ID, re, true, printerName, pi);
+				int jasperRecordId = Record_ID;
+				if (re.getPrintInfo() != null && re.getPrintInfo().getRecord_ID() > 0)
+					jasperRecordId = re.getPrintInfo().getRecord_ID();
+				boolean result = runJasperProcess(jasperRecordId, re, true, printerName, pi);
 				return(result);
 			}
 			else

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/JasperPrintRenderer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/JasperPrintRenderer.java
@@ -121,7 +121,7 @@ public class JasperPrintRenderer {
 		mediaSuppliers.put(toMediaType(Medias.PDF_MIME_TYPE, Medias.PDF_FILE_EXT), () -> {
 			try {
 				createPDF();
-				return new AMedia(makePrefix(title)+"."+Medias.PDF_FILE_EXT, Medias.PDF_FILE_EXT, Medias.PDF_MIME_TYPE, pdfFile, true);			
+				return new AMedia(pdfFile.getName(), Medias.PDF_FILE_EXT, Medias.PDF_MIME_TYPE, pdfFile, true);			
 			} catch (Exception e) {
 				if (e instanceof RuntimeException)
 					throw (RuntimeException)e;

--- a/org.idempiere.test/src/org/idempiere/test/base/ReportTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/base/ReportTest.java
@@ -31,6 +31,7 @@ import java.io.File;
 import org.compiere.model.MOrder;
 import org.compiere.model.MPInstance;
 import org.compiere.model.MProcess;
+import org.compiere.model.SystemIDs;
 import org.compiere.process.ProcessInfo;
 import org.compiere.process.ServerProcessCtl;
 import org.compiere.util.Env;
@@ -45,14 +46,12 @@ public class ReportTest extends AbstractTestCase {
 	public ReportTest() {
 	}
 
-	private static final int Order_Print_Process = 110;
-
 	/**
 	 * https://idempiere.atlassian.net/browse/IDEMPIERE-6165
 	 */
 	@Test
 	public void testPDFFileName() {
-		MProcess orderReport = MProcess.get(Env.getCtx(), Order_Print_Process);
+		MProcess orderReport = MProcess.get(Env.getCtx(), SystemIDs.PROCESS_RPT_C_ORDER);
 		MOrder order = new MOrder(Env.getCtx(),  108, getTrxName()); // Garden Order 60000
 
 		String fileName = order.getDocumentNo() + ".pdf";


### PR DESCRIPTION
[IDEMPIERE-6165](https://idempiere.atlassian.net/browse/IDEMPIERE-6165) + [IDEMPIERE-6168](https://idempiere.atlassian.net/browse/IDEMPIERE-6168)

- the test case is failing for orders with jasper print format
- the downloadable file name for jasper is wrong in zk when using FileNamePattern

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works


[IDEMPIERE-6165]: https://idempiere.atlassian.net/browse/IDEMPIERE-6165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IDEMPIERE-6168]: https://idempiere.atlassian.net/browse/IDEMPIERE-6168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ