### PR TITLE
IDEMPIERE-6194 2Pack must ignore the SIMILAR TO preference from user

### DIFF
--- a/org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java
+++ b/org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java
@@ -171,11 +171,16 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 		return retValue;
 	}
 	
+	/**
+	 * Convert LIKE to SIMILAR TO depending on the user preference P|IsUseSimilarTo - applies just to SELECT queries
+	 * @param statement
+	 * @return
+	 */
 	private String convertSimilarTo(String statement) {
 		String retValue = statement;
 		boolean useSimilarTo = isUseSimilarTo();
-		if (useSimilarTo) {
-			String replacement = "SIMILAR TO";
+		if (useSimilarTo && statement.matches("(?i)^\\s*SELECT\\b.*")) {
+			final String replacement = "SIMILAR TO";
 			try {
 				Matcher m = likePattern.matcher(retValue);
 				retValue = m.replaceAll(replacement);
@@ -188,6 +193,10 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 		return retValue;
 	}
 
+	/**
+	 * True if the user preference IsUseSimilarTo is set to Y
+	 * @return
+	 */
 	private boolean isUseSimilarTo() {
 		return "Y".equals(Env.getContext(Env.getCtx(), "P|IsUseSimilarTo"));
 	}


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-6194

- make the SIMILAR TO conversion work just for SELECT queries

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
