### PR TITLE
IDEMPIERE-6396: Adding support for context varialbe in HTML_REPORT_TH…

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/report/HTMLExtension.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/report/HTMLExtension.java
@@ -31,6 +31,7 @@ import org.compiere.print.PrintData;
 import org.compiere.print.PrintDataElement;
 import org.compiere.util.Env;
 import org.compiere.util.Msg;
+import org.compiere.util.Util;
 import org.zkoss.zk.ui.Executions;
 
 /**
@@ -202,6 +203,16 @@ public class HTMLExtension implements IHTMLExtension {
 		if (!theme.endsWith("/"))
 			theme = theme + "/";
 		String resFile = theme + "css/report.css";
+		
+		// Support to Parse Context Variable
+		if (resFile.contains("@"))
+		{
+			resFile = Env.parseContext(Env.getCtx(), 0, resFile, false);
+			if (Util.isEmpty(resFile))
+			{
+				resFile = "/css/report.css"; // default
+			}
+		}
 		
 		// translate ~./ url to classpath url
 		if (theme.startsWith(ThemeManager.ZK_URL_PREFIX_FOR_CLASSPATH_RESOURCE))

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/report/HTMLExtension.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/report/HTMLExtension.java
@@ -29,6 +29,7 @@ import org.compiere.model.MSysConfig;
 import org.compiere.print.IHTMLExtension;
 import org.compiere.print.PrintData;
 import org.compiere.print.PrintDataElement;
+import org.compiere.util.CLogger;
 import org.compiere.util.Env;
 import org.compiere.util.Msg;
 import org.compiere.util.Util;
@@ -40,6 +41,9 @@ import org.zkoss.zk.ui.Executions;
  */
 public class HTMLExtension implements IHTMLExtension {
 
+	/**	Logger				*/
+	private static CLogger log = CLogger.getCLogger(HTMLExtension.class);
+			
 	private String classPrefix;
 	private String componentId;
 	private String scriptURL;
@@ -210,6 +214,7 @@ public class HTMLExtension implements IHTMLExtension {
 			resFile = Env.parseContext(Env.getCtx(), 0, resFile, false);
 			if (Util.isEmpty(resFile))
 			{
+				log.warning("Report theme URL parsing Failed, Defaulting to default report.css url");
 				resFile = "/css/report.css"; // default
 			}
 		}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/report/HTMLExtension.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/report/HTMLExtension.java
@@ -214,7 +214,7 @@ public class HTMLExtension implements IHTMLExtension {
 			resFile = Env.parseContext(Env.getCtx(), 0, resFile, false);
 			if (Util.isEmpty(resFile))
 			{
-				log.warning("Report theme URL parsing Failed, Defaulting to default report.css url");
+				log.warning("Report theme URL '"+ theme +"' failed to parse, Defaulting to default report.css url");
 				resFile = "/css/report.css"; // default
 			}
 		}


### PR DESCRIPTION
…EME sys config

[ [Please copy here the link to the related Jira ticket](https://idempiere.atlassian.net/browse/IDEMPIERE-6396) ]


# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [x] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [x] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

