### PR TITLE
IDEMPIERE-6531: _TabInfo_AD_Table_ID / _TabInfo_AD_Table_UU are missi…

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/GridTabVO.java
+++ b/org.adempiere.base/src/org/compiere/model/GridTabVO.java
@@ -347,6 +347,8 @@ public class GridTabVO implements Evaluatee, Serializable
 	public static void updateContext(GridTabVO vo) {
 		Env.setContext(vo.ctx, vo.WindowNo, vo.TabNo, GridTab.CTX_AD_Tab_ID, String.valueOf(vo.AD_Tab_ID));
 		Env.setContext(vo.ctx, vo.WindowNo, vo.TabNo, GridTab.CTX_AD_Tab_UU, vo.AD_Tab_UU);
+		Env.setContext(vo.ctx, vo.WindowNo, vo.TabNo, GridTab.CTX_AD_Table_ID, vo.AD_Table_ID);
+		Env.setContext(vo.ctx, vo.WindowNo, vo.TabNo, GridTab.CTX_AD_Table_UU, vo.AD_Table_UU);
 		Env.setContext(vo.ctx, vo.WindowNo, vo.TabNo, GridTab.CTX_Name, vo.Name);
 		Env.setContext(vo.ctx, vo.WindowNo, vo.TabNo, GridTab.CTX_AccessLevel, vo.AccessLevel);
 		Env.setContext(vo.ctx, vo.WindowNo, vo.TabNo, GridTab.CTX_IsLookupOnlySelection, vo.IsLookupOnlySelection);

--- a/org.adempiere.base/src/org/compiere/model/GridWindowVO.java
+++ b/org.adempiere.base/src/org/compiere/model/GridWindowVO.java
@@ -318,8 +318,7 @@ public class GridWindowVO implements Serializable
 					if (mTabVO != null)
 					{
 						GridTabVO.loadUserDefTab(mTabVO);
-						if (firstTab)
-							GridTabVO.updateContext(mTabVO);
+						GridTabVO.updateContext(mTabVO);
 					}
 
 					if (mTabVO == null && firstTab)
@@ -479,8 +478,7 @@ public class GridWindowVO implements Serializable
 					if (cloneTab == null)
 						return null;
 					clone.Tabs.add(cloneTab);
-					if (clone.Tabs.size() == 1)
-						GridTabVO.updateContext(cloneTab);
+					GridTabVO.updateContext(cloneTab);
 				}
 				//set context, cloneTabs is usually for web client session cache
 				Env.setContext(ctx, windowNo, "IsSOTrx", clone.IsSOTrx);


### PR DESCRIPTION
…ng from context

patch from @hengsin

https://idempiere.atlassian.net/browse/IDEMPIERE-6531

# Pull Request Checklist

- [X] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [X] My code follows the best practices of this project
- [X] I have performed a self-review of my own code
- [X] My code is easy to understand and review. 
- [X] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [X] My changes generate no new warnings
### Tests
- [X] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

