### PR TITLE
IDEMPIERE-3551 Automatic Packin - lower verbosity

### DIFF
--- a/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/AbstractActivator.java
+++ b/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/AbstractActivator.java
@@ -126,7 +126,7 @@ public abstract class AbstractActivator implements BundleActivator, ServiceTrack
 				logger.warning("Wrong name, ignored " + fileName);
 				return false;
 			}
-			logger.warning(fileName);
+			if (logger.isLoggable(Level.INFO)) logger.info(fileName);
 			String clientValue = parts[1];
 			clientId = DB.getSQLValueEx(null, "SELECT AD_Client_ID FROM AD_Client WHERE Value=?", clientValue);
 			if (clientId < 0)

--- a/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/PackInApplicationActivator.java
+++ b/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/PackInApplicationActivator.java
@@ -264,6 +264,7 @@ public class PackInApplicationActivator extends AbstractActivator{
 				continue;
 			}
 			
+			logger.warning("Processing " + filePath);
 			processFilePath(toProcess);
 		}
 		


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-3551

This is a minor change to lower verbosity of plugin.

The plugin is showing a warning on every already-processed file which is unnecessary.
Changed to info level, and announce just when processing a folder.

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
