### PR TITLE
IDEMPIERE-6596 Implement $sysconfig. prefix for access to AD_SysConfi…

### DIFF
--- a/org.adempiere.base/src/org/compiere/util/Env.java
+++ b/org.adempiere.base/src/org/compiere/util/Env.java
@@ -139,6 +139,8 @@ public final class Env
 	public static final String USER_LEVEL = "#User_Level";
 
 	public static final String PREFIX_SYSTEM_VARIABLE = "$env.";
+	
+	public static final String PREFIX_SYSCONFIG_VARIABLE = "$sysconfig.";
 
 	@Deprecated
 	private final static ContextProvider clientContextProvider = new DefaultContextProvider();
@@ -602,6 +604,11 @@ public final class Env
 			String retValue = System.getenv(context.substring(PREFIX_SYSTEM_VARIABLE.length()));
 			if (retValue == null)
 				retValue = System.getProperty(context.substring(PREFIX_SYSTEM_VARIABLE.length()), "");
+			return retValue;
+		} else if (context.startsWith(PREFIX_SYSCONFIG_VARIABLE)) {
+			String retValue = MSysConfig.getValue(context.substring(PREFIX_SYSCONFIG_VARIABLE.length()), Env.getAD_Client_ID(Env.getCtx()), Env.getAD_Org_ID(Env.getCtx()));
+			if (retValue == null)
+				retValue = "";
 			return retValue;
 		}
 		String value = ctx.getProperty(context, "");

--- a/org.adempiere.base/src/org/compiere/util/Env.java
+++ b/org.adempiere.base/src/org/compiere/util/Env.java
@@ -605,11 +605,8 @@ public final class Env
 			if (retValue == null)
 				retValue = System.getProperty(context.substring(PREFIX_SYSTEM_VARIABLE.length()), "");
 			return retValue;
-		} else if (context.startsWith(PREFIX_SYSCONFIG_VARIABLE)) {
-			String retValue = MSysConfig.getValue(context.substring(PREFIX_SYSCONFIG_VARIABLE.length()), Env.getAD_Client_ID(Env.getCtx()), Env.getAD_Org_ID(Env.getCtx()));
-			if (retValue == null)
-				retValue = "";
-			return retValue;
+		} else if (isSysConfig(context)) {
+			return getSysConfigValue(context, Env.getAD_Org_ID(ctx));
 		}
 		String value = ctx.getProperty(context, "");
 		if (Util.isEmpty(value) && !context.startsWith("#"))
@@ -635,7 +632,12 @@ public final class Env
 		String s = ctx.getProperty(WindowNo+"|"+context);
 		if (s == null)
 		{
-			//	Explicit Base Values
+			if (isSysConfig(context))
+			{
+				int AD_Org_ID = Env.getContextAsInt(ctx, WindowNo, Env.AD_ORG_ID, false);
+				return getSysConfigValue(context, AD_Org_ID);
+			}
+			//	Explicit Base Values			
 			if (Env.isGlobalVariable(context) || Env.isPreference(context))
 				return getContext(ctx, context);
 			if (onlyWindow)			//	no Default values
@@ -644,6 +646,13 @@ public final class Env
 		}
 		return s;
 	}	//	getContext
