### PR TITLE
IDEMPIERE-6275 Fix row presentation after first time find modal is closed (User preference option - View find result and ZK_GRID_AFTER_FIND)

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/ADSortTab.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/ADSortTab.java
@@ -1040,6 +1040,10 @@ public class ADSortTab extends Panel implements IADTabpanel
 	@Override
 	public void switchRowPresentation() {
 	}
+	
+	@Override
+	public void setupRowPresentation() {
+	}
 
 	@Override
 	public String get_ValueAsString(String variableName) {

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/ADSortTab.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/ADSortTab.java
@@ -1042,7 +1042,7 @@ public class ADSortTab extends Panel implements IADTabpanel
 	}
 	
 	@Override
-	public void setupRowPresentation() {
+	public void onAfterFind() {
 	}
 
 	@Override

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/ADTabpanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/ADTabpanel.java
@@ -978,7 +978,10 @@ DataStatusListener, IADTabpanel, IdSpace, IFieldEditorContainer
     			Events.echoEvent(ON_DEFER_SET_SELECTED_NODE, this, null);
     		}        	
         }
-		               
+        
+        if(!update)
+        	this.setupRowPresentation();
+        
     }
 
     /**

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/ADTabpanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/ADTabpanel.java
@@ -978,10 +978,6 @@ DataStatusListener, IADTabpanel, IdSpace, IFieldEditorContainer
     			Events.echoEvent(ON_DEFER_SET_SELECTED_NODE, this, null);
     		}        	
         }
-        
-        if(!update)
-        	this.setupRowPresentation();
-        
     }
 
     /**

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/ADTabpanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/ADTabpanel.java
@@ -83,6 +83,7 @@ import org.compiere.model.MToolBarButton;
 import org.compiere.model.MToolBarButtonRestrict;
 import org.compiere.model.MTree;
 import org.compiere.model.MTreeNode;
+import org.compiere.model.MUserPreference;
 import org.compiere.model.PO;
 import org.compiere.model.Query;
 import org.compiere.model.SystemProperties;
@@ -561,7 +562,7 @@ DataStatusListener, IADTabpanel, IdSpace, IFieldEditorContainer
     	fieldGroupTabHeaders = new HashMap<String, List<Tab>>();
     	
     	int numCols=gridTab.getNumColumns();
-    	if (numCols <= 0) {
+    	if (numCols <= 0) { 
     		numCols=6;
     	}
 
@@ -957,6 +958,7 @@ DataStatusListener, IADTabpanel, IdSpace, IFieldEditorContainer
         	loadToolbarButtons();
         		
         //create tree
+
         if (!update && gridTab.isTreeTab() && treePanel != null) {
         	int AD_Tree_ID = Env.getContextAsInt (Env.getCtx(), getWindowNo(), "AD_Tree_ID", true);
         	int AD_Tree_ID_Default = MTree.getDefaultAD_Tree_ID (Env.getAD_Client_ID(Env.getCtx()), gridTab.getKeyColumnName());
@@ -976,9 +978,7 @@ DataStatusListener, IADTabpanel, IdSpace, IFieldEditorContainer
     			Events.echoEvent(ON_DEFER_SET_SELECTED_NODE, this, null);
     		}        	
         }
-
-        if (!update && !gridTab.isSingleRow() && !isGridView())
-        	switchRowPresentation();                
+		               
     }
 
     /**
@@ -1946,6 +1946,45 @@ DataStatusListener, IADTabpanel, IdSpace, IFieldEditorContainer
 		
 		Events.sendEvent(this, new Event(ON_SWITCH_VIEW_EVENT, this));
 	}
+	
+
+    
+    /**
+     * Setup Row presentation - switch to grid view if configured
+     * @return void
+     */
+    public void setupRowPresentation() {
+
+ 		if(!isGridView()) {
+ 			
+ 			String userPreference = Env.getContext(Env.getCtx(), MUserPreference.COLUMNNAME_ViewFindResult);
+ 			
+ 			// User preference "View find result" has priority, if "Always In Grid" is set
+ 			if( userPreference.equals(MUserPreference.VIEWFINDRESULT_AlwaysInGridView) ) {
+ 				switchRowPresentation();
+ 			}
+ 			
+ 			// If User preference "View find result" is set to "According To Threshold"
+ 			else if( 
+ 				userPreference.equals(MUserPreference.VIEWFINDRESULT_AccordingToThreshold) &&
+ 				this.getGridTab().getRowCount() >= Env.getContextAsInt(Env.getCtx(), MUserPreference.COLUMNNAME_GridAfterFindThreshold)
+ 			) {
+ 				switchRowPresentation();
+ 			}
+ 			
+ 			// If user preference for View is set to "Default" we will check ZK_GRID_AFTER_FIND system configuration
+ 			else if( MSysConfig.getBooleanValue(MSysConfig.ZK_GRID_AFTER_FIND, false, Env.getAD_Client_ID(Env.getCtx())) ) {
+ 				switchRowPresentation();
+ 			}
+ 			
+ 			// Last, fallback to default behavior - "Is single row" option for specific tab
+ 			else if( !gridTab.isSingleRow() ) {
+ 				switchRowPresentation();
+ 			}
+ 			
+		}
+    	
+    }
 
 	/**
 	 * Listener for zoom event

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/ADTabpanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/ADTabpanel.java
@@ -978,6 +978,10 @@ DataStatusListener, IADTabpanel, IdSpace, IFieldEditorContainer
     			Events.echoEvent(ON_DEFER_SET_SELECTED_NODE, this, null);
     		}        	
         }
+        
+        if (!update && !gridTab.isSingleRow() && !isGridView())
+        	switchRowPresentation(); 
+        
     }
 
     /**
@@ -1949,10 +1953,10 @@ DataStatusListener, IADTabpanel, IdSpace, IFieldEditorContainer
 
     
     /**
-     * Setup Row presentation - switch to grid view if configured
+     * After Find window closes switch to grid view if configured
      * @return void
      */
