### PR TITLE
IDEMPIERE-6386 Detail tabs don't have control over slow or big queries (FHCA-6139)

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/GridTable.java
+++ b/org.adempiere.base/src/org/compiere/model/GridTable.java
@@ -3100,6 +3100,7 @@ public class GridTable extends AbstractTableModel
 					m_rowLoadTimeout = true;
 					throw new AdempiereException(Msg.getMsg(Env.getCtx(), LOAD_TIMEOUT_ERROR_MESSAGE), e);
 				} else {
+					log.severe(e.getLocalizedMessage() + " -> " + m_SQL);
 					log.saveError(e.getLocalizedMessage(), e);
 					throw new DBException(e);
 				}
@@ -3213,7 +3214,8 @@ public class GridTable extends AbstractTableModel
 			}
 			catch (Exception e)
 			{
-				log.log(Level.SEVERE, "run", e);
+				if (! DBException.isTimeout(e))
+					throw new AdempiereException(e);
 			}
 			finally
 			{

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/AbstractADWindowContent.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/adwindow/AbstractADWindowContent.java
@@ -857,6 +857,8 @@ public abstract class AbstractADWindowContent extends AbstractUIPart implements 
 		    		} catch (Exception e) {
 		        		if (DBException.isTimeout(e)) {
 		        			Dialog.error(curWindowNo, GridTable.LOAD_TIMEOUT_ERROR_MESSAGE);
+		        		} else {
+		        			Dialog.error(curWindowNo, "Error", e.getLocalizedMessage());
 		        		}
 		    		}
 			}
@@ -992,7 +994,7 @@ public abstract class AbstractADWindowContent extends AbstractUIPart implements 
 			if (rs.next())
 				no = rs.getInt(1);
 		} catch (SQLException e) {
-			logger.log(Level.WARNING, e.getMessage(), e);
+			logger.log(Level.WARNING, e.getMessage() + " -> " + finalSQL, e);
 			no = -1;
 		}
 		return no;


### PR DESCRIPTION
- show errors immediately when a window query has error (f.e. a wrong virtual column)

https://idempiere.atlassian.net/browse/IDEMPIERE-6386?focusedCommentId=51470

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