+
+	private static String getSysConfigValue(String context, int AD_Org_ID) {
+		String retValue = MSysConfig.getValue(context.substring(PREFIX_SYSCONFIG_VARIABLE.length()), Env.getAD_Client_ID(Env.getCtx()), AD_Org_ID);
+		if (retValue == null)
+			retValue = "";
+		return retValue;
+	}
 
 	/**
 	 *	Get Value of Context for WindowNo.<br/>
@@ -678,7 +687,14 @@ public final class Env
 			return s != null ? s : "";
 		//
 		if (Util.isEmpty(s))
+		{
+			if (isSysConfig(context))
+			{
+				int AD_Org_ID = Env.getContextAsInt(ctx, WindowNo, TabNo, Env.AD_ORG_ID);
+				return getSysConfigValue(context, AD_Org_ID);
+			}
 			return getContext(ctx, WindowNo, context, false);
+		}
 		return s;
 	}	//	getContext
 
@@ -2258,9 +2274,9 @@ public final class Env
 	}
 
 	/**
-	 * Verifies if a context variable name is global, this is, starting with:
-	 *   #  Login
-	 *   $  Accounting
+	 * Verifies if a context variable name is global, this is, starting with:<br/>
+	 *   #  Login<br/>
+	 *   $  Accounting<br/>
 	 *   +  Role Injected
 	 * @param variable
 	 * @return
@@ -2272,7 +2288,7 @@ public final class Env
 	}
 
 	/**
-	 * Verifies if a context variable name is a preference, this is, starting with:
+	 * Verifies if a context variable name is a preference, this is, starting with:<br/>
 	 *   P| Preference
 	 * @param variable
 	 * @return
@@ -2281,4 +2297,13 @@ public final class Env
 		return variable.startsWith("P|");
 	}
 
+	/**
+	 * Verifies if a context variable name is a system configuration, this is, starting with:<br/>
+	 *   $sysconfig.
+	 * @param variable
+	 * @return
+	 */
+	public static boolean isSysConfig(String variable) {
+		return variable.startsWith(PREFIX_SYSCONFIG_VARIABLE);
+	}
 }   //  Env

--- a/org.idempiere.test/src/org/idempiere/test/base/EnvTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/base/EnvTest.java
@@ -296,6 +296,13 @@ public class EnvTest extends AbstractTestCase {
         Env.setContext(Env.getCtx(), windowNo, 0, "Bill_BPartner_ID", null);
         parsedText = Env.parseContext(Env.getCtx(), windowNo, 0, expr, false);
         assertEquals("AD_User.C_BPartner_ID IN (%s, 0)".formatted(DictionaryIDs.C_BPartner.C_AND_W.id), parsedText, "Unexpected parsed text for "+expr);
+        
+        // AD_SysConfig
+        // @$sysconfig.ZK_MAX_UPLOAD_SIZE@
+        expr = "@"+Env.PREFIX_SYSCONFIG_VARIABLE + MSysConfig.ZK_MAX_UPLOAD_SIZE+"@";
+        String sysConfigValue = MSysConfig.getValue(MSysConfig.ZK_MAX_UPLOAD_SIZE, Env.getAD_Client_ID(Env.getCtx()), Env.getAD_Org_ID(Env.getCtx()));
+        parsedText = Env.parseContext(Env.getCtx(), -1, expr, false);
+        assertEquals(sysConfigValue, parsedText, "Unexpected parsed text for "+expr);
 	}
 
 	@Test

--- a/org.idempiere.test/src/org/idempiere/test/base/EnvTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/base/EnvTest.java
@@ -303,6 +303,14 @@ public class EnvTest extends AbstractTestCase {
         String sysConfigValue = MSysConfig.getValue(MSysConfig.ZK_MAX_UPLOAD_SIZE, Env.getAD_Client_ID(Env.getCtx()), Env.getAD_Org_ID(Env.getCtx()));
         parsedText = Env.parseContext(Env.getCtx(), -1, expr, false);
         assertEquals(sysConfigValue, parsedText, "Unexpected parsed text for "+expr);
+        // test logic evaluation
+        evaluatee = new DefaultEvaluatee(null, -1, -1, false);
+		expr = "@"+Env.PREFIX_SYSCONFIG_VARIABLE + MSysConfig.ZK_MAX_UPLOAD_SIZE+"@='"+sysConfigValue+"'";
+		evaluation = Evaluator.evaluateLogic(evaluatee, expr);
+		assertTrue(evaluation, "Unexpected logic evaluation result");
+		expr = "@"+Env.PREFIX_SYSCONFIG_VARIABLE + MSysConfig.ZK_MAX_UPLOAD_SIZE+"@='0'";
+		evaluation = Evaluator.evaluateLogic(evaluatee, expr);
+		assertFalse(evaluation, "Unexpected logic evaluation result");
 	}
 
 	@Test


### PR DESCRIPTION
…g value in context variable expression

https://idempiere.atlassian.net/browse/IDEMPIERE-6596

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [x] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

