### PR TITLE
IDEMPIERE-6531 _TabInfo_AD_Table_ID / _TabInfo_AD_Table_UU are missin…

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/GridTabVO.java
+++ b/org.adempiere.base/src/org/compiere/model/GridTabVO.java
@@ -719,6 +719,7 @@ public class GridTabVO implements Evaluatee, Serializable
 		clone.TreeDisplayedOn = TreeDisplayedOn;
 		clone.MaxQueryRecords = MaxQueryRecords;
 		clone.AD_Table_ID = AD_Table_ID;
+        clone.AD_Table_UU = AD_Table_UU;
 		clone.AD_Column_ID = AD_Column_ID;
 		clone.Parent_Column_ID = Parent_Column_ID;
 		clone.TableName = TableName;

--- a/org.adempiere.base/src/org/compiere/model/GridWindowVO.java
+++ b/org.adempiere.base/src/org/compiere/model/GridWindowVO.java
@@ -44,9 +44,10 @@ public class GridWindowVO implements Serializable
 	
 	private static final CLogger log = CLogger.getCLogger(GridWindowVO.class);
 
-	/**	Window Cache		*/
+    public static final String GRID_WINDOW_VO_CACHE_NAME = I_AD_Window.Table_Name + "|GridWindowVO";
+    /**	Window Cache		*/
 	private static CCache<Integer,GridWindowVO>	s_windowsvo
