### PR TITLE
IDEMPIERE-6527: Read value of ZK_BROWSER_ICON and ZK_BROWSER_TITLE fr…

### DIFF
--- a/org.adempiere.base/src/org/compiere/util/Env.java
+++ b/org.adempiere.base/src/org/compiere/util/Env.java
@@ -138,7 +138,7 @@ public final class Env
 	public static final String UI_CLIENT = "#UIClient";
 	public static final String USER_LEVEL = "#User_Level";
 
-	private static final String PREFIX_SYSTEM_VARIABLE = "$env.";
+	public static final String PREFIX_SYSTEM_VARIABLE = "$env.";
 
 	@Deprecated
 	private final static ContextProvider clientContextProvider = new DefaultContextProvider();
@@ -601,7 +601,7 @@ public final class Env
 		if (context.startsWith(PREFIX_SYSTEM_VARIABLE)) {
 			String retValue = System.getenv(context.substring(PREFIX_SYSTEM_VARIABLE.length()));
 			if (retValue == null)
-				retValue = "";
+				retValue = System.getProperty(context.substring(PREFIX_SYSTEM_VARIABLE.length()), "");
 			return retValue;
 		}
 		String value = ctx.getProperty(context, "");

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/DefaultWebAppInit.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/DefaultWebAppInit.java
@@ -24,6 +24,7 @@ import org.compiere.model.I_AD_SysConfig;
 import org.compiere.model.MSysConfig;
 import org.compiere.model.PO;
 import org.compiere.model.X_AD_SysConfig;
+import org.compiere.util.Env;
 import org.osgi.service.event.Event;
 import org.zkoss.zk.ui.WebApp;
 import org.zkoss.zk.ui.util.WebAppInit;
@@ -45,7 +46,9 @@ public class DefaultWebAppInit implements WebAppInit {
 		this.webApp = wapp;
 		// save app name get from zk.xml to restore when delete app name in system config value
 		AdempiereWebUI.APP_NAME = this.webApp.getAppName();
-		String appNameConfig = MSysConfig.getValue(MSysConfig.ZK_BROWSER_TITLE);
+		
+		String fromFile = Env.getContext(Env.getCtx(), Env.PREFIX_SYSTEM_VARIABLE + MSysConfig.ZK_BROWSER_TITLE);
+		String appNameConfig = MSysConfig.getValue(MSysConfig.ZK_BROWSER_TITLE, fromFile);
 		if (appNameConfig != null){
 			this.webApp.setAppName(appNameConfig);
 		}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/DefaultWebAppInit.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/DefaultWebAppInit.java
@@ -25,6 +25,7 @@ import org.compiere.model.MSysConfig;
 import org.compiere.model.PO;
 import org.compiere.model.X_AD_SysConfig;
 import org.compiere.util.Env;
+import org.compiere.util.Util;
 import org.osgi.service.event.Event;
 import org.zkoss.zk.ui.WebApp;
 import org.zkoss.zk.ui.util.WebAppInit;
@@ -46,9 +47,12 @@ public class DefaultWebAppInit implements WebAppInit {
 		this.webApp = wapp;
 		// save app name get from zk.xml to restore when delete app name in system config value
 		AdempiereWebUI.APP_NAME = this.webApp.getAppName();
-		
-		String fromFile = Env.getContext(Env.getCtx(), Env.PREFIX_SYSTEM_VARIABLE + MSysConfig.ZK_BROWSER_TITLE);
-		String appNameConfig = MSysConfig.getValue(MSysConfig.ZK_BROWSER_TITLE, fromFile);
+
+		String appNameConfig = Env.getContext(Env.getCtx(), Env.PREFIX_SYSTEM_VARIABLE + MSysConfig.ZK_BROWSER_TITLE);
+
+		if (Util.isEmpty(appNameConfig))
+			appNameConfig = MSysConfig.getValue(MSysConfig.ZK_BROWSER_TITLE);
+
 		if (appNameConfig != null){
 			this.webApp.setAppName(appNameConfig);
 		}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/theme/ThemeManager.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/theme/ThemeManager.java
@@ -170,8 +170,14 @@ public final class ThemeManager {
 	 * @return url for browser icon
 	 */
 	public static String getBrowserIcon() {
-		String theme = getTheme();
-		String def = THEME_PATH_PREFIX + theme + ITheme.BROWSER_ICON_IMAGE;
+
+		String def = Env.getContext(Env.getCtx(), Env.PREFIX_SYSTEM_VARIABLE + MSysConfig.ZK_BROWSER_ICON);
+
+		if (Util.isEmpty(def)) {
+			String theme = getTheme();
+			def = THEME_PATH_PREFIX + theme + ITheme.BROWSER_ICON_IMAGE;
+		}
+
 		return MSysConfig.getValue(MSysConfig.ZK_BROWSER_ICON, def);
 	}
 	

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/theme/ThemeManager.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/theme/ThemeManager.java
@@ -173,11 +173,11 @@ public final class ThemeManager {
 
 		String def = Env.getContext(Env.getCtx(), Env.PREFIX_SYSTEM_VARIABLE + MSysConfig.ZK_BROWSER_ICON);
 
-		if (Util.isEmpty(def)) {
-			String theme = getTheme();
-			def = THEME_PATH_PREFIX + theme + ITheme.BROWSER_ICON_IMAGE;
-		}
+		if (!Util.isEmpty(def))
+			return def;
 
+		String theme = getTheme();
+		def = THEME_PATH_PREFIX + theme + ITheme.BROWSER_ICON_IMAGE;
 		return MSysConfig.getValue(MSysConfig.ZK_BROWSER_ICON, def);
 	}
 	


### PR DESCRIPTION
…om the server

https://idempiere.atlassian.net/browse/IDEMPIERE-6527

# Pull Request Checklist

- [X] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [X] My code follows the best practices of this project
- [X] I have performed a self-review of my own code
- [X] My code is easy to understand and review. 
- [X] I have checked my code and corrected any misspellings
- [] In hard-to-understand areas, I have commented my code.
- [X] My changes generate no new warnings
### Tests
- [X] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

