### PR TITLE
IDEMPIERE-5939: If Financial report marked as List Source and List Tr…

### DIFF
--- a/migration/iD13/oracle/202506251618_IDMEPIERE-5939.sql
+++ b/migration/iD13/oracle/202506251618_IDMEPIERE-5939.sql
@@ -1,0 +1,17 @@
+-- IDEMPIERE-5939: If Financial report marked as List Source and List Transactions both with Report cube, it throw SQL exceptions.
+SELECT register_migration_script('202506251725_IDEMPIERE-5939.sql') FROM dual;
+
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Jun 25, 2025, 5:20:07 PM IST
+UPDATE AD_Field SET DisplayLogic='@ListSources@=Y&@PA_ReportCube_ID@=0', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_DATE('2025-06-25 17:20:07','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=6267
+;
+
+-- Jun 25, 2025, 5:20:27 PM IST
+UPDATE AD_Field SET DisplayLogic='@ListTrx@=N', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_DATE('2025-06-25 17:20:27','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=57034
+;
+
+-- Jun 25, 2025, 5:20:42 PM IST
+UPDATE AD_Process_Para SET ReadOnlyLogic='@ListTrx@=Y',Updated=TO_DATE('2025-06-25 17:19:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Process_Para_ID=53313
+;

--- a/migration/iD13/postgresql/202506251618_IDEMPIERE-5939.sql
+++ b/migration/iD13/postgresql/202506251618_IDEMPIERE-5939.sql
@@ -1,0 +1,14 @@
+-- IDMEPIERE-5939 If Financial report marked as List Source and List Transactions both with Report cube, it throw SQL exceptions
+SELECT register_migration_script('202506251725_IDEMPIERE-5939.sql') FROM dual;
+
+-- Jun 25, 2025, 5:20:07 PM IST
+UPDATE AD_Field SET DisplayLogic='@ListSources@=Y&@PA_ReportCube_ID@=0', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2025-06-25 17:20:07','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=6267
+;
+
+-- Jun 25, 2025, 5:20:27 PM IST
+UPDATE AD_Field SET DisplayLogic='@ListTrx@=N', AD_Reference_Value_ID=NULL, AD_Val_Rule_ID=NULL, IsToolbarButton=NULL,Updated=TO_TIMESTAMP('2025-06-25 17:20:27','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=57034
+;
+
+-- Jun 25, 2025, 5:20:42 PM IST
+UPDATE AD_Process_Para SET ReadOnlyLogic='@ListTrx@=Y',Updated=TO_TIMESTAMP('2025-06-25 17:19:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Process_Para_ID=53313
+;


### PR DESCRIPTION
…ansactions both with Report cube, it throw SQL exceptions.

[ Please copy here the link to the related Jira ticket ]


# Pull Request Checklist

- [ ] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [ ] My code follows the best practices of this project
- [ ] I have performed a self-review of my own code
- [ ] My code is easy to understand and review. 
- [ ] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [ ] My changes generate no new warnings
### Tests
- [ ] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

