### PR TITLE
IDEMPIERE-6355 : Virtual UI column type date field cause record to di…

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WDateEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WDateEditor.java
@@ -175,7 +175,7 @@ public class WDateEditor extends WEditor implements ContextMenuListener
     		Timestamp currentValue = oldValue;
     		oldValue = null;
     		getComponent().setValue(null);
-    		if (currentValue != null)
+    		if (currentValue != null && !isGridFieldVirtualUIColumn())
     		{
     			ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, null);
     			super.fireValueChange(changeEvent);
@@ -187,7 +187,7 @@ public class WDateEditor extends WEditor implements ContextMenuListener
     		LocalDateTime localDateTime = ((Timestamp)value).toLocalDateTime();
             getComponent().setValueInLocalDateTime(localDateTime);            
             oldValue = Timestamp.valueOf(localDateTime);
-            if (!Objects.equals(currentValue, oldValue)) 
+			if (!Objects.equals(currentValue, oldValue) && !isGridFieldVirtualUIColumn()) 
             {
             	ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, oldValue);
             	super.fireValueChange(changeEvent);
@@ -203,7 +203,7 @@ public class WDateEditor extends WEditor implements ContextMenuListener
         			oldValue = Timestamp.valueOf(getComponent().getValue().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
         		else
         			oldValue = null;
-    			if (!Objects.equals(currentValue, oldValue))
+    			if (!Objects.equals(currentValue, oldValue) && !isGridFieldVirtualUIColumn())
     			{
 	    			ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, oldValue);
 	                super.fireValueChange(changeEvent);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WDateEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WDateEditor.java
@@ -175,7 +175,7 @@ public class WDateEditor extends WEditor implements ContextMenuListener
     		Timestamp currentValue = oldValue;
     		oldValue = null;
     		getComponent().setValue(null);
-    		if (currentValue != null && !isGridFieldVirtualUIColumn())
+    		if (currentValue != null && !readOnly)
     		{
     			ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, null);
     			super.fireValueChange(changeEvent);
@@ -187,7 +187,7 @@ public class WDateEditor extends WEditor implements ContextMenuListener
     		LocalDateTime localDateTime = ((Timestamp)value).toLocalDateTime();
             getComponent().setValueInLocalDateTime(localDateTime);            
             oldValue = Timestamp.valueOf(localDateTime);
-			if (!Objects.equals(currentValue, oldValue) && !isGridFieldVirtualUIColumn()) 
+			if (!Objects.equals(currentValue, oldValue) && !readOnly) 
             {
             	ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, oldValue);
             	super.fireValueChange(changeEvent);
@@ -203,7 +203,7 @@ public class WDateEditor extends WEditor implements ContextMenuListener
         			oldValue = Timestamp.valueOf(getComponent().getValue().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
         		else
         			oldValue = null;
-    			if (!Objects.equals(currentValue, oldValue) && !isGridFieldVirtualUIColumn())
+    			if (!Objects.equals(currentValue, oldValue) && !readOnly)
     			{
 	    			ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, oldValue);
 	                super.fireValueChange(changeEvent);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WDatetimeEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WDatetimeEditor.java
@@ -220,7 +220,7 @@ public class WDatetimeEditor extends WEditor implements ContextMenuListener
     		Timestamp currentValue = oldValue;
     		oldValue = null;
     		getComponent().setValue(null);
-    		if (currentValue != null)
+    		if (currentValue != null && !isGridFieldVirtualUIColumn())
     		{
     			ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, null);
     			super.fireValueChange(changeEvent);
@@ -235,7 +235,7 @@ public class WDatetimeEditor extends WEditor implements ContextMenuListener
     			ZonedDateTime zdt = ts.toInstant().atZone(getComponent().getDatebox().getTimeZone().toZoneId());
     			getComponent().setValueInZonedDateTime(zdt);
     			oldValue = Timestamp.from(zdt.toInstant());
-    			if (!Objects.equal(currentValue, oldValue))
+    			if (!Objects.equal(currentValue, oldValue) && !isGridFieldVirtualUIColumn())
     			{
     				ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, oldValue);
     				super.fireValueChange(changeEvent);
@@ -247,7 +247,7 @@ public class WDatetimeEditor extends WEditor implements ContextMenuListener
 	    		LocalDateTime localTime = ts.toLocalDateTime();
 	    		getComponent().setValueInLocalDateTime(localTime);
 	    		oldValue = Timestamp.valueOf(localTime);
-    			if (!Objects.equal(currentValue, oldValue))
+	    		if (!Objects.equal(currentValue, oldValue) && !isGridFieldVirtualUIColumn())
     			{
     				ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, oldValue);
     				super.fireValueChange(changeEvent);
@@ -267,7 +267,7 @@ public class WDatetimeEditor extends WEditor implements ContextMenuListener
     				oldValue = Timestamp.from(getComponent().getDatebox().getValue().toInstant());
     			else
     				oldValue = Timestamp.valueOf(getComponent().getDatebox().getValue().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
-    			if (!Objects.equal(currentValue, oldValue))
+    			if (!Objects.equal(currentValue, oldValue) && !isGridFieldVirtualUIColumn())
     			{
     				ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, oldValue);
     				super.fireValueChange(changeEvent);
@@ -276,7 +276,7 @@ public class WDatetimeEditor extends WEditor implements ContextMenuListener
     		else
     		{
     			oldValue = null;
-    			if (currentValue != null)
+    			if (currentValue != null && !isGridFieldVirtualUIColumn())
         		{
         			ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, null);
         			super.fireValueChange(changeEvent);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WDatetimeEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WDatetimeEditor.java
@@ -220,7 +220,7 @@ public class WDatetimeEditor extends WEditor implements ContextMenuListener
     		Timestamp currentValue = oldValue;
     		oldValue = null;
     		getComponent().setValue(null);
-    		if (currentValue != null && !isGridFieldVirtualUIColumn())
+    		if (currentValue != null && !readOnly)
     		{
     			ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, null);
     			super.fireValueChange(changeEvent);
@@ -235,7 +235,7 @@ public class WDatetimeEditor extends WEditor implements ContextMenuListener
     			ZonedDateTime zdt = ts.toInstant().atZone(getComponent().getDatebox().getTimeZone().toZoneId());
     			getComponent().setValueInZonedDateTime(zdt);
     			oldValue = Timestamp.from(zdt.toInstant());
-    			if (!Objects.equal(currentValue, oldValue) && !isGridFieldVirtualUIColumn())
+    			if (!Objects.equal(currentValue, oldValue) && !readOnly)
     			{
     				ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, oldValue);
     				super.fireValueChange(changeEvent);
@@ -247,7 +247,7 @@ public class WDatetimeEditor extends WEditor implements ContextMenuListener
 	    		LocalDateTime localTime = ts.toLocalDateTime();
 	    		getComponent().setValueInLocalDateTime(localTime);
 	    		oldValue = Timestamp.valueOf(localTime);
-	    		if (!Objects.equal(currentValue, oldValue) && !isGridFieldVirtualUIColumn())
+	    		if (!Objects.equal(currentValue, oldValue) && !readOnly)
     			{
     				ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, oldValue);
     				super.fireValueChange(changeEvent);
@@ -267,7 +267,7 @@ public class WDatetimeEditor extends WEditor implements ContextMenuListener
     				oldValue = Timestamp.from(getComponent().getDatebox().getValue().toInstant());
     			else
     				oldValue = Timestamp.valueOf(getComponent().getDatebox().getValue().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
-    			if (!Objects.equal(currentValue, oldValue) && !isGridFieldVirtualUIColumn())
+    			if (!Objects.equal(currentValue, oldValue) && !readOnly)
     			{
     				ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, oldValue);
     				super.fireValueChange(changeEvent);
@@ -276,7 +276,7 @@ public class WDatetimeEditor extends WEditor implements ContextMenuListener
     		else
     		{
     			oldValue = null;
-    			if (currentValue != null && !isGridFieldVirtualUIColumn())
+    			if (currentValue != null && !readOnly)
         		{
         			ValueChangeEvent changeEvent = new ValueChangeEvent(this, this.getColumnName(), currentValue, null);
         			super.fireValueChange(changeEvent);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WEditor.java
@@ -932,6 +932,16 @@ public abstract class WEditor implements EventListener<Event>, PropertyChangeLis
 		}
 	}
 
+	/**
+	 * Is Virtual UI Column (using @SQL= and loaded separately from main query)
+	 * 
+	 * @return true if column is virtual UI
+	 */
+	protected boolean isGridFieldVirtualUIColumn()
+	{
+		return gridField != null && gridField.isVirtualUIColumn();
+	}
+
     /**
      * Add text editor dialog entry to context menu
      * @param popupMenu

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WEditor.java
@@ -932,16 +932,6 @@ public abstract class WEditor implements EventListener<Event>, PropertyChangeLis
 		}
 	}
 
-	/**
-	 * Is Virtual UI Column (using @SQL= and loaded separately from main query)
-	 * 
-	 * @return true if column is virtual UI
-	 */
-	protected boolean isGridFieldVirtualUIColumn()
-	{
-		return gridField != null && gridField.isVirtualUIColumn();
-	}
-
     /**
      * Add text editor dialog entry to context menu
      * @param popupMenu


### PR DESCRIPTION
…splay as not saved

https://idempiere.atlassian.net/browse/IDEMPIERE-6355


# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [ ] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

