### PR TITLE
IDEMPIERE-6532 Regression: For Tab 0, Env.parseContext is always gett…

### DIFF
--- a/org.adempiere.base/src/org/compiere/util/DefaultEvaluatee.java
+++ b/org.adempiere.base/src/org/compiere/util/DefaultEvaluatee.java
@@ -195,7 +195,7 @@ public class DefaultEvaluatee implements Evaluatee {
 						m_onlyTab != null ? m_onlyTab.booleanValue() : false);
 				value = Env.getContext(Env.getCtx(), m_windowNo, m_tabNo, keycolumnName, m_onlyTab != null ? m_onlyTab.booleanValue() : false);
 			}
-			else if (m_tabNo <= 0)
+			else if (m_tabNo < 0)
 			{
 				if (!tabOnly)
 					value = Env.getContext (ctx, m_windowNo, variableName, m_onlyWindow);

--- a/org.idempiere.test/src/org/idempiere/test/base/EnvTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/base/EnvTest.java
@@ -289,6 +289,13 @@ public class EnvTest extends AbstractTestCase {
 		String validationCode = "M_Warehouse.AD_Org_ID=@NonExisting_AD_Org_ID@";
 		String dynamicValid = Env.parseContext(Env.getCtx(), -1, 0, validationCode, false);
 		assertEquals("M_Warehouse.AD_Org_ID=11", dynamicValid, "Unexpected parsed text for "+validationCode);
+
+        //TabNo 0 for null _ID
+        expr = "AD_User.C_BPartner_ID IN (@C_BPartner_ID@, @Bill_BPartner_ID@)";
+        Env.setContext(Env.getCtx(), windowNo, 0, "C_BPartner_ID", DictionaryIDs.C_BPartner.C_AND_W.id);
+        Env.setContext(Env.getCtx(), windowNo, 0, "Bill_BPartner_ID", null);
+        parsedText = Env.parseContext(Env.getCtx(), windowNo, 0, expr, false);
+        assertEquals("AD_User.C_BPartner_ID IN (%s, 0)".formatted(DictionaryIDs.C_BPartner.C_AND_W.id), parsedText, "Unexpected parsed text for "+expr);
 	}
 
 	@Test


### PR DESCRIPTION
…ing value from window context instead of from tab 0 context

https://idempiere.atlassian.net/browse/IDEMPIERE-6532

# Pull Request Checklist

- [ ] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [ ] My code follows the best practices of this project
- [ ] I have performed a self-review of my own code
- [ ] My code is easy to understand and review. 
- [ ] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [ ] My changes generate no new warnings
### Tests
- [ ] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

