### PR TITLE
IDEMPIERE-6172 Open from a highlighted window, DateRangePicker popup …

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/DateRangeButton.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/DateRangeButton.java
@@ -28,10 +28,12 @@ import java.util.Properties;
 
 import org.adempiere.webui.LayoutUtils;
 import org.adempiere.webui.component.ToolBarButton;
+import org.adempiere.webui.component.Window;
 import org.adempiere.webui.editor.WDateEditor;
 import org.adempiere.webui.editor.WEditor;
 import org.adempiere.webui.theme.ThemeManager;
 import org.compiere.util.Env;
+import org.zkoss.zk.ui.Component;
 import org.zkoss.zk.ui.event.Events;
 
 /**
@@ -74,9 +76,24 @@ public class DateRangeButton extends ToolBarButton implements WEditor.DynamicDis
 			setImage(ThemeManager.getThemeResource(IMAGES_CONTEXT_HISTORY_PNG));
 		
 		DateRangePicker popup = new DateRangePicker(editor, editor2);
-		this.setTooltip(popup);
 		this.addEventListener(Events.ON_CLICK, event -> {
-			popup.setPage(this.getPage());
+			Window window = null;
+			Component component = this.getParent();
+			while(component != null) {
+				if (component instanceof Window w) {
+					window = w;
+					break;
+				} else {
+					component = component.getParent();
+				}
+			}
+			// Popup must be a child of highlighted parent, otherwise combobox wouldn't work
+			// https://tracker.zkoss.org/browse/ZK-5740
+			if (window != null && "highlighted".equals(window.getMode())) {
+				window.appendChild(popup);
+			} else {
+				popup.setPage(this.getPage());
+			}
 			popup.open(this, "after_center");
 			LayoutUtils.autoDetachOnClose(popup);
 		});


### PR DESCRIPTION
…will auto close when selecting an item in dropdown list

- Implement workaround for highlighted+popup+combobox

https://idempiere.atlassian.net/browse/IDEMPIERE-6172

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

