### PR TITLE
IDEMPIERE-6423:Process dialog evaluates 'ReadOnly/Display Logic, Mand…

### DIFF
--- a/org.adempiere.base/src/org/compiere/util/DefaultEvaluatee.java
+++ b/org.adempiere.base/src/org/compiere/util/DefaultEvaluatee.java
@@ -117,7 +117,11 @@ public class DefaultEvaluatee implements Evaluatee {
 	 * @param dataProvider
 	 */
 	public DefaultEvaluatee(DataProvider dataProvider) {
-		
+		this.m_dataProvider = dataProvider;
+		this.m_windowNo = 0;
+		this.m_tabNo = -1;
+		this.m_onlyWindow = false;
+		this.m_onlyTab = null;
 	}
 	
 	/**

--- a/org.adempiere.base/src/org/compiere/util/DefaultEvaluatee.java
+++ b/org.adempiere.base/src/org/compiere/util/DefaultEvaluatee.java
@@ -105,7 +105,10 @@ public class DefaultEvaluatee implements Evaluatee {
 	}
 	
 	/**
+	 * Help to use variable from window context 
 	 * @param dataProvider
+	 * @param windowNo
+	 * @param tabNo
 	 */
 	public DefaultEvaluatee(DataProvider dataProvider, int windowNo, int tabNo) {
 		this(dataProvider);

--- a/org.adempiere.base/src/org/compiere/util/DefaultEvaluatee.java
+++ b/org.adempiere.base/src/org/compiere/util/DefaultEvaluatee.java
@@ -107,12 +107,17 @@ public class DefaultEvaluatee implements Evaluatee {
 	/**
 	 * @param dataProvider
 	 */
+	public DefaultEvaluatee(DataProvider dataProvider, int windowNo, int tabNo) {
+		this(dataProvider);
+		this.m_windowNo = windowNo;
+		this.m_tabNo = tabNo;
+	}
+	
+	/**
+	 * @param dataProvider
+	 */
 	public DefaultEvaluatee(DataProvider dataProvider) {
-		this.m_dataProvider = dataProvider;
-		this.m_windowNo = 0;
-		this.m_tabNo = -1;
-		this.m_onlyWindow = false;
-		this.m_onlyTab = null;
+		
 	}
 	
 	/**

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/ProcessParameterPanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/ProcessParameterPanel.java
@@ -1456,7 +1456,7 @@ public class ProcessParameterPanel extends Panel implements
 
 	@Override
 	public String get_ValueAsString(String variableName) {
-		DefaultEvaluatee evaluatee = new DefaultEvaluatee(new FieldEditorDataProvider());
+		DefaultEvaluatee evaluatee = new DefaultEvaluatee(new FieldEditorDataProvider(), m_WindowNo, m_TabNo);
 		return evaluatee.get_ValueAsString(variableName);				
 	}
 

--- a/org.idempiere.test/src/org/idempiere/test/base/LogicExpressionTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/base/LogicExpressionTest.java
@@ -37,6 +37,7 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.compiere.model.GridTab;
 import org.compiere.model.MColumn;
 import org.compiere.model.MTable;
 import org.compiere.model.PO;
@@ -699,18 +700,18 @@ public class LogicExpressionTest  extends AbstractTestCase {
 	public void testNestedProperty() {
 		String expr = "@Processed@=Y & @M_Product_ID.IsBOM@=Y";
 		Env.setContext(Env.getCtx(), 1, "Processed", (String)null);
-		assertFalse(LegacyLogicEvaluator.evaluateLogic(new DefaultEvaluatee(null, 1, 0), expr));
+		assertFalse(LegacyLogicEvaluator.evaluateLogic(new DefaultEvaluatee((GridTab)null, 1, 0), expr));
 		
 		int pchair = 133;
 		Env.setContext(Env.getCtx(), 1, "Processed", "Y");
 		Env.setContext(Env.getCtx(), 1, "M_Product_ID", pchair);
-		assertTrue(LegacyLogicEvaluator.evaluateLogic(new DefaultEvaluatee(null, 1, 0), expr));
+		assertTrue(LegacyLogicEvaluator.evaluateLogic(new DefaultEvaluatee((GridTab)null, 1, 0), expr));
 		
 		Env.setContext(Env.getCtx(), 1, "Processed", (String)null);
-		assertFalse(LogicEvaluator.evaluateLogic(new DefaultEvaluatee(null, 1, 0), expr));
+		assertFalse(LogicEvaluator.evaluateLogic(new DefaultEvaluatee((GridTab)null, 1, 0), expr));
 		
 		Env.setContext(Env.getCtx(), 1, "Processed", "Y");
 		Env.setContext(Env.getCtx(), 1, "M_Product_ID", pchair);
-		assertTrue(LogicEvaluator.evaluateLogic(new DefaultEvaluatee(null, 1, 0), expr));
+		assertTrue(LogicEvaluator.evaluateLogic(new DefaultEvaluatee((GridTab)null, 1, 0), expr));
 	}	
 }


### PR DESCRIPTION
[IDEMPIERE-6423:Process dialog evaluates 'ReadOnly/Display Logic, Mandatory Logic' without windown context](https://idempiere.atlassian.net/browse/IDEMPIERE-6423)


# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

