### PR TITLE
IDEMPIERE-6256 Get image through url from attachment

### DIFF
--- a/org.adempiere.base/src/org/compiere/print/MPrintFormatItem.java
+++ b/org.adempiere.base/src/org/compiere/print/MPrintFormatItem.java
@@ -26,6 +26,7 @@ import java.util.logging.Level;
 import org.compiere.model.GridField;
 import org.compiere.model.I_AD_PrintFormatItem;
 import org.compiere.model.MRole;
+import org.compiere.model.MSysConfig;
 import org.compiere.model.X_AD_PrintFormatItem;
 import org.compiere.util.CCache;
 import org.compiere.util.CLogger;
@@ -619,6 +620,13 @@ public class MPrintFormatItem extends X_AD_PrintFormatItem implements ImmutableP
 					pfi.setIsOrderBy(true);
 					pfi.setSortNo(idSeqNo);
 				}
+				if (displayType == DisplayType.ImageURL)
+				{
+					pfi.setPrintFormatType(PRINTFORMATTYPE_Image);
+					pfi.setIsImageField(true);
+					pfi.setMaxWidth(MSysConfig.getIntValue(MSysConfig.ZK_THUMBNAIL_IMAGE_WIDTH, 100, Env.getAD_Client_ID(Env.getCtx())));
+					pfi.setMaxHeight(MSysConfig.getIntValue(MSysConfig.ZK_THUMBNAIL_IMAGE_HEIGHT, 100, Env.getAD_Client_ID(Env.getCtx())));
+				}
 			}
 			else
 				s_log.log(Level.SEVERE, "Not Found AD_Column_ID=" + AD_Column_ID
@@ -711,6 +719,13 @@ public class MPrintFormatItem extends X_AD_PrintFormatItem implements ImmutableP
 				{
 					pfi.setIsOrderBy(true);
 					pfi.setSortNo(idSeqNo);
+				}
+				if (displayType == DisplayType.ImageURL)
+				{
+					pfi.setPrintFormatType(PRINTFORMATTYPE_Image);
+					pfi.setIsImageField(true);
+					pfi.setMaxWidth(MSysConfig.getIntValue(MSysConfig.ZK_THUMBNAIL_IMAGE_WIDTH, 100, Env.getAD_Client_ID(Env.getCtx())));
+					pfi.setMaxHeight(MSysConfig.getIntValue(MSysConfig.ZK_THUMBNAIL_IMAGE_HEIGHT, 100, Env.getAD_Client_ID(Env.getCtx())));
 				}
 			}
 			else

--- a/org.adempiere.base/src/org/idempiere/print/renderer/HTMLReportRenderer.java
+++ b/org.adempiere.base/src/org/idempiere/print/renderer/HTMLReportRenderer.java
@@ -865,8 +865,10 @@ public class HTMLReportRenderer implements IReportRenderer<HTMLReportRendererCon
 			style.append("height:").append(item.getMaxHeight()).append("px;");
 		if (item.getMaxWidth() > 0) 
 			style.append("width:").append(item.getMaxWidth()).append("px;");
