### PR TITLE
IDEMPIERE-6366 : Generic Info window shows all columns exists on tabl…

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoGeneralPanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoGeneralPanel.java
@@ -398,18 +398,19 @@ public class InfoGeneralPanel extends InfoPanel implements EventListener<Event>
 		String uucolName = PO.getUUIDColumnName(p_tableName);
 		boolean hasWindowAndTab = new Query(Env.getCtx(), MTab.Table_Name, " AD_Table_ID = ? ", null)
 									.setParameters(table.getAD_Table_ID())
+									.setOnlyActiveRecords(true)
 									.match();
 
 		//	Get Query Columns
 		String sqlqc = "SELECT c.ColumnName, t.AD_Table_ID, t.TableName, c.ColumnSql "
 			+ "FROM AD_Table t"
-			+ " INNER JOIN AD_Column c ON (t.AD_Table_ID=c.AD_Table_ID)"
+			+ " INNER JOIN AD_Column c ON (t.AD_Table_ID=c.AD_Table_ID AND c.IsActive = 'Y' )"
 			+ "WHERE c.AD_Reference_ID IN (10,14)"
 			+ " AND t.TableName=? ";	//	#1
 		if(hasWindowAndTab) {
 			//	Displayed in Window
-			sqlqc += " AND EXISTS (SELECT * FROM AD_Field f "
-					+ " WHERE f.AD_Column_ID=c.AD_Column_ID "
+			sqlqc += " AND EXISTS (SELECT 1 FROM AD_Field f "
+				+ "WHERE f.AD_Column_ID=c.AD_Column_ID AND f.IsActive = 'Y'"
 					+ " AND f.IsDisplayed='Y' AND f.IsEncrypted='N' AND f.ObscureType IS NULL) ";
 		}
 		sqlqc += " ORDER BY c.IsIdentifier DESC, c.IsSelectionColumn Desc, c.AD_Reference_ID, c.SeqNoSelection, c.SeqNo";
@@ -508,7 +509,7 @@ public class InfoGeneralPanel extends InfoPanel implements EventListener<Event>
 			+ " INNER JOIN AD_Table t ON (c.AD_Table_ID=t.AD_Table_ID)");
 		if(hasWindowAndTab) {
 			sqlc.append(" INNER JOIN AD_Tab tab ON (t.AD_Table_ID=tab.AD_Table_ID)"
-					+ " INNER JOIN AD_Field f ON (tab.AD_Tab_ID=f.AD_Tab_ID AND f.AD_Column_ID=c.AD_Column_ID) ");
+					+ " INNER JOIN AD_Field f ON (tab.AD_Tab_ID=f.AD_Tab_ID AND f.AD_Column_ID=c.AD_Column_ID AND f.IsActive='Y') ");
 		}	
 		sqlc.append( "WHERE t.AD_Table_ID=? ");
 		if(hasWindowAndTab) {
@@ -516,23 +517,23 @@ public class InfoGeneralPanel extends InfoPanel implements EventListener<Event>
 					+ " AND tab.Ad_Tab_ID=(SELECT MIN(mt.AD_Tab_ID) FROM AD_tab mt WHERE mt.AD_Window_ID=? AND mt.AD_Table_ID=t.AD_Table_ID AND mt.IsActive='Y')"
 					+ " AND (c.IsKey='Y' OR "
 					+ "		(f.IsEncrypted='N' AND f.ObscureType IS NULL))");
-		} else {
-			sqlc.append(" AND (c.IsKey='Y' "
+		}
+		sqlc.append(" AND (c.IsKey='Y' "
 					+ "			OR c.IsIdentifier='Y' "
 					+ "			OR c.IsParent='Y' "
 					+ "			OR c.IsSelectionColumn='Y' "
 					+ "			OR Upper(c.ColumnName) IN ('NAME','VALUE','DESCRIPTION','DOCUMENTNO') "
 					+ "			OR Upper(c.ColumnName) Like '%_NAME' "
 					+ "			OR Upper(c.ColumnName) Like '%_Value') ");
-		}
+
 		sqlc.append(" AND c.IsActive = 'Y' "
 			+ "ORDER BY ");
 		if (table.isUUIDKeyTable() || p_keyColumn.endsWith("_UU"))
 			sqlc.append("CASE WHEN c.columnname=").append(DB.TO_STRING(uucolName)).append("THEN 0 ELSE 1 END");
 		else
 			sqlc.append("c.IsKey DESC");
-		if(hasWindowAndTab)
-			sqlc.append(", f.SeqNo");
+
+		sqlc.append(", c.IsSelectionColumn DESC, c.SeqNoSelection, c.IsIdentifier DESC, c.SeqNo, c.AD_Reference_ID ");
 
 		try
 		{


### PR DESCRIPTION
…e and do not respect seqNoSelection

[ Please copy here the link to the related Jira ticket ](https://idempiere.atlassian.net/browse/IDEMPIERE-6366)]


# Pull Request Checklist

- [ ] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [ ] My code follows the best practices of this project
- [ ] I have performed a self-review of my own code
- [ ] My code is easy to understand and review. 
- [ ] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [ ] My changes generate no new warnings
### Tests
- [ ] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

