### PR TITLE
IDEMPIERE-6521 Create RUN_ImportIdempiereDev.sh

### DIFF
--- a/RUN_ImportIdempiereDev.sh
+++ b/RUN_ImportIdempiereDev.sh
@@ -108,7 +108,7 @@ then
 
     echo "*** Applying migration scripts ***"
     IDEMPIERE_HOME=$( dirname "$($READLINK_CMD -f "${BASH_SOURCE[0]}")" )
-    bash $IDEMPIERE_HOME/RUN_SyncDBDev.sh "$@"
+    bash $IDEMPIERE_HOME/RUN_SyncDBDev.sh "$1"
 
     DBIMPORT_FOLDER="${2:-$DBIMPORT_FOLDER}"
     if [ -f "$DBIMPORT_FOLDER"/post_$ADEMPIERE_DB_NAME.sql ]


### PR DESCRIPTION
- fix issue when passing two parameters, the RUN_SyncDB has a second parameter with different meaning

https://idempiere.atlassian.net/browse/IDEMPIERE-6521

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
