### PR TITLE
IDEMPIERE-6659 Estimated Landed Cost Scenarios for Purchase Orders and Incorrect Product Costs

### DIFF
--- a/org.adempiere.base/src/org/compiere/acct/Doc_MatchPO.java
+++ b/org.adempiere.base/src/org/compiere/acct/Doc_MatchPO.java
@@ -689,6 +689,8 @@ public class Doc_MatchPO extends Doc
 		for(Integer elementId : landedCostMap.keySet())
 		{
 			BigDecimal amt = landedCostMap.get(elementId);
+			if (mMatchPO.isReversal())
+				amt = amt.negate();
 			amt = amt.multiply(tQty);
 			if (amt.scale() > as.getCostingPrecision())
 				amt = amt.setScale(as.getCostingPrecision(), RoundingMode.HALF_UP);

--- a/org.idempiere.test/src/org/idempiere/test/costing/AveragePOCostingTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/costing/AveragePOCostingTest.java
@@ -5254,6 +5254,398 @@ public class AveragePOCostingTest extends AbstractTestCase {
 		}	
 	}
 	
+	/**
+	 * IDEMPIERE-6659
+	 * PO, Qty=20, Price=10, Landed Cost=100
+	 * MR1, Qty=2
+	 * MR2, Qty=2
+	 * MR3, Qty=2
+	 * MR3, Qty=2 (Reversed)
+	 * MR2, Qty=2 (Reversed)
+	 * MR1, Qty=2 (Reversed)
+	 */
+	@Test
+	public void testLandedCostForPOWithMultiMRAndReversal() {
+		MClient client = MClient.get(Env.getCtx());
+		MAcctSchema as = client.getAcctSchema();
+		assertEquals(as.getCostingMethod(), MCostElement.COSTINGMETHOD_AveragePO, "Default costing method not Average PO");
+		
+		try (MockedStatic<MProduct> productMock = mockStatic(MProduct.class)) {
+			MProduct product = new MProduct(Env.getCtx(), 0, getTrxName());
+			product.setM_Product_Category_ID(DictionaryIDs.M_Product_Category.STANDARD.id);
+			product.setName("testLandedCostForPOWithMultiMRAndReversal");
+			product.setProductType(MProduct.PRODUCTTYPE_Item);
+			product.setIsStocked(true);
+			product.setIsSold(true);
+			product.setIsPurchased(true);
+			product.setC_UOM_ID(DictionaryIDs.C_UOM.EACH.id);
+			product.setC_TaxCategory_ID(DictionaryIDs.C_TaxCategory.STANDARD.id);
+			product.saveEx();
+			
+			mockProductGet(productMock, product);
+			
+			MPriceListVersion plv = MPriceList.get(DictionaryIDs.M_PriceList.PURCHASE.id).getPriceListVersion(null);
+			MProductPrice pp = new MProductPrice(Env.getCtx(), 0, getTrxName());
+			pp.setM_PriceList_Version_ID(plv.getM_PriceList_Version_ID());
+			pp.setM_Product_ID(product.get_ID());
+			pp.setPriceStd(new BigDecimal("10"));
+			pp.setPriceList(new BigDecimal("10"));
+			pp.saveEx();
+			
+			// create order
+			MOrder order = new MOrder(Env.getCtx(), 0, getTrxName());
+			order.setBPartner(MBPartner.get(Env.getCtx(), DictionaryIDs.C_BPartner.PATIO.id));
+			order.setC_DocTypeTarget_ID(DictionaryIDs.C_DocType.PURCHASE_ORDER.id);
+			order.setIsSOTrx(false);
+			order.setSalesRep_ID(DictionaryIDs.AD_User.GARDEN_ADMIN.id);
+			order.setDocStatus(DocAction.STATUS_Drafted);
+			order.setDocAction(DocAction.ACTION_Complete);
+			Timestamp today = TimeUtil.getDay(System.currentTimeMillis());
+			order.setDateOrdered(today);
+			order.setDatePromised(today);
+			order.saveEx();
+
+			MOrderLine line = new MOrderLine(order);
+			line.setLine(10);
+			line.setProduct(new MProduct(Env.getCtx(), product.get_ID(), getTrxName()));
+			line.setQty(new BigDecimal("20"));
+			line.setDatePromised(today);
+			line.setPrice(new BigDecimal("10"));
+			line.saveEx();
+			
+			MOrderLandedCost landedCost = new MOrderLandedCost(Env.getCtx(), 0, getTrxName());
+			landedCost.setC_Order_ID(order.get_ID());
+			landedCost.setLandedCostDistribution(MOrderLandedCost.LANDEDCOSTDISTRIBUTION_Costs);
+			landedCost.setM_CostElement_ID(DictionaryIDs.M_CostElement.FREIGHT.id);
+			landedCost.setAmt(new BigDecimal("100"));
+			landedCost.saveEx();
+			
+			ProcessInfo info = MWorkflow.runDocumentActionWorkflow(order, DocAction.ACTION_Complete);
+			assertFalse(info.isError(), info.getSummary());
+			order.load(getTrxName());
+			assertEquals(DocAction.STATUS_Completed, order.getDocStatus());		
+			
+			List<MInOut> receipts = new ArrayList<MInOut>();
+			for (int i = 0; i < 3; i++) {
+				MInOut receipt = new MInOut(order, DictionaryIDs.C_DocType.MM_RECEIPT.id, order.getDateOrdered());
+				receipt.setDocStatus(DocAction.STATUS_Drafted);
+				receipt.setDocAction(DocAction.ACTION_Complete);
+				receipt.saveEx();
+				receipts.add(receipt);
+				
+				MInOutLine receiptLine = new MInOutLine(receipt);
+				receiptLine.setOrderLine(line, 0, new BigDecimal("2"));
+				receiptLine.setQty(new BigDecimal("2"));
+				receiptLine.saveEx();
+	
+				info = MWorkflow.runDocumentActionWorkflow(receipt, DocAction.ACTION_Complete);
+				assertFalse(info.isError(), info.getSummary());
+				receipt.load(getTrxName());
+				assertEquals(DocAction.STATUS_Completed, receipt.getDocStatus());
+				if (!receipt.isPosted()) {
+					String error = DocumentEngine.postImmediate(Env.getCtx(), receipt.getAD_Client_ID(), receipt.get_Table_ID(), receipt.get_ID(), false, getTrxName());
+					assertNull(error, error);
+				}
+				
+				List<MCostDetail> cds = MCostDetail.list(Env.getCtx(), "C_OrderLine_ID=?", line.getC_OrderLine_ID(), 0, as.get_ID(), getTrxName());
+				assertTrue(cds.size() == 2, "MCostDetail not found for order line");
+				for (MCostDetail cd : cds) {
+					if (cd.getM_CostElement_ID() == 0) {
+						assertEquals(2 * (i+1), cd.getQty().intValue(), "Unexpected MCostDetail Qty");
+						assertEquals(new BigDecimal("20.00").setScale(2, RoundingMode.HALF_UP).multiply(new BigDecimal(i+1)), cd.getAmt().setScale(2, RoundingMode.HALF_UP), "Unexpected MCostDetail Amt");
+					} else if (cd.getM_CostElement_ID() == DictionaryIDs.M_CostElement.FREIGHT.id ) {
+						assertEquals(2 * (i+1), cd.getQty().intValue(), "Unexpected MCostDetail Qty");
+						assertEquals(new BigDecimal("10.00").setScale(2, RoundingMode.HALF_UP).multiply(new BigDecimal(i+1)), cd.getAmt().setScale(2, RoundingMode.HALF_UP), "Unexpected MCostDetail Amt");
+					}
+				}
+				
+				product.set_TrxName(getTrxName());			
+				MCost cost1 = product.getCostingRecord(as, getAD_Org_ID(), 0, MCostElement.COSTINGMETHOD_AveragePO);
+				MCost cost2 = product.getCostingRecord(as, getAD_Org_ID(), 0, MCostElement.COSTINGMETHOD_StandardCosting);
+				assertNotNull(cost1, "No MCost record found");
+				assertNotNull(cost2, "No MCost record found");
+				assertEquals(cost1.getCurrentQty().setScale(2, RoundingMode.HALF_UP), cost2.getCurrentQty().setScale(2, RoundingMode.HALF_UP), "Unexpected current quantity");
+				assertEquals(new BigDecimal("15.00"), cost1.getCurrentCostPrice().setScale(2, RoundingMode.HALF_UP), "Unexpected current cost price");
+				assertEquals(new BigDecimal("30.00").multiply(new BigDecimal(i+1)), cost1.getCumulatedAmt().setScale(2, RoundingMode.HALF_UP), "Unexpected cumulated amount");
+				assertEquals(new BigDecimal("2.00").multiply(new BigDecimal(i+1)), cost1.getCumulatedQty().setScale(2, RoundingMode.HALF_UP), "Unexpected cumulated quantity");
+				assertEquals(new BigDecimal("10.00"), cost2.getCurrentCostPrice().setScale(2, RoundingMode.HALF_UP), "Unexpected current cost price");
+				assertEquals(new BigDecimal("20.00").multiply(new BigDecimal(i+1)), cost2.getCumulatedAmt().setScale(2, RoundingMode.HALF_UP), "Unexpected cumulated amount");
+				assertEquals(new BigDecimal("2.00").multiply(new BigDecimal(i+1)), cost2.getCumulatedQty().setScale(2, RoundingMode.HALF_UP), "Unexpected cumulated quantity");				
+				
+				// check posting
+				ProductCost productCost = new ProductCost(Env.getCtx(), product.get_ID(), 0, getTrxName());
+				MAccount assetAccount = productCost.getAccount(ProductCost.ACCTTYPE_P_Asset, as);
+				Doc doc = DocManager.getDocument(as, MInOut.Table_ID, receipt.get_ID(), getTrxName());
+				MAccount nivReceiptAccount = doc.getAccount(Doc.ACCTTYPE_NotInvoicedReceipts, as);
+				MAccount landedCostAccount = productCost.getAccount(ProductCost.ACCTTYPE_P_LandedCostClearing, as);
+				Query query = MFactAcct.createRecordIdQuery(MInOut.Table_ID, receipt.get_ID(), as.get_ID(), getTrxName());
+				List<MFactAcct> list = query.list();
+				List<FactAcct> expected = Arrays.asList(new FactAcct(assetAccount, new BigDecimal("30.00"), 2, true),
+						new FactAcct(nivReceiptAccount, new BigDecimal("20.00"), 2, false), new FactAcct(landedCostAccount, new BigDecimal("10.00"), 2, false));
+				assertFactAcctEntries(list, expected);
+			}
+			
+			for (int i = receipts.size()-1; i >= 0; i--) {
+				MInOut receipt = receipts.get(i);
+				
+				// reverse receipt
+				info = MWorkflow.runDocumentActionWorkflow(receipt, DocAction.ACTION_Reverse_Accrual);
+				assertFalse(info.isError(), info.getSummary());
+				receipt.load(getTrxName());
+				assertEquals(DocAction.STATUS_Reversed, receipt.getDocStatus());
+				
+				List<MCostDetail> cds = MCostDetail.list(Env.getCtx(), "C_OrderLine_ID=?", line.getC_OrderLine_ID(), 0, as.get_ID(), getTrxName());
+				assertTrue(cds.size() == 2, "MCostDetail not found for order line");
+				for (MCostDetail cd : cds) {
+					if (cd.getM_CostElement_ID() == 0) {
+						assertEquals(2 * (i), cd.getQty().intValue(), "Unexpected MCostDetail Qty");
+						assertEquals(new BigDecimal("20.00").setScale(2, RoundingMode.HALF_UP).multiply(new BigDecimal(i)), cd.getAmt().setScale(2, RoundingMode.HALF_UP), "Unexpected MCostDetail Amt");
+					} else if (cd.getM_CostElement_ID() == DictionaryIDs.M_CostElement.FREIGHT.id ) {
+						assertEquals(2 * (i), cd.getQty().intValue(), "Unexpected MCostDetail Qty");
+						assertEquals(new BigDecimal("10.00").setScale(2, RoundingMode.HALF_UP).multiply(new BigDecimal(i)), cd.getAmt().setScale(2, RoundingMode.HALF_UP), "Unexpected MCostDetail Amt");
+					}
+				}
+				
+				product.set_TrxName(getTrxName());			
+				MCost cost1 = product.getCostingRecord(as, getAD_Org_ID(), 0, MCostElement.COSTINGMETHOD_AveragePO);
+				MCost cost2 = product.getCostingRecord(as, getAD_Org_ID(), 0, MCostElement.COSTINGMETHOD_StandardCosting);
+				assertNotNull(cost1, "No MCost record found");
+				assertNotNull(cost2, "No MCost record found");
+				assertEquals(cost1.getCurrentQty().setScale(2, RoundingMode.HALF_UP), cost2.getCurrentQty().setScale(2, RoundingMode.HALF_UP), "Unexpected current quantity");
+				assertEquals(new BigDecimal(i == 0 ? "10.00" : "15.00"), cost1.getCurrentCostPrice().setScale(2, RoundingMode.HALF_UP), "Unexpected current cost price");
+				assertEquals(new BigDecimal("30.00").multiply(new BigDecimal(i)), cost1.getCumulatedAmt().setScale(2, RoundingMode.HALF_UP), "Unexpected cumulated amount");
+				assertEquals(new BigDecimal("2.00").multiply(new BigDecimal(i)), cost1.getCumulatedQty().setScale(2, RoundingMode.HALF_UP), "Unexpected cumulated quantity");
+				assertEquals(new BigDecimal("10.00"), cost2.getCurrentCostPrice().setScale(2, RoundingMode.HALF_UP), "Unexpected current cost price");
+				assertEquals(new BigDecimal("20.00").multiply(new BigDecimal(i)), cost2.getCumulatedAmt().setScale(2, RoundingMode.HALF_UP), "Unexpected cumulated amount");
+				assertEquals(new BigDecimal("2.00").multiply(new BigDecimal(i)), cost2.getCumulatedQty().setScale(2, RoundingMode.HALF_UP), "Unexpected cumulated quantity");				
+				
+				// check posting for reversal document
+				ProductCost productCost = new ProductCost(Env.getCtx(), product.get_ID(), 0, getTrxName());
+				MAccount assetAccount = productCost.getAccount(ProductCost.ACCTTYPE_P_Asset, as);
+				Doc doc = DocManager.getDocument(as, MInOut.Table_ID, receipt.get_ID(), getTrxName());
+				MAccount nivReceiptAccount = doc.getAccount(Doc.ACCTTYPE_NotInvoicedReceipts, as);
+				MAccount landedCostAccount = productCost.getAccount(ProductCost.ACCTTYPE_P_LandedCostClearing, as);
+				Query query = MFactAcct.createRecordIdQuery(MInOut.Table_ID, receipt.getReversal_ID(), as.get_ID(), getTrxName());
+				List<MFactAcct> list = query.list();
+				List<FactAcct> expected = Arrays.asList(new FactAcct(assetAccount, new BigDecimal("30.00"), 2, false),
+						new FactAcct(nivReceiptAccount, new BigDecimal("20.00"), 2, true), new FactAcct(landedCostAccount, new BigDecimal("10.00"), 2, true));
+				assertFactAcctEntries(list, expected);
+			}
+		}
+	}
+	
+	/**
+	 * IDEMPIERE-6659
+	 * PO, Qty=20, Price=10, Landed Cost=100
+	 * MR1, Qty=2
+	 * MR2, Qty=2
+	 * MR2, Qty=2 (Reversed)
+	 * MR3, Qty=2
+	 * MR3, Qty=2 (Reversed)
+	 */
+	@Test
+	public void testLandedCostForPOWithMultiMRAndReversal2() {
+		MClient client = MClient.get(Env.getCtx());
+		MAcctSchema as = client.getAcctSchema();
+		assertEquals(as.getCostingMethod(), MCostElement.COSTINGMETHOD_AveragePO, "Default costing method not Average PO");
+		
+		try (MockedStatic<MProduct> productMock = mockStatic(MProduct.class)) {
+			MProduct product = new MProduct(Env.getCtx(), 0, getTrxName());
+			product.setM_Product_Category_ID(DictionaryIDs.M_Product_Category.STANDARD.id);
+			product.setName("testLandedCostForPOWithMultiMRAndReversal2");
+			product.setProductType(MProduct.PRODUCTTYPE_Item);
+			product.setIsStocked(true);
+			product.setIsSold(true);
+			product.setIsPurchased(true);
+			product.setC_UOM_ID(DictionaryIDs.C_UOM.EACH.id);
+			product.setC_TaxCategory_ID(DictionaryIDs.C_TaxCategory.STANDARD.id);
+			product.saveEx();
+			
+			mockProductGet(productMock, product);
+			
+			MPriceListVersion plv = MPriceList.get(DictionaryIDs.M_PriceList.PURCHASE.id).getPriceListVersion(null);
+			MProductPrice pp = new MProductPrice(Env.getCtx(), 0, getTrxName());
+			pp.setM_PriceList_Version_ID(plv.getM_PriceList_Version_ID());
+			pp.setM_Product_ID(product.get_ID());
+			pp.setPriceStd(new BigDecimal("10"));
+			pp.setPriceList(new BigDecimal("10"));
+			pp.saveEx();
+			
+			// create order
+			MOrder order = new MOrder(Env.getCtx(), 0, getTrxName());
+			order.setBPartner(MBPartner.get(Env.getCtx(), DictionaryIDs.C_BPartner.PATIO.id));
+			order.setC_DocTypeTarget_ID(DictionaryIDs.C_DocType.PURCHASE_ORDER.id);
+			order.setIsSOTrx(false);
+			order.setSalesRep_ID(DictionaryIDs.AD_User.GARDEN_ADMIN.id);
+			order.setDocStatus(DocAction.STATUS_Drafted);
+			order.setDocAction(DocAction.ACTION_Complete);
+			Timestamp today = TimeUtil.getDay(System.currentTimeMillis());
+			order.setDateOrdered(today);
+			order.setDatePromised(today);
+			order.saveEx();
+
+			MOrderLine line = new MOrderLine(order);
+			line.setLine(10);
+			line.setProduct(new MProduct(Env.getCtx(), product.get_ID(), getTrxName()));
+			line.setQty(new BigDecimal("20"));
+			line.setDatePromised(today);
+			line.setPrice(new BigDecimal("10"));
+			line.saveEx();
+			
+			MOrderLandedCost landedCost = new MOrderLandedCost(Env.getCtx(), 0, getTrxName());
+			landedCost.setC_Order_ID(order.get_ID());
+			landedCost.setLandedCostDistribution(MOrderLandedCost.LANDEDCOSTDISTRIBUTION_Costs);
+			landedCost.setM_CostElement_ID(DictionaryIDs.M_CostElement.FREIGHT.id);
+			landedCost.setAmt(new BigDecimal("100"));
+			landedCost.saveEx();
+			
+			ProcessInfo info = MWorkflow.runDocumentActionWorkflow(order, DocAction.ACTION_Complete);
+			assertFalse(info.isError(), info.getSummary());
+			order.load(getTrxName());
+			assertEquals(DocAction.STATUS_Completed, order.getDocStatus());		
+			
+			MInOut receipt = new MInOut(order, DictionaryIDs.C_DocType.MM_RECEIPT.id, order.getDateOrdered());
+			receipt.setDocStatus(DocAction.STATUS_Drafted);
+			receipt.setDocAction(DocAction.ACTION_Complete);
+			receipt.saveEx();
+			
+			MInOutLine receiptLine = new MInOutLine(receipt);
+			receiptLine.setOrderLine(line, 0, new BigDecimal("2"));
+			receiptLine.setQty(new BigDecimal("2"));
+			receiptLine.saveEx();
+
+			info = MWorkflow.runDocumentActionWorkflow(receipt, DocAction.ACTION_Complete);
+			assertFalse(info.isError(), info.getSummary());
+			receipt.load(getTrxName());
+			assertEquals(DocAction.STATUS_Completed, receipt.getDocStatus());
+			if (!receipt.isPosted()) {
+				String error = DocumentEngine.postImmediate(Env.getCtx(), receipt.getAD_Client_ID(), receipt.get_Table_ID(), receipt.get_ID(), false, getTrxName());
+				assertNull(error, error);
+			}
+			
+			List<MCostDetail> cds = MCostDetail.list(Env.getCtx(), "C_OrderLine_ID=?", line.getC_OrderLine_ID(), 0, as.get_ID(), getTrxName());
+			assertTrue(cds.size() == 2, "MCostDetail not found for order line");
+			for (MCostDetail cd : cds) {
+				if (cd.getM_CostElement_ID() == 0) {
+					assertEquals(2, cd.getQty().intValue(), "Unexpected MCostDetail Qty");
+					assertEquals(new BigDecimal("20.00").setScale(2, RoundingMode.HALF_UP), cd.getAmt().setScale(2, RoundingMode.HALF_UP), "Unexpected MCostDetail Amt");
+				} else if (cd.getM_CostElement_ID() == DictionaryIDs.M_CostElement.FREIGHT.id ) {
+					assertEquals(2, cd.getQty().intValue(), "Unexpected MCostDetail Qty");
+					assertEquals(new BigDecimal("10.00").setScale(2, RoundingMode.HALF_UP), cd.getAmt().setScale(2, RoundingMode.HALF_UP), "Unexpected MCostDetail Amt");
+				}
+			}
+			
+			product.set_TrxName(getTrxName());			
+			MCost cost1 = product.getCostingRecord(as, getAD_Org_ID(), 0, MCostElement.COSTINGMETHOD_AveragePO);
+			MCost cost2 = product.getCostingRecord(as, getAD_Org_ID(), 0, MCostElement.COSTINGMETHOD_StandardCosting);
+			assertNotNull(cost1, "No MCost record found");
+			assertNotNull(cost2, "No MCost record found");
+			assertEquals(cost1.getCurrentQty().setScale(2, RoundingMode.HALF_UP), cost2.getCurrentQty().setScale(2, RoundingMode.HALF_UP), "Unexpected current quantity");
+			assertEquals(new BigDecimal("15.00"), cost1.getCurrentCostPrice().setScale(2, RoundingMode.HALF_UP), "Unexpected current cost price");
+			assertEquals(new BigDecimal("30.00"), cost1.getCumulatedAmt().setScale(2, RoundingMode.HALF_UP), "Unexpected cumulated amount");
+			assertEquals(new BigDecimal("2.00"), cost1.getCumulatedQty().setScale(2, RoundingMode.HALF_UP), "Unexpected cumulated quantity");
+			assertEquals(new BigDecimal("10.00"), cost2.getCurrentCostPrice().setScale(2, RoundingMode.HALF_UP), "Unexpected current cost price");
+			assertEquals(new BigDecimal("20.00"), cost2.getCumulatedAmt().setScale(2, RoundingMode.HALF_UP), "Unexpected cumulated amount");
+			assertEquals(new BigDecimal("2.00"), cost2.getCumulatedQty().setScale(2, RoundingMode.HALF_UP), "Unexpected cumulated quantity");
+			
+			for (int i = 0; i < 2; i++) {
+				receipt = new MInOut(order, DictionaryIDs.C_DocType.MM_RECEIPT.id, order.getDateOrdered());
+				receipt.setDocStatus(DocAction.STATUS_Drafted);
+				receipt.setDocAction(DocAction.ACTION_Complete);
+				receipt.saveEx();
+				
+				receiptLine = new MInOutLine(receipt);
+				receiptLine.setOrderLine(line, 0, new BigDecimal("2"));
+				receiptLine.setQty(new BigDecimal("2"));
+				receiptLine.saveEx();
+	
+				info = MWorkflow.runDocumentActionWorkflow(receipt, DocAction.ACTION_Complete);
+				assertFalse(info.isError(), info.getSummary());
+				receipt.load(getTrxName());
+				assertEquals(DocAction.STATUS_Completed, receipt.getDocStatus());
+				if (!receipt.isPosted()) {
+					String error = DocumentEngine.postImmediate(Env.getCtx(), receipt.getAD_Client_ID(), receipt.get_Table_ID(), receipt.get_ID(), false, getTrxName());
+					assertNull(error, error);
+				}
+				
+				cds = MCostDetail.list(Env.getCtx(), "C_OrderLine_ID=?", line.getC_OrderLine_ID(), 0, as.get_ID(), getTrxName());
+				assertTrue(cds.size() == 2, "MCostDetail not found for order line");
+				for (MCostDetail cd : cds) {
+					if (cd.getM_CostElement_ID() == 0) {
+						assertEquals(4, cd.getQty().intValue(), "Unexpected MCostDetail Qty");
+						assertEquals(new BigDecimal("40.00").setScale(2, RoundingMode.HALF_UP), cd.getAmt().setScale(2, RoundingMode.HALF_UP), "Unexpected MCostDetail Amt");
+					} else if (cd.getM_CostElement_ID() == DictionaryIDs.M_CostElement.FREIGHT.id ) {
+						assertEquals(4, cd.getQty().intValue(), "Unexpected MCostDetail Qty");
+						assertEquals(new BigDecimal("20.00").setScale(2, RoundingMode.HALF_UP), cd.getAmt().setScale(2, RoundingMode.HALF_UP), "Unexpected MCostDetail Amt");
+					}
+				}
+				
+				product.set_TrxName(getTrxName());			
+				cost1 = product.getCostingRecord(as, getAD_Org_ID(), 0, MCostElement.COSTINGMETHOD_AveragePO);
+				cost2 = product.getCostingRecord(as, getAD_Org_ID(), 0, MCostElement.COSTINGMETHOD_StandardCosting);
+				assertNotNull(cost1, "No MCost record found");
+				assertNotNull(cost2, "No MCost record found");
+				assertEquals(cost1.getCurrentQty().setScale(2, RoundingMode.HALF_UP), cost2.getCurrentQty().setScale(2, RoundingMode.HALF_UP), "Unexpected current quantity");
+				assertEquals(new BigDecimal("15.00"), cost1.getCurrentCostPrice().setScale(2, RoundingMode.HALF_UP), "Unexpected current cost price");
+				assertEquals(new BigDecimal("60.00"), cost1.getCumulatedAmt().setScale(2, RoundingMode.HALF_UP), "Unexpected cumulated amount");
+				assertEquals(new BigDecimal("4.00"), cost1.getCumulatedQty().setScale(2, RoundingMode.HALF_UP), "Unexpected cumulated quantity");
+				assertEquals(new BigDecimal("10.00"), cost2.getCurrentCostPrice().setScale(2, RoundingMode.HALF_UP), "Unexpected current cost price");
+				assertEquals(new BigDecimal("40.00"), cost2.getCumulatedAmt().setScale(2, RoundingMode.HALF_UP), "Unexpected cumulated amount");
+				assertEquals(new BigDecimal("4.00"), cost2.getCumulatedQty().setScale(2, RoundingMode.HALF_UP), "Unexpected cumulated quantity");				
+				
+				// check posting
+				ProductCost productCost = new ProductCost(Env.getCtx(), product.get_ID(), 0, getTrxName());
+				MAccount assetAccount = productCost.getAccount(ProductCost.ACCTTYPE_P_Asset, as);
+				Doc doc = DocManager.getDocument(as, MInOut.Table_ID, receipt.get_ID(), getTrxName());
+				MAccount nivReceiptAccount = doc.getAccount(Doc.ACCTTYPE_NotInvoicedReceipts, as);
+				MAccount landedCostAccount = productCost.getAccount(ProductCost.ACCTTYPE_P_LandedCostClearing, as);
+				Query query = MFactAcct.createRecordIdQuery(MInOut.Table_ID, receipt.get_ID(), as.get_ID(), getTrxName());
+				List<MFactAcct> list = query.list();
+				List<FactAcct> expected = Arrays.asList(new FactAcct(assetAccount, new BigDecimal("30.00"), 2, true),
+						new FactAcct(nivReceiptAccount, new BigDecimal("20.00"), 2, false), new FactAcct(landedCostAccount, new BigDecimal("10.00"), 2, false));
+				assertFactAcctEntries(list, expected);
+				
+				// reverse receipt
+				info = MWorkflow.runDocumentActionWorkflow(receipt, DocAction.ACTION_Reverse_Accrual);
+				assertFalse(info.isError(), info.getSummary());
+				receipt.load(getTrxName());
+				assertEquals(DocAction.STATUS_Reversed, receipt.getDocStatus());
+				
+				cds = MCostDetail.list(Env.getCtx(), "C_OrderLine_ID=?", line.getC_OrderLine_ID(), 0, as.get_ID(), getTrxName());
+				assertTrue(cds.size() == 2, "MCostDetail not found for order line");
+				for (MCostDetail cd : cds) {
+					if (cd.getM_CostElement_ID() == 0) {
+						assertEquals(2, cd.getQty().intValue(), "Unexpected MCostDetail Qty");
+						assertEquals(new BigDecimal("20.00").setScale(2, RoundingMode.HALF_UP), cd.getAmt().setScale(2, RoundingMode.HALF_UP), "Unexpected MCostDetail Amt");
+					} else if (cd.getM_CostElement_ID() == DictionaryIDs.M_CostElement.FREIGHT.id ) {
+						assertEquals(2, cd.getQty().intValue(), "Unexpected MCostDetail Qty");
+						assertEquals(new BigDecimal("10.00").setScale(2, RoundingMode.HALF_UP), cd.getAmt().setScale(2, RoundingMode.HALF_UP), "Unexpected MCostDetail Amt");
+					}
+				}
+				
+				product.set_TrxName(getTrxName());			
+				cost1 = product.getCostingRecord(as, getAD_Org_ID(), 0, MCostElement.COSTINGMETHOD_AveragePO);
+				cost2 = product.getCostingRecord(as, getAD_Org_ID(), 0, MCostElement.COSTINGMETHOD_StandardCosting);
+				assertNotNull(cost1, "No MCost record found");
+				assertNotNull(cost2, "No MCost record found");
+				assertEquals(cost1.getCurrentQty().setScale(2, RoundingMode.HALF_UP), cost2.getCurrentQty().setScale(2, RoundingMode.HALF_UP), "Unexpected current quantity");
+				assertEquals(new BigDecimal("15.00"), cost1.getCurrentCostPrice().setScale(2, RoundingMode.HALF_UP), "Unexpected current cost price");
+				assertEquals(new BigDecimal("30.00"), cost1.getCumulatedAmt().setScale(2, RoundingMode.HALF_UP), "Unexpected cumulated amount");
+				assertEquals(new BigDecimal("2.00"), cost1.getCumulatedQty().setScale(2, RoundingMode.HALF_UP), "Unexpected cumulated quantity");
+				assertEquals(new BigDecimal("10.00"), cost2.getCurrentCostPrice().setScale(2, RoundingMode.HALF_UP), "Unexpected current cost price");
+				assertEquals(new BigDecimal("20.00"), cost2.getCumulatedAmt().setScale(2, RoundingMode.HALF_UP), "Unexpected cumulated amount");
+				assertEquals(new BigDecimal("2.00"), cost2.getCumulatedQty().setScale(2, RoundingMode.HALF_UP), "Unexpected cumulated quantity");				
+				
+				// check posting for reversal document
+				query = MFactAcct.createRecordIdQuery(MInOut.Table_ID, receipt.getReversal_ID(), as.get_ID(), getTrxName());
+				list = query.list();
+				expected = Arrays.asList(new FactAcct(assetAccount, new BigDecimal("30.00"), 2, false),
+						new FactAcct(nivReceiptAccount, new BigDecimal("20.00"), 2, true), new FactAcct(landedCostAccount, new BigDecimal("10.00"), 2, true));
+				assertFactAcctEntries(list, expected);
+			}
+		}
+	}
+	
 	private MInOutLine createPOAndMRForProduct(int productId, MAttributeSetInstance asi, BigDecimal price) {
 		MOrder order = new MOrder(Env.getCtx(), 0, getTrxName());
 		order.setBPartner(MBPartner.get(Env.getCtx(), DictionaryIDs.C_BPartner.PATIO.id));


### PR DESCRIPTION
[IDEMPIERE-6659](https://idempiere.atlassian.net/browse/IDEMPIERE-6659) Estimated Landed Cost Scenarios for Purchase Orders and Incorrect Product Costs


# Pull Request Checklist

- [X] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [X] My code follows the best practices of this project
- [X] I have performed a self-review of my own code
- [X] My code is easy to understand and review. 
- [X] I have checked my code and corrected any misspellings
- [X] In hard-to-understand areas, I have commented my code.
- [X] My changes generate no new warnings
### Tests
- [X] I have tested the direct scenario that my code is solving
- [X] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [X] New and existing unit tests pass locally with my changes
- [X] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

