### PR TITLE
IDEMPIERE-6656: Unclear message when reactivating a document with reconciled posting

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MFactAcct.java
+++ b/org.adempiere.base/src/org/compiere/model/MFactAcct.java
@@ -75,6 +75,9 @@ public class MFactAcct extends X_Fact_Acct
 	public static int deleteEx(int AD_Table_ID, int Record_ID, String trxName)
 	throws DBException
 	{
+		if (isPostingReconciled(AD_Table_ID, Record_ID, trxName))
+			throw new DBException("Posting is reconciled");
+		
 		// backup the posting records before delete them
 		final String sqlInsert = "INSERT INTO T_Fact_Acct_History SELECT * FROM Fact_Acct WHERE AD_Table_ID=? AND Record_ID=?";
 		int no = DB.executeUpdateEx(sqlInsert, new Object[]{AD_Table_ID, Record_ID}, trxName);
@@ -176,5 +179,8 @@ public class MFactAcct extends X_Fact_Acct
 		Query query = new Query(Env.getCtx(), Table_Name, recordIdWhereClause, trxName);
 		return query.setParameters(AD_Table_ID, Record_ID, C_AcctSchema_ID);
 	}
-	
+
+	public static boolean isPostingReconciled(int AD_Table_ID, int Record_ID, String trxName) {
+		return DB.getSQLValueEx(trxName, "SELECT 1 FROM Fact_Reconciliation WHERE Fact_Acct_ID IN (SELECT FAct_Acct_ID FROM Fact_Acct WHERE AD_Table_ID=? AND Record_ID=?)", AD_Table_ID, Record_ID) == 1;
+	}
 }	//	MFactAcct


### PR DESCRIPTION

https://idempiere.atlassian.net/browse/IDEMPIERE-6656


# Pull Request Checklist

- [ ] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [ ] My code follows the best practices of this project
- [ ] I have performed a self-review of my own code
- [ ] My code is easy to understand and review. 
- [ ] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [ ] My changes generate no new warnings
### Tests
- [ ] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

