### PR TITLE
IDEMPIERE-6635 - Makes the DataProvider a priority for search of context variables and restores 'IDEMPIERE-6473'

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/GridField.java
+++ b/org.adempiere.base/src/org/compiere/model/GridField.java
@@ -1374,7 +1374,7 @@ public class GridField
 	{
 		if (m_parentEvaluatee != null) {
 			String value = m_parentEvaluatee.get_ValueAsString(variableName);
-			if (!Util.isEmpty(value))
+			if (value != null)
 				return value;
 		}
 		return new DefaultEvaluatee(getGridTab(), m_vo.WindowNo, m_vo.TabNo).get_ValueAsString(ctx, variableName);

--- a/org.adempiere.base/src/org/compiere/util/DefaultEvaluatee.java
+++ b/org.adempiere.base/src/org/compiere/util/DefaultEvaluatee.java
@@ -189,13 +189,13 @@ public class DefaultEvaluatee implements Evaluatee {
 
 		// get value from data provider(usually PO or GridTab)
 		Object dataValue = null;
-		if (Util.isEmpty(value) && m_dataProvider != null && !globalVariable) {
+		if (m_dataProvider != null && !globalVariable) {
 			dataValue = m_dataProvider.getValue(variableName);
-			value = dataValue != null ? dataValue.toString() : "";
+			value = dataValue != null ? dataValue.toString() : null;
 		}
 
 		// get value from window context or global
-		if (Util.isEmpty(value) && m_windowNo != 0)
+		if (value == null && m_windowNo != 0)
 		{
 			if (variableName.equalsIgnoreCase(GridTab.CTX_Record_ID))			
 			{

--- a/org.adempiere.base/src/org/compiere/util/DefaultEvaluatee.java
+++ b/org.adempiere.base/src/org/compiere/util/DefaultEvaluatee.java
@@ -186,8 +186,16 @@ public class DefaultEvaluatee implements Evaluatee {
 		String value = null;
 		boolean globalVariable = Env.isGlobalVariable(variableName);
 		boolean tabOnly = m_onlyTab != null ? m_onlyTab.booleanValue() : false;
+
+		// get value from data provider(usually PO or GridTab)
+		Object dataValue = null;
+		if (Util.isEmpty(value) && m_dataProvider != null && !globalVariable) {
+			dataValue = m_dataProvider.getValue(variableName);
+			value = dataValue != null ? dataValue.toString() : "";
+		}
+
 		// get value from window context or global
-		if (m_windowNo != 0)
+		if (Util.isEmpty(value) && m_windowNo != 0)
 		{
 			if (variableName.equalsIgnoreCase(GridTab.CTX_Record_ID))			
 			{
@@ -215,7 +223,6 @@ public class DefaultEvaluatee implements Evaluatee {
 		}
 
 		// po property operator
-		Object dataValue = null;
 		if (Util.isEmpty(value) && m_dataProvider != null && !globalVariable) {
 			if (variableName.startsWith(Evaluator.VARIABLE_PO_PROPERTY_OPERATOR)) {
 				variableName = variableName.substring(1);
@@ -240,12 +247,6 @@ public class DefaultEvaluatee implements Evaluatee {
 		//try window context again after removal of tab no
 		if (!globalVariable && Util.isEmpty(value) && m_windowNo != 0 && withTabNo && !tabOnly) {
 			value = Env.getContext(ctx, m_windowNo, variableName);
-		}
-		
-		// get value from data provider(usually PO or GridTab)
-		if (Util.isEmpty(value) && m_dataProvider != null && !globalVariable) {
-			dataValue = m_dataProvider.getValue(variableName);
-			value = dataValue != null ? dataValue.toString() : "";
 		}
 		
 		//try context if no data provider and not only window and not only tab

--- a/org.idempiere.test/src/org/idempiere/test/base/LogicExpressionTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/base/LogicExpressionTest.java
@@ -44,6 +44,7 @@ import org.compiere.model.PO;
 import org.compiere.model.Query;
 import org.compiere.util.DB;
 import org.compiere.util.DefaultEvaluatee;
+import org.compiere.util.DefaultEvaluatee.DataProvider;
 import org.compiere.util.Env;
 import org.compiere.util.LegacyLogicEvaluator;
 import org.compiere.util.TimeUtil;
@@ -713,5 +714,44 @@ public class LogicExpressionTest  extends AbstractTestCase {
 		Env.setContext(Env.getCtx(), 1, "Processed", "Y");
 		Env.setContext(Env.getCtx(), 1, "M_Product_ID", pchair);
 		assertTrue(LogicEvaluator.evaluateLogic(new DefaultEvaluatee((GridTab)null, 1, 0), expr));
-	}	
+	}
+
+	@Test
+	public void testDataProvider() {
+
+		final int DUMMY_WINDOW_NO = 1;
+		final int DUMMY_TAB_NO = 0;
+
+		DefaultEvaluatee.DataProvider dp = new DataProvider() {
+			@Override
+			public Object getValue(String columnName) {
+
+				String value = null;
+
+				if ("MyContext".equals(columnName))
+					value = "MyDataProviderValue";
+
+				return value;
+			}
+
+			@Override
+			public Object getProperty(String propertyName) { return null; }
+
+			@Override
+			public MColumn getColumn(String columnName) { return null; }
+
+			@Override
+			public String getTrxName() { return null; }
+		};
+		DefaultEvaluatee myEvaluatee = new DefaultEvaluatee(dp, DUMMY_WINDOW_NO, DUMMY_TAB_NO);
+		Env.setContext(Env.getCtx(), DUMMY_WINDOW_NO, DUMMY_TAB_NO, "MyContext", "MyContextValue");
+
+		String expression = "@MyContext@ = 'MyDataProviderValue'";
+		assertTrue(LogicEvaluator.evaluateLogic(myEvaluatee, expression));
+
+		Env.setContext(Env.getCtx(), DUMMY_WINDOW_NO, DUMMY_TAB_NO, "MyOtherContext", "MyOtherValue");
+
+		expression = "@MyOtherContext@ = 'MyOtherValue'";
+		assertTrue(LogicEvaluator.evaluateLogic(myEvaluatee, expression));
+	}
 }


### PR DESCRIPTION
[IDEMPIERE-6635](https://idempiere.atlassian.net/browse/IDEMPIERE-6635)

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [x] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.



[IDEMPIERE-6635]: https://idempiere.atlassian.net/browse/IDEMPIERE-6635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