### PR TITLE
IDEMPIERE-6387:Asset Expense for the same period becomes two after asset addition

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MDepreciationExp.java
+++ b/org.adempiere.base/src/org/compiere/model/MDepreciationExp.java
@@ -228,6 +228,8 @@ public class MDepreciationExp extends X_A_Depreciation_Exp
 			}
 			//
 			assetwk.adjustAccumulatedDepr(getExpense(), getExpense_F(), false);
+			// set period and dateacct from latest depreciation expense (do nothing in case of first depreciation)
+			assetwk.setA_Current_Period();
 			// Update workfile - Remaining asset cost
 			assetwk.saveEx();
 			//adjust to the last day of the month in before save assetwk.

--- a/org.adempiere.base/src/org/compiere/model/MDepreciationExp.java
+++ b/org.adempiere.base/src/org/compiere/model/MDepreciationExp.java
@@ -229,7 +229,6 @@ public class MDepreciationExp extends X_A_Depreciation_Exp
 			//
 			assetwk.adjustAccumulatedDepr(getExpense(), getExpense_F(), false);
 			// Update workfile - Remaining asset cost
-			assetwk.setA_Current_Period();
 			assetwk.saveEx();
 			//adjust to the last day of the month in before save assetwk.
 			setDateAcct(assetwk.getDateAcct());
@@ -242,6 +241,10 @@ public class MDepreciationExp extends X_A_Depreciation_Exp
 		setProcessed(true);
 		updateFrom(assetwk);
 		saveEx();
+
+		// Increment the current period (A_Current_Period) 1, and a month DateAcct.
+		assetwk.setA_Current_Period();
+		assetwk.saveEx();
 	}
 	
 	@Override

--- a/org.adempiere.base/src/org/compiere/model/MDepreciationWorkfile.java
+++ b/org.adempiere.base/src/org/compiere/model/MDepreciationWorkfile.java
@@ -718,17 +718,6 @@ public class MDepreciationWorkfile extends X_A_Depreciation_Workfile
 		
 		for (int currentPeriod = A_Current_Period, cnt = 1; currentPeriod <= lifePeriods; currentPeriod++, cnt++)
 		{
-			final String whereClause = MDepreciationExp.COLUMNNAME_A_Asset_ID+"=?"
-					+" AND A_Period=?"
-					+" AND "+MDepreciationExp.COLUMNNAME_PostingType+"=?"
-					+" AND "+MDepreciationExp.COLUMNNAME_Processed+"=?";
-			boolean match = new Query(getCtx(), MDepreciationExp.Table_Name, whereClause, get_TrxName())
-					.setParameters(new Object[]{getA_Asset_ID(), currentPeriod, getPostingType(), true})
-					.match();
-			if (match) {
-				continue;
-			}
-			
 			exp_C = Env.ZERO;
 			exp_F = Env.ZERO;
 			


### PR DESCRIPTION
[IDEMPIERE-6387:Asset Expense for the same period becomes two after asset addition](https://idempiere.atlassian.net/browse/IDEMPIERE-6387)


# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

