### PR TITLE
IDEMPIERE-6297 Fix RelatedInfoWindow Order By

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/RelatedInfoWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/RelatedInfoWindow.java
@@ -356,7 +356,7 @@ public class RelatedInfoWindow implements EventListener<Event>, Sortable<Object>
         if (!Util.isEmpty(m_sqlUserOrder)) {
         	dataSql = dataSql + m_sqlUserOrder;
         	if(!Util.isEmpty(orderByClause))
-        		dataSql = dataSql + orderByClause;
+        		dataSql = dataSql + ", " + orderByClause;
         }
         else if(!Util.isEmpty(orderByClause)) {
         	dataSql = dataSql + " ORDER BY " + orderByClause;

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/RelatedInfoWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/RelatedInfoWindow.java
@@ -423,7 +423,7 @@ public class RelatedInfoWindow implements EventListener<Event>, Sortable<Object>
 
 		catch (SQLException e)
 		{
-			log.log(Level.SEVERE, dataSql, e);
+			throw new AdempiereException(e);
 		}
 
 		finally


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-6297

The info's default Order By clause must be separated by a comma if there is a user-entered order

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