-		if (style.length() > 0)
+		if (style.length() > 0) {
+			style.append("object-fit: scale-down;");
 			image.setStyle(style.toString());
+		}
 	}
 
 	private static void createDataURLImageElement(MultiPartElement td, URL url, MPrintFormatItem item) {

--- a/org.adempiere.report.jasper/src/org/adempiere/report/jasper/ColumnLookup.java
+++ b/org.adempiere.report.jasper/src/org/adempiere/report/jasper/ColumnLookup.java
@@ -39,7 +39,6 @@ import org.compiere.model.MLocator;
 import org.compiere.model.MLookup;
 import org.compiere.model.MLookupFactory;
 import org.compiere.model.MLookupInfo;
-import org.compiere.model.MRole;
 import org.compiere.model.MTable;
 import org.compiere.util.DisplayType;
 import org.compiere.util.Env;

--- a/org.adempiere.ui.zk/WEB-INF/src/metainfo/zk/lang-addon.xml
+++ b/org.adempiere.ui.zk/WEB-INF/src/metainfo/zk/lang-addon.xml
@@ -47,7 +47,7 @@ Copyright (C) 2007 Ashley G Ramdass (ADempiere WebUI).
 	<javascript-module name="jawwa.atmosphere" version="202205100600"/>
 	<javascript-module name="adempiere.local.storage" version="202205100600"/>
 	<javascript-module name="html2canvas" version="1.3.1"/>
-	<javascript-module name="org.idempiere.commons" version="202409241250"/>
+	<javascript-module name="org.idempiere.commons" version="202410230300"/>
 	<javascript-module name="jquery.maskedinput" version="1.4.1" />
 	<javascript-module name="photobooth"	version="0.7-rsd3" />
 	<javascript-module name="chosenbox" version="202205100600"/>

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/GridTabRowRenderer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/GridTabRowRenderer.java
@@ -345,12 +345,6 @@ public class GridTabRowRenderer implements RowRenderer<Object[]>, RowRendererExt
 				editor.setReadWrite(false);
 				editor.setValue(value);
 				Image image = editor.getComponent();
-				if (image.getContent() != null) {
-					image.setWidth(MSysConfig.getIntValue(MSysConfig.ZK_THUMBNAIL_IMAGE_WIDTH, 100, Env.getAD_Client_ID(Env.getCtx()))+"px");
-					image.setHeight(MSysConfig.getIntValue(MSysConfig.ZK_THUMBNAIL_IMAGE_HEIGHT, 100, Env.getAD_Client_ID(Env.getCtx()))+"px");
-					image.setClientAttribute("onmouseenter", "idempiere.showFullSizeImage(event)");
-					image.setClientAttribute("onmouseleave", "idempiere.hideFullSizeImage(event)");
-				}
 				component = image;
 			} else {
 				Span span = new Span();

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/ZkCssHelper.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/ZkCssHelper.java
@@ -19,6 +19,7 @@ package org.adempiere.webui.component;
 
 import java.awt.Color;
 
+import org.compiere.util.Util;
 import org.zkoss.zk.ui.HtmlBasedComponent;
 
 /**
@@ -75,14 +76,18 @@ public final class ZkCssHelper
      */
     public static void appendStyle(HtmlBasedComponent component, String style)
     {
-    	String oldStyle = "";
-
 		if (component.getStyle() != null)
 		{
-			oldStyle = component.getStyle();
+			String oldStyle = component.getStyle().trim();
+			if (!oldStyle.endsWith(";"))
+				component.setStyle(oldStyle + ";" + style);
+			else
+				component.setStyle(oldStyle + style);
+		}		
+		else
+		{
+			component.setStyle(style);
 		}
-		component.setStyle(oldStyle
-						+ "; " + style);
     }
 
     /**
@@ -151,5 +156,29 @@ public final class ZkCssHelper
         String colorString = createHexColorString(color);
         String colorStyleString = STYLE_BACKGROUND_COLOR + colorString;
         component.setStyle(colorStyleString);
+    }
+    
+    /**
+     * Remove named style property (for e.g width) from component
+     * @param component
+     * @param styleName
+     */
+    public static void removeStyle(HtmlBasedComponent component, String styleName) {
+    	if (component.getStyle() != null) {
+    		String style = component.getStyle();
+    		int index = style.indexOf(styleName+":"); 
+    		if (index >= 0) {
+    			int end = style.indexOf(";", index);
+    			if (end > index) {
+    				style = style.replace(style.substring(index, end+1), "");
+    			} else {
+    				style = style.replace(style.substring(index, style.length()), "");
+    			}
+    			if (Util.isEmpty(style, true))
+    				component.setStyle(null);
+    			else
+    				component.setStyle(style);
+    		}
+    	}
     }
 }

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WEditor.java
@@ -747,8 +747,8 @@ public abstract class WEditor implements EventListener<Event>, PropertyChangeLis
 		if (applyDictionaryStyle && gridField.getAD_FieldStyle_ID() > 0) 
 		{
 			style = buildStyle(gridField.getAD_FieldStyle_ID());
-		}
-		setFieldStyle(style);
+			setFieldStyle(style);
+		}		
 		setFieldMandatoryStyle(applyDictionaryStyle);
 	}
 	

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WImageEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WImageEditor.java
@@ -17,6 +17,7 @@ package org.adempiere.webui.editor;
 import java.util.logging.Level;
 
 import org.adempiere.webui.LayoutUtils;