-    public void setupRowPresentation() {
+    public void onAfterFind() {
 
  		if(!isGridView()) {
  			

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/AbstractADWindowContent.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/AbstractADWindowContent.java
@@ -17,7 +17,6 @@
 
 package org.adempiere.webui.adwindow;
 
-import static org.compiere.model.MSysConfig.ZK_GRID_AFTER_FIND;
 import static org.compiere.model.SystemIDs.PROCESS_AD_CHANGELOG_REDO;
 import static org.compiere.model.SystemIDs.PROCESS_AD_CHANGELOG_UNDO;
 
@@ -111,7 +110,6 @@ import org.compiere.model.MRecentItem;
 import org.compiere.model.MRole;
 import org.compiere.model.MSysConfig;
 import org.compiere.model.MTable;
-import org.compiere.model.MUserPreference;
 import org.compiere.model.MWindow;
 import org.compiere.model.PO;
 import org.compiere.model.StateChangeEvent;
@@ -896,6 +894,7 @@ public abstract class AbstractADWindowContent extends AbstractUIPart implements 
 			            	callback.onCallback(result);
 			            	EventListener<? extends Event> listener = findWindow.getEventListeners(DialogEvents.ON_WINDOW_CLOSE).iterator().next();
 			            	findWindow.removeEventListener(DialogEvents.ON_WINDOW_CLOSE, listener);
+			            	adTabbox.getSelectedTabpanel().setupRowPresentation();
 			            }
 			            else
 			            {
@@ -2575,25 +2574,7 @@ public abstract class AbstractADWindowContent extends AbstractUIPart implements 
 				        	onNew();
 				        } else {
 				        	adTabbox.getSelectedGridTab().dataRefresh(false); // Elaine 2008/07/25
-
-				        	if (!adTabbox.getSelectedTabpanel().isGridView()) { // See if we should force the grid view
-
-				        		boolean forceGridView = false;
-				        		String up = Env.getContext(Env.getCtx(), MUserPreference.COLUMNNAME_ViewFindResult);
-
-				        		if (up.equals(MUserPreference.VIEWFINDRESULT_Default)) {
-				        			forceGridView = MSysConfig.getBooleanValue(ZK_GRID_AFTER_FIND, false, Env.getAD_Client_ID(Env.getCtx()));
-				        		}
-				        		else if (up.equals(MUserPreference.VIEWFINDRESULT_AlwaysInGridView)) {
-				        			forceGridView = true;
-				        		}
-				        		else if (up.equals(MUserPreference.VIEWFINDRESULT_AccordingToThreshold)) {
-				        			forceGridView = adTabbox.getSelectedTabpanel().getGridTab().getRowCount() >= Env.getContextAsInt(Env.getCtx(), MUserPreference.COLUMNNAME_GridAfterFindThreshold);
-				        		}
-
-				        		if (forceGridView)
-				        			adTabbox.getSelectedTabpanel().switchRowPresentation();
-				        	}
+		        			adTabbox.getSelectedTabpanel().setupRowPresentation();
 				        }
 				        toolbar.refreshUserQuery(adTabbox.getSelectedGridTab().getAD_Tab_ID(), getCurrentFindWindow().getAD_UserQuery_ID());
 				        focusToActivePanel();

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/AbstractADWindowContent.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/AbstractADWindowContent.java
@@ -894,7 +894,7 @@ public abstract class AbstractADWindowContent extends AbstractUIPart implements 
 			            	callback.onCallback(result);
 			            	EventListener<? extends Event> listener = findWindow.getEventListeners(DialogEvents.ON_WINDOW_CLOSE).iterator().next();
 			            	findWindow.removeEventListener(DialogEvents.ON_WINDOW_CLOSE, listener);
-			            	adTabbox.getSelectedTabpanel().setupRowPresentation();
+			            	adTabbox.getSelectedTabpanel().onAfterFind();
 			            }
 			            else
 			            {
@@ -2574,7 +2574,7 @@ public abstract class AbstractADWindowContent extends AbstractUIPart implements 
 				        	onNew();
 				        } else {
 				        	adTabbox.getSelectedGridTab().dataRefresh(false); // Elaine 2008/07/25
-		        			adTabbox.getSelectedTabpanel().setupRowPresentation();
+		        			adTabbox.getSelectedTabpanel().onAfterFind();
 				        }
 				        toolbar.refreshUserQuery(adTabbox.getSelectedGridTab().getAD_Tab_ID(), getCurrentFindWindow().getAD_UserQuery_ID());
 				        focusToActivePanel();

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/IADTabpanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/IADTabpanel.java
@@ -117,9 +117,10 @@ public interface IADTabpanel extends Component, Evaluatee {
 	public void switchRowPresentation();
 
 	/**
-	 * Setup Row presentation - switch to grid view if configured
-	 */
-	public void setupRowPresentation();
+     * After Find window closes switch to grid view if configured
+     * @return void
+     */
+	public void onAfterFind();
 
 	/**
 	 * Dynamic update of every field's UI properties ( visibility, filter and mandatory ).

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/IADTabpanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/IADTabpanel.java
@@ -117,6 +117,11 @@ public interface IADTabpanel extends Component, Evaluatee {
 	public void switchRowPresentation();
 
 	/**
+	 * Setup Row presentation - switch to grid view if configured
+	 */
+	public void setupRowPresentation();
+
+	/**
 	 * Dynamic update of every field's UI properties ( visibility, filter and mandatory ).
 	 * @param col optional column name
 	 */


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-6275

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

