### PR TITLE
IDEMPIERE-6584:Ldap user can't co-exist with MSysConfig.USE_EMAIL_FOR_LOGIN

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MUser.java
+++ b/org.adempiere.base/src/org/compiere/model/MUser.java
@@ -231,7 +231,7 @@ public class MUser extends X_AD_User implements ImmutablePOSupport
 		
 		StringBuilder where = new StringBuilder("Password IS NOT NULL AND ");
 		if (email_login)
-			where.append("EMail=?");
+			where.append("COALESCE(LDAPUser,EMail)=?");
 		else
 			where.append("COALESCE(LDAPUser,Name)=?");
 		where.append(" AND")
@@ -995,7 +995,7 @@ public class MUser extends X_AD_User implements ImmutablePOSupport
 				}
 				// email with password must be unique on the same tenant
 				int cnt = DB.getSQLValue(get_TrxName(),
-						"SELECT COUNT(*) FROM AD_User WHERE Password IS NOT NULL AND EMail=? AND AD_Client_ID=? AND AD_User_ID!=?",
+						"SELECT COUNT(*) FROM AD_User WHERE Password IS NOT NULL AND COALESCE(LDAPUser,EMail)=? AND AD_Client_ID=? AND AD_User_ID!=?",
 						getEMail(), getAD_Client_ID(), getAD_User_ID());
 				if (cnt > 0) {
 					log.saveError("SaveError", Msg.getMsg(getCtx(), DBException.SAVE_ERROR_NOT_UNIQUE_MSG, true) + Msg.getElement(getCtx(), COLUMNNAME_EMail));
@@ -1077,7 +1077,7 @@ public class MUser extends X_AD_User implements ImmutablePOSupport
 		sql.append("WHERE u.Password IS NOT NULL AND ur.AD_Client_ID=? AND ");		//	#1/2
 		boolean email_login = MSysConfig.getBooleanValue(MSysConfig.USE_EMAIL_FOR_LOGIN, false);
 		if (email_login)
-			sql.append("u.EMail=?");
+			sql.append("COALESCE(u.LDAPUser,u.EMail)=?");
 		else
 			sql.append("COALESCE(u.LDAPUser,u.Name)=?");
 		sql.append(" AND u.IsActive='Y'").append(" AND EXISTS (SELECT * FROM AD_Client c WHERE u.AD_Client_ID=c.AD_Client_ID AND c.IsActive='Y')");

--- a/org.adempiere.base/src/org/compiere/model/MUser.java
+++ b/org.adempiere.base/src/org/compiere/model/MUser.java
@@ -994,9 +994,12 @@ public class MUser extends X_AD_User implements ImmutablePOSupport
 					return false;
 				}
 				// email with password must be unique on the same tenant