+import org.adempiere.webui.component.ZkCssHelper;
 import org.adempiere.webui.event.DialogEvents;
 import org.adempiere.webui.event.ValueChangeEvent;
 import org.adempiere.webui.window.WImageDialog;
@@ -33,6 +34,7 @@ import org.zkoss.zk.ui.Page;
 import org.zkoss.zk.ui.event.Event;
 import org.zkoss.zk.ui.event.EventListener;
 import org.zkoss.zk.ui.event.Events;
+import org.zkoss.zk.ui.util.Clients;
 import org.zkoss.zul.Cell;
 import org.zkoss.zul.Html;
 import org.zkoss.zul.Image;
@@ -104,7 +106,7 @@ public class WImageEditor extends WEditor
     {
     	AImage img = null;
         getComponent().setContent(img);
-        getComponent().setSclass("image-field image-fit-contain");        
+        getComponent().setSclass("image-field");        
     }
 
      @Override
@@ -160,8 +162,14 @@ public class WImageEditor extends WEditor
 			m_mImage = null;
 			AImage img = null;
 			getComponent().setContent(img);
-			getComponent().setWidth(null);
-			getComponent().setHeight(null);
+			ZkCssHelper.removeStyle(getComponent(), "width");
+			ZkCssHelper.removeStyle(getComponent(), "height");
+			LayoutUtils.removeSclass("thumbnail", getComponent());
+			LayoutUtils.removeSclass("image-fit", getComponent());
+			getComponent().setClientAttribute("onmouseenter", null);
+			getComponent().setClientAttribute("onmouseleave", null);
+			//invalidate necessary for setClientAttribute to work
+			getComponent().invalidate();
 			return;
 		}
 		//  Get/Create Image
@@ -183,13 +191,25 @@ public class WImageEditor extends WEditor
 		{
 			String width = MSysConfig.getIntValue(MSysConfig.ZK_THUMBNAIL_IMAGE_WIDTH, 100, Env.getAD_Client_ID(Env.getCtx()))+"px";
 			String height = MSysConfig.getIntValue(MSysConfig.ZK_THUMBNAIL_IMAGE_HEIGHT, 100, Env.getAD_Client_ID(Env.getCtx()))+"px";
-			getComponent().setWidth(width);
-			getComponent().setHeight(height);
+			String style = "width:"+width+";height:"+height;
+			ZkCssHelper.appendStyle(getComponent(), style);
+			LayoutUtils.addSclass("thumbnail", getComponent());
+			LayoutUtils.addSclass("image-fit", getComponent());
+			getComponent().setClientAttribute("onmouseenter", "idempiere.showFullSizeImage(event)");
+			getComponent().setClientAttribute("onmouseleave", "idempiere.hideFullSizeImage(event)");
+			//invalidate necessary for setClientAttribute to work
+			getComponent().invalidate();
 		}
 		else
 		{
-			getComponent().setWidth(null);
-			getComponent().setHeight(null);
+			ZkCssHelper.removeStyle(getComponent(), "width");
+			ZkCssHelper.removeStyle(getComponent(), "height");
+			LayoutUtils.removeSclass("thumbnail", getComponent());
+			LayoutUtils.removeSclass("image-fit", getComponent());
+			getComponent().setClientAttribute("onmouseenter", null);
+			getComponent().setClientAttribute("onmouseleave", null);
+			//invalidate necessary for setClientAttribute to work
+			getComponent().invalidate();
 		}
     }
     
