### PR TITLE
IDEMPIERE-6472 Payment - Amounts not recalculated if no BP/Inv leaving corrupt data

### DIFF
--- a/org.adempiere.base.callout/src/org/compiere/model/CalloutPayment.java
+++ b/org.adempiere.base.callout/src/org/compiere/model/CalloutPayment.java
@@ -372,10 +372,15 @@ public class CalloutPayment extends CalloutEngine
 					return "";
 				}
 				BigDecimal payAmt = (BigDecimal) mTab.getValue(I_C_Payment.COLUMNNAME_PayAmt);
-				if (payAmt != null)
+				if (payAmt != null && payAmt.signum() != 0)
 				{
-					BigDecimal baseCurrencyRate = convertedAmt.divide(payAmt, 6, RoundingMode.HALF_UP);
+					BigDecimal baseCurrencyRate = convertedAmt.divide(payAmt, 12, RoundingMode.HALF_UP);
 					mTab.setValue(I_C_Payment.COLUMNNAME_CurrencyRate, baseCurrencyRate);
+				}
+				else
+				{
+					// divide by zero
+					mTab.setValue(I_C_Payment.COLUMNNAME_CurrencyRate, null);
 				}
 				return "";
 			}
@@ -594,6 +599,13 @@ public class CalloutPayment extends CalloutEngine
 				if (colName.equals(I_C_Payment.COLUMNNAME_PayAmt)) {
 					BigDecimal baseConversionRate = (BigDecimal) mTab.getValue(I_C_Payment.COLUMNNAME_CurrencyRate);
 					BigDecimal converted = (BigDecimal) mTab.getValue(I_C_Payment.COLUMNNAME_ConvertedAmt);
+					if (baseConversionRate == null) {
+						if (converted != null) {
+							baseConversionRate = converted.divide(payAmt, 12, RoundingMode.HALF_UP);
+							mTab.setValue(I_C_Payment.COLUMNNAME_CurrencyRate, baseConversionRate);
+						}
+						return "";
+					}
 					converted = payAmt.multiply(baseConversionRate);
 					int stdPrecision = MCurrency.getStdPrecision(ctx, baseCurrencyId);
 					if (converted.scale() > stdPrecision)


### PR DESCRIPTION
- fix NPE when ConvertedAmt or CurrencyRate are null
- calculate currency rate with 12 decimals - consistency with Conversion Rate calculation in CalloutEngine.rate

https://idempiere.atlassian.net/browse/IDEMPIERE-6472?focusedCommentId=53907

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works