-		= new CCache<Integer,GridWindowVO>(I_AD_Window.Table_Name, I_AD_Window.Table_Name+"|GridWindowVO", 10);
+		= new CCache<Integer,GridWindowVO>(I_AD_Window.Table_Name, GRID_WINDOW_VO_CACHE_NAME, 10);
 	
 	/**
 	 * @param AD_Window_ID
@@ -239,7 +240,8 @@ public class GridWindowVO implements Serializable
 		return vo;
 	}   //  create
 
-	private static final CCache<String, ArrayList<GridTabVO>> s_gridTabsCache = new CCache<String, ArrayList<GridTabVO>>(MTab.Table_Name, "GridTabVOs Cache", 100, 0, false, 0);
+    public static final String GRID_TAB_VO_CACHE_NAME = "GridTabVOs Cache";
+    private static final CCache<String, ArrayList<GridTabVO>> s_gridTabsCache = new CCache<String, ArrayList<GridTabVO>>(MTab.Table_Name, GRID_TAB_VO_CACHE_NAME, 100, 0, false, 0);
 	
 	/**
 	 *  Create Window Tabs
@@ -271,8 +273,7 @@ public class GridWindowVO implements Serializable
 				else if (!firstTabIsNull)
 				{
 					GridTabVO.loadUserDefTab(tabvo);
-					if (mWindowVO.Tabs.isEmpty())
-						GridTabVO.updateContext(tabvo);
+                    GridTabVO.updateContext(tabvo);
 					if (!tabvo.IsReadOnly && "N".equals(mWindowVO.IsReadWrite))
 						tabvo.IsReadOnly = true;
 					mWindowVO.Tabs.add(tabvo);

--- a/org.idempiere.test/src/org/idempiere/test/adwindow/GridWindowTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/adwindow/GridWindowTest.java
@@ -30,20 +30,8 @@ import java.util.ArrayList;
 import java.util.Optional;
 
 import org.adempiere.webui.apps.AEnv;
-import org.compiere.model.GridFieldVO;
-import org.compiere.model.GridWindowVO;
-import org.compiere.model.I_AD_Window;
-import org.compiere.model.MField;
-import org.compiere.model.MSession;
-import org.compiere.model.MTab;
-import org.compiere.model.MUserDefField;
-import org.compiere.model.MUserDefTab;
-import org.compiere.model.MUserDefWin;
-import org.compiere.model.SystemIDs;
-import org.compiere.util.CCache;
-import org.compiere.util.CacheInterface;
-import org.compiere.util.CacheMgt;
-import org.compiere.util.Env;
+import org.compiere.model.*;
+import org.compiere.util.*;
 import org.idempiere.test.AbstractTestCase;
 import org.idempiere.test.DictionaryIDs;
 import org.junit.jupiter.api.Test;
@@ -61,26 +49,25 @@ public class GridWindowTest extends AbstractTestCase {
 	@Test
 	public void testGridWindowCache() {
 		int testRecordIdFieldId = 207570; //advanced field
-		String gridWindowVOCacheName = I_AD_Window.Table_Name+"|GridWindowVO";
-		String gridTabVOsCacheName = "GridTabVOs Cache";
-		
+
 		//init static cache
 		GridWindowVO.get(SystemIDs.WINDOW_TEST, 0);
-		
+
 		//find cache via name
 		CCache<?, ?> gridTabVOsCache = null;
 		CCache<?, ?> gridWindowVOCache = null;
 		CacheInterface[] cacheInstances = CacheMgt.get().getInstancesAsArray();
 		for(CacheInterface cacheInstance : cacheInstances) {
 			if (cacheInstance instanceof CCache<?, ?> ccache) {
-				if (ccache.getName().equals(gridTabVOsCacheName)) {
+				if (ccache.getName().equals(GridWindowVO.GRID_TAB_VO_CACHE_NAME)) {
 					gridTabVOsCache = ccache;
-				} else if (ccache.getName().equals(gridWindowVOCacheName)) {
+				} else if (ccache.getName().equals(GridWindowVO.GRID_WINDOW_VO_CACHE_NAME)) {
 					gridWindowVOCache = ccache;
 				}
-			}			
+                if (gridTabVOsCache != null && gridWindowVOCache != null) break;
+			}
 		}
-		
+
 		assertNotNull(gridWindowVOCache, "Can't find cache for GridWindowVO");
 		assertNotNull(gridTabVOsCache, "Can't find cache for GridTabVOs");
 		gridWindowVOCache.reset();
@@ -277,4 +264,60 @@ public class GridWindowTest extends AbstractTestCase {
 			win.deleteEx(true);			
 		}
 	}
+
+    @Test
+    public void testGridTabContextInfo() {
+        //find cache via name
+        CCache<?, ?> gridTabVOsCache = null;
+        CCache<?, ?> gridWindowVOCache = null;
+        CacheInterface[] cacheInstances = CacheMgt.get().getInstancesAsArray();
+        for(CacheInterface cacheInstance : cacheInstances) {
+            if (cacheInstance instanceof CCache<?, ?> ccache) {
+                if (ccache.getName().equals(GridWindowVO.GRID_TAB_VO_CACHE_NAME)) {
+                    gridTabVOsCache = ccache;
+                } else if (ccache.getName().equals(GridWindowVO.GRID_WINDOW_VO_CACHE_NAME)) {
+                    gridWindowVOCache = ccache;
+                }
+                if (gridTabVOsCache != null && gridWindowVOCache != null) break;
+            }
+        }
+
+        if (gridWindowVOCache != null) {
+            gridWindowVOCache.reset();
+            assertNotNull(gridTabVOsCache);
+            gridTabVOsCache.reset();
+        }
+
+        //test without gridwindowvo and gridtabvo cache
+        GridWindowVO windowVO = GridWindowVO.create(Env.getCtx(), 1, SystemIDs.WINDOW_BUSINESS_PARTNER);
+        assertNotNull(windowVO.Tabs, "Failed to retrieve GridTabVOs");
+        assertFalse(windowVO.Tabs.isEmpty(), "Failed to retrieve GridTabVOs");
+        for (GridTabVO tab : windowVO.Tabs) {
+            assertFalse(Util.isEmpty(Env.getContext(Env.getCtx(), tab.WindowNo, tab.TabNo, GridTab.CTX_AD_Tab_ID)));
+            assertFalse(Util.isEmpty(Env.getContext(Env.getCtx(), tab.WindowNo, tab.TabNo, GridTab.CTX_AD_Tab_UU)));
+            assertFalse(Util.isEmpty(Env.getContext(Env.getCtx(), tab.WindowNo, tab.TabNo, GridTab.CTX_AD_Table_ID)));
+            assertFalse(Util.isEmpty(Env.getContext(Env.getCtx(), tab.WindowNo, tab.TabNo, GridTab.CTX_AD_Table_UU)));
+            assertFalse(Util.isEmpty(Env.getContext(Env.getCtx(), tab.WindowNo, tab.TabNo, GridTab.CTX_Name)));
+            assertFalse(Util.isEmpty(Env.getContext(Env.getCtx(), tab.WindowNo, tab.TabNo, GridTab.CTX_IsSortTab)));
+            assertFalse(Util.isEmpty(Env.getContext(Env.getCtx(), tab.WindowNo, tab.TabNo, GridTab.CTX_AccessLevel)));
+            assertFalse(Util.isEmpty(Env.getContext(Env.getCtx(), tab.WindowNo, tab.TabNo, GridTab.CTX_IsLookupOnlySelection)));
+            assertFalse(Util.isEmpty(Env.getContext(Env.getCtx(), tab.WindowNo, tab.TabNo, GridTab.CTX_IsAllowAdvancedLookup)));
+        }
+
+        //test with gridwindowvo and gridtabvo cache
+        windowVO = GridWindowVO.create(Env.getCtx(), 2, SystemIDs.WINDOW_BUSINESS_PARTNER);
+        assertNotNull(windowVO.Tabs, "Failed to retrieve GridTabVOs");
+        assertFalse(windowVO.Tabs.isEmpty(), "Failed to retrieve GridTabVOs");
+        for (GridTabVO tab : windowVO.Tabs) {
+            assertFalse(Util.isEmpty(Env.getContext(Env.getCtx(), tab.WindowNo, tab.TabNo, GridTab.CTX_AD_Tab_ID)));
+            assertFalse(Util.isEmpty(Env.getContext(Env.getCtx(), tab.WindowNo, tab.TabNo, GridTab.CTX_AD_Tab_UU)));
+            assertFalse(Util.isEmpty(Env.getContext(Env.getCtx(), tab.WindowNo, tab.TabNo, GridTab.CTX_AD_Table_ID)));
+            assertFalse(Util.isEmpty(Env.getContext(Env.getCtx(), tab.WindowNo, tab.TabNo, GridTab.CTX_AD_Table_UU)));
+            assertFalse(Util.isEmpty(Env.getContext(Env.getCtx(), tab.WindowNo, tab.TabNo, GridTab.CTX_Name)));
+            assertFalse(Util.isEmpty(Env.getContext(Env.getCtx(), tab.WindowNo, tab.TabNo, GridTab.CTX_IsSortTab)));
+            assertFalse(Util.isEmpty(Env.getContext(Env.getCtx(), tab.WindowNo, tab.TabNo, GridTab.CTX_AccessLevel)));
+            assertFalse(Util.isEmpty(Env.getContext(Env.getCtx(), tab.WindowNo, tab.TabNo, GridTab.CTX_IsLookupOnlySelection)));
+            assertFalse(Util.isEmpty(Env.getContext(Env.getCtx(), tab.WindowNo, tab.TabNo, GridTab.CTX_IsAllowAdvancedLookup)));
+        }
+    }
 }


### PR DESCRIPTION
…g from context

https://idempiere.atlassian.net/browse/IDEMPIERE-6531

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [x] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

