### PR TITLE
IDEMPIERE-6386 Detail tabs don't have control over slow or big queries (FHCA-6139)

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/GridTable.java
+++ b/org.adempiere.base/src/org/compiere/model/GridTable.java
@@ -1151,10 +1151,13 @@ public class GridTable extends AbstractTableModel
 		int loops = 0;
 		//wait for [timeout] seconds
 		int timeout = MSysConfig.getIntValue(MSysConfig.GRIDTABLE_LOAD_TIMEOUT_IN_SECONDS, DEFAULT_GRIDTABLE_LOAD_TIMEOUT_IN_SECONDS, Env.getAD_Client_ID(Env.getCtx()));
-		if (timeout <= 0)
-			timeout = 120; /* wait max 2 minutes if the load timeout is not set, WARNING, this is not recommended as the query keeps running in the database */
-		else
+		if (timeout <= 0) {
+			timeout = 120;
+			log.warning("Setting GRIDTABLE_LOAD_TIMEOUT_IN_SECONDS = 0 is not recommended as long queries can keep running in the database and affects performance, "
+					+ " in this case the system assigns a wait of 2 minutes to load records of a window");
+		} else {
 			timeout += 5; /* give 5 seconds extra for the query to timeout first in the database */
+		}
 		while (row >= m_sort.size() && m_loaderFuture != null && !m_loaderFuture.isDone() && !m_rowLoadTimeout && loops < timeout)
 		{
 			if (log.isLoggable(Level.FINE)) log.fine("Waiting for loader row=" + row + ", size=" + m_sort.size());


### PR DESCRIPTION
- fix misleading "no rows found" message instead of timeout
- optimize waitLoadingForRow heavily called
- log info level queries that timeout
- show correctly the final number of records when background loading takes place

https://idempiere.atlassian.net/browse/IDEMPIERE-6386?focusedCommentId=51472

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