+				String emailToValidate = getLDAPUser();
+				if (Util.isEmpty(emailToValidate))
+					emailToValidate = getEMail();
 				int cnt = DB.getSQLValue(get_TrxName(),
 						"SELECT COUNT(*) FROM AD_User WHERE Password IS NOT NULL AND COALESCE(LDAPUser,EMail)=? AND AD_Client_ID=? AND AD_User_ID!=?",
-						getEMail(), getAD_Client_ID(), getAD_User_ID());
+						emailToValidate, getAD_Client_ID(), getAD_User_ID());
 				if (cnt > 0) {
 					log.saveError("SaveError", Msg.getMsg(getCtx(), DBException.SAVE_ERROR_NOT_UNIQUE_MSG, true) + Msg.getElement(getCtx(), COLUMNNAME_EMail));
 					return false;

--- a/org.adempiere.base/src/org/compiere/util/Login.java
+++ b/org.adempiere.base/src/org/compiere/util/Login.java
@@ -300,7 +300,7 @@ public class Login
 		boolean email_login = MSysConfig.getBooleanValue(MSysConfig.USE_EMAIL_FOR_LOGIN, false);
 		String userNameCol;
 		if (email_login)
-			userNameCol = "AD_User.EMail";
+			userNameCol = "COALESCE(AD_User.LDAPUser,AD_User.EMail)";
 		else
 			userNameCol = "COALESCE(AD_User.LDAPUser,AD_User.Name)";
 
@@ -1360,7 +1360,7 @@ public class Login
 
 		StringBuilder where = new StringBuilder("Password IS NOT NULL AND ");
 		if (email_login)
-			where.append("EMail=?");
+			where.append("COALESCE(LDAPUser,EMail)=?");
 		else
 			where.append("COALESCE(LDAPUser,Name)=?");
 
@@ -1701,7 +1701,7 @@ public class Login
 		sql.append("WHERE u.Password IS NOT NULL AND ur.AD_Client_ID=? AND ");		
 		boolean email_login = MSysConfig.getBooleanValue(MSysConfig.USE_EMAIL_FOR_LOGIN, false);
 		if (email_login)
-			sql.append("u.EMail=?");
+			sql.append("COALESCE(u.LDAPUser,u.EMail)=?");
 		else
 			sql.append("COALESCE(u.LDAPUser,u.Name)=?");
 		sql.append(" AND r.IsMasterRole='N'");

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/LoginPanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/LoginPanel.java
@@ -189,15 +189,13 @@ public class LoginPanel extends Window implements EventListener<Event>
 							    	onUserIdChange(AD_User_ID);
 							    	if (MSystem.isZKRememberUserAllowed()) {
 							    		String fillUser = null;
-							    		if (email_login) {
-							    			fillUser = user.getEMail();
-							    		} else {
-							    			if (user.getLDAPUser() != null && user.getLDAPUser().length() > 0) {
-							    				fillUser = user.getLDAPUser();
-							    			} else {
-							    				fillUser = user.getName();
-							    			}
-							    		}
+						    			if (user.getLDAPUser() != null && user.getLDAPUser().length() > 0) {
+						    				fillUser = user.getLDAPUser();
+						    			} else if (email_login){
+						    				fillUser = user.getEMail();
+						    			}else {
+						    				fillUser = user.getName();
+						    			}
 							    		if (MSystem.isUseLoginPrefix()) {
 							    			MClient client = MClient.get(session.getAD_Client_ID());
 							    			if (! Util.isEmpty(client.getLoginPrefix())) {
@@ -551,7 +549,7 @@ public class LoginPanel extends Window implements EventListener<Event>
 		{
 			String column;
 			if (email_login)
-				column = "EMail";
+				column = "COALESCE(LDAPUser,EMail)";
 			else
 				column = "COALESCE(LDAPUser,Name)";
 			List<MUser> users = new Query(Env.getCtx(), MUser.Table_Name, "Password IS NOT NULL AND IsActive='Y' AND " + column + "=?", null)
@@ -758,7 +756,7 @@ public class LoginPanel extends Window implements EventListener<Event>
 		boolean email_login = MSysConfig.getBooleanValue(MSysConfig.USE_EMAIL_FOR_LOGIN, false);
     	StringBuilder whereClause = new StringBuilder("Password IS NOT NULL AND ");
 		if (email_login)
-			whereClause.append("EMail=?");
+			whereClause.append("COALESCE(LDAPUser,EMail)=?");
 		else
 			whereClause.append("COALESCE(LDAPUser,Name)=?");
 		whereClause.append(" AND")

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/ResetPasswordPanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/ResetPasswordPanel.java
@@ -305,8 +305,7 @@ public class ResetPasswordPanel extends Window implements EventListener<Event>
     	sql.append("FROM AD_User ");
     	sql.append("WHERE IsActive='Y' ");
    		sql.append("AND COALESCE(LDAPUser,Name)=? ");
-   		// TODO: re-check here
-    	sql.append("AND EMail=? ");
+    	sql.append("AND COALESCE(LDAPUser, EMail)=? ");
     	sql.append("AND SecurityQuestion IS NOT NULL ");    	
     	sql.append("ORDER BY AD_Client_ID DESC");
     	
@@ -367,7 +366,7 @@ public class ResetPasswordPanel extends Window implements EventListener<Event>
     	StringBuilder whereClause = new StringBuilder("Password IS NOT NULL ");
 		whereClause.append("AND COALESCE(LDAPUser,Name)=? ");
 		//TODO:recheck here
-    	whereClause.append("AND EMail=? ");
+    	whereClause.append("AND COALESCE(LDAPUser,EMail)=? ");
 		whereClause.append(" AND")
 				.append(" EXISTS (SELECT * FROM AD_User_Roles ur")
 				.append("         INNER JOIN AD_Role r ON (ur.AD_Role_ID=r.AD_Role_ID)")
@@ -402,8 +401,7 @@ public class ResetPasswordPanel extends Window implements EventListener<Event>
     	{
 	    	StringBuilder whereClause = new StringBuilder("Password IS NOT NULL ");
 			whereClause.append("AND COALESCE(LDAPUser,Name)=? ");
-			// TODO:recheck here
-    		whereClause.append("AND EMail=? ");
+    		whereClause.append("AND COALESCE(LDAPUser,EMail)=? ");
 			whereClause.append(" AND")
 					.append(" EXISTS (SELECT * FROM AD_User_Roles ur")
 					.append("         INNER JOIN AD_Role r ON (ur.AD_Role_ID=r.AD_Role_ID)")
@@ -431,7 +429,7 @@ public class ResetPasswordPanel extends Window implements EventListener<Event>
 	    	
 	    	StringBuilder whereClause = new StringBuilder("Password IS NOT NULL AND ");
 	    	
-			whereClause.append("EMail=?");//TODO:recheck here
+			whereClause.append("COALESCE(LDAPUser,EMail)=?");
 			whereClause.append(" AND")
 					.append(" EXISTS (SELECT * FROM AD_User_Roles ur")
 					.append("         INNER JOIN AD_Role r ON (ur.AD_Role_ID=r.AD_Role_ID)")

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/ResetPasswordPanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/ResetPasswordPanel.java
@@ -305,6 +305,7 @@ public class ResetPasswordPanel extends Window implements EventListener<Event>
     	sql.append("FROM AD_User ");
     	sql.append("WHERE IsActive='Y' ");
    		sql.append("AND COALESCE(LDAPUser,Name)=? ");
+   		// TODO: re-check here
     	sql.append("AND EMail=? ");
     	sql.append("AND SecurityQuestion IS NOT NULL ");    	
     	sql.append("ORDER BY AD_Client_ID DESC");
@@ -365,6 +366,7 @@ public class ResetPasswordPanel extends Window implements EventListener<Event>
 
     	StringBuilder whereClause = new StringBuilder("Password IS NOT NULL ");
 		whereClause.append("AND COALESCE(LDAPUser,Name)=? ");
+		//TODO:recheck here
     	whereClause.append("AND EMail=? ");
 		whereClause.append(" AND")
 				.append(" EXISTS (SELECT * FROM AD_User_Roles ur")
@@ -400,6 +402,7 @@ public class ResetPasswordPanel extends Window implements EventListener<Event>
     	{
 	    	StringBuilder whereClause = new StringBuilder("Password IS NOT NULL ");
 			whereClause.append("AND COALESCE(LDAPUser,Name)=? ");
+			// TODO:recheck here
     		whereClause.append("AND EMail=? ");
 			whereClause.append(" AND")
 					.append(" EXISTS (SELECT * FROM AD_User_Roles ur")
@@ -427,7 +430,8 @@ public class ResetPasswordPanel extends Window implements EventListener<Event>
 	    		throw new IllegalArgumentException(Msg.getMsg(m_ctx, "AnswerMandatory"));
 	    	
 	    	StringBuilder whereClause = new StringBuilder("Password IS NOT NULL AND ");
-			whereClause.append("EMail=?");
+	    	
+			whereClause.append("EMail=?");//TODO:recheck here
 			whereClause.append(" AND")
 					.append(" EXISTS (SELECT * FROM AD_User_Roles ur")
 					.append("         INNER JOIN AD_Role r ON (ur.AD_Role_ID=r.AD_Role_ID)")

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/LoginWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/LoginWindow.java
@@ -470,10 +470,14 @@ public class LoginWindow extends Window implements EventListener<Event>
     	MUser user = MUser.get(ctx, Env.getAD_User_ID(ctx));
     	String loginName;
 		boolean email_login = MSysConfig.getBooleanValue(MSysConfig.USE_EMAIL_FOR_LOGIN, false);
-		if (email_login)
+		if (user.getLDAPUser() != null) {
+			loginName = user.getLDAPUser();
+		}else if (email_login) {
 			loginName = user.getEMail();
-		else
-			loginName = user.getLDAPUser() != null ? user.getLDAPUser() : user.getName();
+		}else {
+			loginName = user.getName();
+		}
+
     	loginOk(loginName, true, login.getClients());
     	getDesktop().getSession().setAttribute(AdempiereWebUI.CHECK_AD_USER_ID_ATTR, Env.getAD_User_ID(ctx));
     	pnlRole.setChangeRole(true);

--- a/org.idempiere.webservices/WEB-INF/src/org/idempiere/adinterface/CompiereService.java
+++ b/org.idempiere.webservices/WEB-INF/src/org/idempiere/adinterface/CompiereService.java
@@ -260,10 +260,13 @@ public class CompiereService {
 		m_locale = Lang;
 		boolean email_login = MSysConfig.getBooleanValue(MSysConfig.USE_EMAIL_FOR_LOGIN, false);
 		MUser user = MUser.get(getCtx(), m_AD_User_ID);
-		if (email_login)
+		if (!Util.isEmpty(user.getLDAPUser())) {
+			m_userName = user.getLDAPUser();
+		}else if (email_login) {
 			m_userName = user.getEMail();
-		else
-			m_userName = Util.isEmpty(user.getLDAPUser()) ? user.getName() : user.getLDAPUser();
+		}else {
+			m_userName = user.getName();
+		}
 
 		Env.setContext( getCtx(), Env.LANGUAGE, Lang);
 		m_language = Language.getLanguage(Lang);


### PR DESCRIPTION
[IDEMPIERE-6584:Ldap user can't co-exist with MSysConfig.USE_EMAIL_FOR_LOGIN](https://idempiere.atlassian.net/browse/IDEMPIERE-6584)

I haven't tested the changes on ResetPasswordPanel yet since I'm not sure how to make the full panel appear.

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

