### PR TITLE
IDEMPIERE-6318 : Tab Icon not show when ZK_THEME_USE_FONT_ICON_FOR_IM…

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/Tab.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/Tab.java
@@ -136,6 +136,8 @@ public class Tab extends org.zkoss.zul.Tab
 					Image ico = ManageImageCache.instance().getImage(imageKey);
 					if (ico != null)
 						comp.setImageContent(ico);
+					else
+						comp.setImage(ThemeManager.getThemeResource("images/m"+imageKey+".png"));
 				}
 			}
 		}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/part/WindowContainer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/part/WindowContainer.java
@@ -310,8 +310,12 @@ public class WindowContainer extends AbstractUIPart implements EventListener<Eve
 			item.setValue(Integer.toString(i));
 			if (ThemeManager.isUseFontIconForImage())
 				item.setIconSclass(tab.getIconSclass());
-			else
+			else if(tab.getImageContent()!=null)
+				item.setImageContent(tab.getImageContent());
+			else if(tab.getImage()!=null)
 				item.setImage(tab.getImage());
+			else
+				item.setImage(ThemeManager.getThemeResource("images/mWindow.png"));
 			
 			if (!Util.isEmpty(tab.getTooltiptext(), true) && !(item.getLabel().equals(tab.getTooltiptext())))
 				item.setTooltiptext(tab.getTooltiptext());

--- a/org.idempiere.zk.iceblue_c.theme/src/metainfo/zk/lang-addon.xml
+++ b/org.idempiere.zk.iceblue_c.theme/src/metainfo/zk/lang-addon.xml
@@ -5,5 +5,5 @@
 
 	<!-- this js module doesn't actually exists and it is here for iceblue_c theme version -->
 	<!-- since loading of js module is on demand, it doesn't cause any error as long as you don't try to load it -->
-	<javascript-module name="idempiere.theme.iceblue_c" version="202411251000" />
+	<javascript-module name="idempiere.theme.iceblue_c" version="202411261000" />
 </language>

--- a/org.idempiere.zk.iceblue_c.theme/src/web/theme/iceblue_c/css/fragment/desktop.css.dsp
+++ b/org.idempiere.zk.iceblue_c.theme/src/web/theme/iceblue_c/css/fragment/desktop.css.dsp
@@ -145,7 +145,6 @@
 .desktop-tabbox.z-tabbox  > .z-tabs > .z-tabs-content .z-tab-image {
 	width: 16px;
 	height: 16px;
-	padding-bottom: 4px;
 }
 
 .desktop-tabpanel {


### PR DESCRIPTION
…AGE is N

https://idempiere.atlassian.net/browse/IDEMPIERE-6318


# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

