### PR TITLE
IDEMPIERE-4925 - Fixed bug cause by original commit that made QtyCoun…

### DIFF
--- a/migration/iD12/oracle/202503041233_IDEMPIERE-4925.sql
+++ b/migration/iD12/oracle/202503041233_IDEMPIERE-4925.sql
@@ -1,0 +1,14 @@
+-- IDEMPIERE-4925 - Adding column for UOM and QtyEntered on Inventory Move
+SELECT register_migration_script('202503041233_IDEMPIERE-4925.sql') FROM dual;
+
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Mar 4, 2025, 12:33:28 PM CET
+UPDATE AD_Field SET IsReadOnly='N',Updated=TO_TIMESTAMP('2025-03-04 12:33:28','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=10998
+;
+
+-- Mar 4, 2025, 12:33:54 PM CET
+UPDATE AD_Field SET IsReadOnly='N',Updated=TO_TIMESTAMP('2025-03-04 12:33:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2699
+;
+

--- a/migration/iD12/postgresql/202503041233_IDEMPIERE-4925.sql
+++ b/migration/iD12/postgresql/202503041233_IDEMPIERE-4925.sql
@@ -1,0 +1,11 @@
+-- IDEMPIERE-4925 - Adding column for UOM and QtyEntered on Inventory Move
+SELECT register_migration_script('202503041233_IDEMPIERE-4925.sql') FROM dual;
+
+-- Mar 4, 2025, 12:33:28 PM CET
+UPDATE AD_Field SET IsReadOnly='N',Updated=TO_TIMESTAMP('2025-03-04 12:33:28','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=10998
+;
+
+-- Mar 4, 2025, 12:33:54 PM CET
+UPDATE AD_Field SET IsReadOnly='N',Updated=TO_TIMESTAMP('2025-03-04 12:33:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2699
+;
+


### PR DESCRIPTION
…t and InternalQty read only on inventory windows

https://idempiere.atlassian.net/jira/software/c/projects/IDEMPIERE/issues/IDEMPIERE-4925


# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [ ] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

