### PR TITLE
IDEMPIERE-6437:fix java.lang.OutOfMemoryError: Java heap space on sonarquibe action

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -38,9 +38,9 @@ jobs:
       - name: Build and analyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          MAVEN_OPTS: "-Xmx7g"
+          SONAR_SCANNER_JAVA_OPTS: "-Xmx7g"
         run: |
-          mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
+          mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:5.0.0.4389:sonar \
           -Dsonar.projectKey=idempiere_idempiere \
           -Dsonar.exclusions=**/I_*.java,**/X_*.java \
           -Dsonar.organization=idempiere \

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -41,10 +41,10 @@ jobs:
         run: |
           mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:5.0.0.4389:sonar \
           -Dsonar.projectKey=${{ vars.sonarProjectKey }} \
-		  -Dsonar.organization=${{ vars.sonarOrganization }} \
+          -Dsonar.organization=${{ vars.sonarOrganization }} \
           -Dsonar.exclusions=**/I_*.java,**/X_*.java \
           -Dsonar.host.url=https://sonarcloud.io \
-		  -Dsonar.scanner.javaOpts="-Xmx6g" \
+          -Dsonar.scanner.javaOpts="-Xmx6g" \
           -DmaterializeProduct=none \
           -DassembleRepository=none \
           -Dsonar.sourceEncoding=UTF-8 \

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -38,13 +38,13 @@ jobs:
       - name: Build and analyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_SCANNER_JAVA_OPTS: "-Xmx7g"
         run: |
           mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:5.0.0.4389:sonar \
-          -Dsonar.projectKey=idempiere_idempiere \
+          -Dsonar.projectKey=${{ vars.sonarProjectKey }} \
+		  -Dsonar.organization=${{ vars.sonarOrganization }} \
           -Dsonar.exclusions=**/I_*.java,**/X_*.java \
-          -Dsonar.organization=idempiere \
           -Dsonar.host.url=https://sonarcloud.io \
+		  -Dsonar.scanner.javaOpts="-Xmx6g" \
           -DmaterializeProduct=none \
           -DassembleRepository=none \
           -Dsonar.sourceEncoding=UTF-8 \


### PR DESCRIPTION

1. setting memory is change on latest (5.x) https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/scanners/sonarscanner-for-maven/#if-you-get-a-javalangoutofmemoryerror

2. specifying the version instead of using the latest to avoid breaking changes at an unwanted time

[IDEMPIERE-6437:Change sonarqube analysis to manual workflow](https://idempiere.atlassian.net/browse/IDEMPIERE-6437)


# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

