### PR TITLE
IDEMPIERE-6510: NPE on login : Cannot invoke "org.compiere.model.MCou…

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MCountry.java
+++ b/org.adempiere.base/src/org/compiere/model/MCountry.java
@@ -218,9 +218,20 @@ public class MCountry extends X_C_Country
 	/**	Display Language				*/
 	@SuppressWarnings("unused")
 	private static String		s_AD_Language = null;
-	
+
 	/**	Country Cache					*/
-	private static ImmutableIntPOCache<Integer,MCountry>	s_countries = null;
+	private static ImmutableIntPOCache<Integer,MCountry>    s_countries = new ImmutableIntPOCache<Integer,MCountry>(Table_Name, 250, 0, false) {
+		private static final long serialVersionUID = 1106078701451046946L;
+
+		@Override
+		public int reset(int recordId) {
+			if (recordId <= 0)
+				return super.reset(recordId);
+			else 
+				return 0;
+		}
+	};
+
 	/**	Default Country 				*/
 	private static ImmutableIntPOCache<Integer,MCountry>	s_default = new ImmutableIntPOCache<Integer,MCountry>(Table_Name, Table_Name+"|Default", 3);
 	/**	Static Logger					*/


### PR DESCRIPTION
…ntry.getC_Country_ID()" because the return value of "org.compiere.model.MCountry.getDefault()" is null

patch from hengsin

https://idempiere.atlassian.net/browse/IDEMPIERE-6510

# Pull Request Checklist

- [X] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [X] My code follows the best practices of this project
- [X] I have performed a self-review of my own code
- [X] My code is easy to understand and review. 
- [X] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [X] My changes generate no new warnings
### Tests
- [X] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

