### PR TITLE
IDEMPIERE-6214 PackIn AD_TableIndex can fail if the index exists previously without columns

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MTableIndex.java
+++ b/org.adempiere.base/src/org/compiere/model/MTableIndex.java
@@ -104,7 +104,6 @@ public class MTableIndex extends X_AD_TableIndex {
 	public MTableIndex(Properties ctx, ResultSet rs, String trxName)
 	{
 		super(ctx, rs, trxName);
-		m_ddl = createDDL();
 	}
 	
 	/**


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-6214

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
