### PR TITLE
IDEMPIERE-6248: SysConfig to avoid cutting log

### DIFF
--- a/migration/iD11/oracle/202409231820_IDEMPIERE-6248.sql
+++ b/migration/iD11/oracle/202409231820_IDEMPIERE-6248.sql
@@ -1,0 +1,10 @@
+-- IDEMPIERE-6248
+SELECT register_migration_script('202409231820_IDEMPIERE-6248.sql') FROM dual;
+
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Sep 23, 2024, 6:20:30 PM CEST
+INSERT INTO AD_SysConfig (AD_SysConfig_ID,AD_Client_ID,AD_Org_ID,Created,Updated,CreatedBy,UpdatedBy,IsActive,Name,Value,Description,EntityType,ConfigurationLevel,AD_SysConfig_UU) VALUES (200250,0,0,TO_TIMESTAMP('2024-09-23 18:20:29','YYYY-MM-DD HH24:MI:SS'),TO_TIMESTAMP('2024-09-23 18:20:29','YYYY-MM-DD HH24:MI:SS'),10,10,'Y','FULL_EXCEPTION_TRACE_IN_LOG','N','If set to Y, the stack trace is not cut in the log (see https://idempiere.atlassian.net/browse/IDEMPIERE-6248)','D','S','8308ac18-d0a6-479f-ab59-7edd0bcb0b54')
+;
+

--- a/migration/iD11/postgresql/202409231820_IDEMPIERE-6248.sql
+++ b/migration/iD11/postgresql/202409231820_IDEMPIERE-6248.sql
@@ -1,0 +1,7 @@
+-- IDEMPIERE-6248
+SELECT register_migration_script('202409231820_IDEMPIERE-6248.sql') FROM dual;
+
+-- Sep 23, 2024, 6:20:30 PM CEST
+INSERT INTO AD_SysConfig (AD_SysConfig_ID,AD_Client_ID,AD_Org_ID,Created,Updated,CreatedBy,UpdatedBy,IsActive,Name,Value,Description,EntityType,ConfigurationLevel,AD_SysConfig_UU) VALUES (200250,0,0,TO_TIMESTAMP('2024-09-23 18:20:29','YYYY-MM-DD HH24:MI:SS'),TO_TIMESTAMP('2024-09-23 18:20:29','YYYY-MM-DD HH24:MI:SS'),10,10,'Y','FULL_EXCEPTION_TRACE_IN_LOG','N','If set to Y, the stack trace is not cut in the log (see https://idempiere.atlassian.net/browse/IDEMPIERE-6248)','D','S','8308ac18-d0a6-479f-ab59-7edd0bcb0b54')
+;
+

--- a/org.adempiere.base/src/org/compiere/model/MSysConfig.java
+++ b/org.adempiere.base/src/org/compiere/model/MSysConfig.java
@@ -120,6 +120,7 @@ public class MSysConfig extends X_AD_SysConfig
     public static final String FORM_SQL_QUERY_LOG_ISSUE = "FORM_SQL_QUERY_LOG_ISSUE";
     public static final String FORM_SQL_QUERY_MAX_RECORDS = "FORM_SQL_QUERY_MAX_RECORDS";
     public static final String FORM_SQL_QUERY_TIMEOUT_IN_SECONDS = "FORM_SQL_QUERY_TIMEOUT_IN_SECONDS";
+    public static final String FULL_EXCEPTION_TRACE_IN_LOG = "FULL_EXCEPTION_TRACE_IN_LOG";
 	public static final String GLOBAL_MAX_QUERY_RECORDS = "GLOBAL_MAX_QUERY_RECORDS";
 	public static final String GLOBAL_MAX_REPORT_RECORDS = "GLOBAL_MAX_REPORT_RECORDS";
     public static final String GRIDTABLE_LOAD_TIMEOUT_IN_SECONDS = "GRIDTABLE_LOAD_TIMEOUT_IN_SECONDS";

--- a/org.adempiere.base/src/org/compiere/util/CLogFormatter.java
+++ b/org.adempiere.base/src/org/compiere/util/CLogFormatter.java
@@ -16,6 +16,8 @@
  *****************************************************************************/
 package org.compiere.util;
 
+import static org.compiere.model.MSysConfig.FULL_EXCEPTION_TRACE_IN_LOG;
+
 import java.awt.Toolkit;
 import java.rmi.ServerException;
 import java.sql.SQLException;
@@ -25,6 +27,7 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
+import org.compiere.model.MSysConfig;
 import org.compiere.model.SystemProperties;
 
 /**
@@ -300,8 +303,7 @@ public class CLogFormatter extends Formatter
         		if (adempiereTrace)
                 	sb.append("\tat ").append(trace[i]).append(NL);
         	}
-        	else if (i > 20
-        		|| (i > 10 && adempiereTraceNo > 8))
+        	else if (!MSysConfig.getBooleanValue(FULL_EXCEPTION_TRACE_IN_LOG, false) && (i > 20 || (i > 10 && adempiereTraceNo > 8)))
         		break;
         	else
         		sb.append("\tat ").append(trace[i]).append(NL);


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-6248

# Pull Request Checklist

- [X] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [X] My code follows the best practices of this project
- [X] I have performed a self-review of my own code
- [X] My code is easy to understand and review. 
- [X] I have checked my code and corrected any misspellings
- [X] In hard-to-understand areas, I have commented my code.
- [X] My changes generate no new warnings
### Tests
- [X] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

