### PR TITLE
IDEMPIERE-4087 - Set isDisplayed='N' by default for virtual search co…

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MField.java
+++ b/org.adempiere.base/src/org/compiere/model/MField.java
@@ -229,6 +229,15 @@ public class MField extends X_AD_Field implements ImmutablePOSupport
 				setIsToolbarButton(null);
 		}
 		
+		//If the column is a virtual search column - set displayed to false 
+		if (isDisplayed()) {
+			MColumn column = (MColumn) getAD_Column();
+			if (column.isVirtualSearchColumn()) {
+				setIsDisplayed(false);
+				setIsDisplayedGrid(false);
+			}
+		}
+		
 		// Validate read only, display and mandatory logic expression
 		if (newRecord || is_ValueChanged(COLUMNNAME_ReadOnlyLogic)) {
 			if (isActive() && !Util.isEmpty(getReadOnlyLogic(), true) && !getReadOnlyLogic().startsWith(MColumn.VIRTUAL_UI_COLUMN_PREFIX)) {


### PR DESCRIPTION
…lumns in field

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works

