### PR TITLE
IDEMPIERE-6553:Add logs to investigate why the model event handler is…

### DIFF
--- a/org.adempiere.base/src/org/adempiere/base/event/annotations/BaseEventHandler.java
+++ b/org.adempiere.base/src/org/adempiere/base/event/annotations/BaseEventHandler.java
@@ -46,7 +46,7 @@ public abstract class BaseEventHandler implements EventHandler {
 	/** event topic:method */
 	protected final Map<String, Method> eventTopicMap = new HashMap<String, Method>();
 	private String filter;
-	private Class<? extends EventDelegate> delegateClass;
+	protected Class<? extends EventDelegate> delegateClass;
 
 	/**
 	 * @param delegateClass

--- a/org.adempiere.base/src/org/adempiere/base/event/annotations/ModelEventHandler.java
+++ b/org.adempiere.base/src/org/adempiere/base/event/annotations/ModelEventHandler.java
@@ -26,11 +26,13 @@ package org.adempiere.base.event.annotations;
 
 import java.lang.reflect.Field;
 import java.util.function.BiFunction;
+import java.util.logging.Level;
 
 import org.adempiere.base.Model;
 import org.adempiere.base.event.EventHelper;
 import org.adempiere.base.event.EventManager;
 import org.compiere.model.PO;
+import org.compiere.util.CLogger;
 import org.osgi.service.event.Event;
 
 /**
@@ -44,6 +46,7 @@ public final class ModelEventHandler<T extends PO> extends BaseEventHandler {
 	private Class<T> modelClassType;
 	private String tableName;
 	private BiFunction<T, Event, ? extends ModelEventDelegate<T>> supplier;
+	private static CLogger log = CLogger.getCLogger(ModelEventHandler.class);
 	
 	/**
 	 * @param modelClassType
@@ -85,9 +88,14 @@ public final class ModelEventHandler<T extends PO> extends BaseEventHandler {
 		if (po == null || modelClassType == null)
 			return;
 		
-		if (!modelClassType.isAssignableFrom(po.getClass()))
-			return;
+		if (!modelClassType.isAssignableFrom(po.getClass())) {
+			if (log.isLoggable(Level.WARNING))
+		        log.warning(String.format("ModelEventHandler %s was skipped: the po class %s is not assignable to the expected type %s",
+		            delegateClass.getName(), po.getClass().getName(), modelClassType.getName()));
+		    return;
+		}
 		
+			
 		super.handleEvent(event);
 	}
 

--- a/org.adempiere.base/src/org/adempiere/base/event/annotations/ModelEventHandler.java
+++ b/org.adempiere.base/src/org/adempiere/base/event/annotations/ModelEventHandler.java
@@ -89,8 +89,8 @@ public final class ModelEventHandler<T extends PO> extends BaseEventHandler {
 			return;
 		
 		if (!modelClassType.isAssignableFrom(po.getClass())) {
-			if (log.isLoggable(Level.WARNING))
-		        log.warning(String.format("ModelEventHandler %s was skipped: the po class %s is not assignable to the expected type %s",
+			if (log.isLoggable(Level.INFO))
+		        log.info(String.format("ModelEventHandler %s was skipped: the po class %s is not assignable to the expected type %s",
 		            delegateClass.getName(), po.getClass().getName(), modelClassType.getName()));
 		    return;
 		}


### PR DESCRIPTION
…n't being triggered

[Add logs to investigate why the model event handler isn't being triggered](https://idempiere.atlassian.net/browse/IDEMPIERE-6553)


# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