@@ -211,6 +231,8 @@ public class WImageEditor extends WEditor
 	@Override
 	public void onEvent(Event event) throws Exception 
 	{
+		String script = "jq('#"+getComponent().getUuid()+"').trigger('mouseleave');";
+		Clients.evalJavaScript(script);
 		if (Events.ON_CLICK.equals(event.getName()) && readwrite)
 		{
 			final WImageDialog vid = new WImageDialog(m_mImage);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WImageDialog.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WImageDialog.java
@@ -225,7 +225,7 @@ public class WImageDialog extends Window implements EventListener<Event>
 		ZKUpdateUtil.setHflex(image, "true");
 		ZKUpdateUtil.setVflex(image, "true");
 		center.setParent(mainLayout);
-		image.setSclass("image-fit-contain");
+		image.setSclass("image-fit");
 		center.appendChild(image);
 		
 		South south = new South();

--- a/org.adempiere.ui.zk/WEB-INF/src/web/js/org/idempiere/commons/layout.js
+++ b/org.adempiere.ui.zk/WEB-INF/src/web/js/org/idempiere/commons/layout.js
@@ -150,8 +150,6 @@ window.idempiere.showFullSizeImage = function (event) {
 		event.target._fullsize.style.top = y + "px";
 	 }
   }
-  event.target._fullsize.style.display = "none";
-  jq(event.target._fullsize).fadeIn();	    
 }
 
 window.idempiere.hideFullSizeImage = function (event) {

--- a/org.idempiere.zk.breeze.theme/src/metainfo/zk/lang-addon.xml
+++ b/org.idempiere.zk.breeze.theme/src/metainfo/zk/lang-addon.xml
@@ -5,5 +5,5 @@
 
 	<!-- this js module doesn't actually exists and it is here for breeze theme version -->
 	<!-- since loading of js module is on demand, it doesn't cause any error as long as you don't try to load it -->
-	<javascript-module name="idempiere.theme.default" version="202410030205" />
+	<javascript-module name="idempiere.theme.default" version="202410230300" />
 </language>

--- a/org.idempiere.zk.breeze.theme/src/web/theme/default/css/fragment/field-editor.css.dsp
+++ b/org.idempiere.zk.breeze.theme/src/web/theme/default/css/fragment/field-editor.css.dsp
@@ -199,8 +199,8 @@ span.grid-combobox-editor {
 	cursor: default;
 	border: none;
 }
-.image-fit-contain {
-	object-fit: contain;
+.image-fit {
+	object-fit: scale-down;
 }
 .z-cell.image-field-cell {
 	z-index: 1;

--- a/org.idempiere.zk.datatable/src/org/idempiere/zk/datatable/DatatableReportRenderer.java
+++ b/org.idempiere.zk.datatable/src/org/idempiere/zk/datatable/DatatableReportRenderer.java
@@ -939,8 +939,10 @@ public class DatatableReportRenderer implements IReportRenderer<DatatableReportR
 			style.append("height:").append(item.getMaxHeight()).append("px;");
 		if (item.getMaxWidth() > 0) 
 			style.append("width:").append(item.getMaxWidth()).append("px;");
-		if (style.length() > 0)
+		if (style.length() > 0) {
+			style.append("object-fit: scale-down;");
 			image.setStyle(style.toString());
+		}
 	}
 
 	private static void createDataURLImageElement(MultiPartElement td, URL url, MPrintFormatItem item) {

--- a/org.idempiere.zk.iceblue_c.theme/src/metainfo/zk/lang-addon.xml
+++ b/org.idempiere.zk.iceblue_c.theme/src/metainfo/zk/lang-addon.xml
@@ -5,5 +5,5 @@
 
 	<!-- this js module doesn't actually exists and it is here for iceblue_c theme version -->
 	<!-- since loading of js module is on demand, it doesn't cause any error as long as you don't try to load it -->
-	<javascript-module name="idempiere.theme.iceblue_c" version="202410140807" />
+	<javascript-module name="idempiere.theme.iceblue_c" version="202410230300" />
 </language>

--- a/org.idempiere.zk.iceblue_c.theme/src/web/theme/iceblue_c/css/fragment/field-editor.css.dsp
+++ b/org.idempiere.zk.iceblue_c.theme/src/web/theme/iceblue_c/css/fragment/field-editor.css.dsp
@@ -174,8 +174,8 @@ span.grid-combobox-editor {
 	cursor: default;
 	border: none;
 }
-.image-fit-contain {
-	object-fit: contain;
+.image-fit {
+	object-fit: scale-down;
 }
 .z-cell.image-field-cell {
 	z-index: 1;


### PR DESCRIPTION
- implement hover image for image url and image editor in form mode
- fix aspect ratio of thumbnail
- added thumbnail css class for thumbnail image
- rename image-fit-contain css class to image-fit
- handle ImageURL type for generation of new print format

https://idempiere.atlassian.net/browse/IDEMPIERE-6256

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

