### PR TITLE
IDEMPIERE-6645 Error message being cleared due to concurrency issue

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/PO.java
+++ b/org.adempiere.base/src/org/compiere/model/PO.java
@@ -2487,6 +2487,7 @@ public abstract class PO
 
 		try
 		{
+			setSupressMIssue(); 
 			// Call ModelValidators TYPE_NEW/TYPE_CHANGE
 			String errorMsg = ModelValidationEngine.get().fireModelChange
 				(this, newRecord ? ModelValidator.TYPE_NEW : ModelValidator.TYPE_CHANGE);
@@ -2596,6 +2597,7 @@ public abstract class PO
 		}
 		finally
 		{
+			isSupressMIssue.remove();
 			if (localTrx != null)
 			{
 				localTrx.close();
@@ -6085,6 +6087,30 @@ public abstract class PO
 				throw new CrossTenantException(writing, get_TableName(), get_ID());
 			}
 		}
+	}
+	
+	private static ThreadLocal<Boolean> isSupressMIssue = new ThreadLocal<Boolean>() {
+		@Override protected Boolean initialValue() {
+			return Boolean.FALSE;
+		};
+	};
+	
+	/**
+	 * Turn on supress MIssue safe thread local flag
+	 */
+	public static void setSupressMIssue() {
+		isSupressMIssue.set(Boolean.TRUE);
+	}
+	
+	/**
+	 * Clear supress MIssue safe thread local flag
+	 */
+	public static void clearSupressMIssue() {
+		isSupressMIssue.set(Boolean.FALSE);
+	}
+	
+	public static boolean checkSupressMIssue() {
+		return isSupressMIssue.get();
 	}
 	
 	/**

--- a/org.adempiere.base/src/org/compiere/util/CLogErrorBuffer.java
+++ b/org.adempiere.base/src/org/compiere/util/CLogErrorBuffer.java
@@ -26,6 +26,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
 import org.compiere.model.MIssue;
+import org.compiere.model.PO;
 
 /**
  *	Handler that publish log record to the system error output stream
@@ -226,6 +227,7 @@ public class CLogErrorBuffer extends Handler
 					&& loggerName.indexOf("Issue") == -1
 					&& loggerName.indexOf("CConnection") == -1
 					&& !loggerName.startsWith("com.zaxxer.hikari")
+					&& !PO.checkSupressMIssue()
 					&& DB.isConnected()
 					)
 				{


### PR DESCRIPTION
[ IDEMPIERE-6645 ](https://idempiere.atlassian.net/browse/IDEMPIERE-6645)


# Pull Request Checklist

- [X] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [X] My code follows the best practices of this project
- [X] I have performed a self-review of my own code
- [X] My code is easy to understand and review. 
- [ ] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [ ] My changes generate no new warnings
### Tests
- [X] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

