### PR TITLE
IDEMPIERE-6684 Unable to save a record via Rest API when a column is set to Record UUID display type

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/PO.java
+++ b/org.adempiere.base/src/org/compiere/model/PO.java
@@ -6308,8 +6308,8 @@ public abstract class PO
 		int size = get_ColumnCount();
 		for (int i = 0; i < size; i++) {
 			int dt = p_info.getColumnDisplayType(i);
-			if (   (dt != DisplayType.ID   && DisplayType.isID(dt)  )
-				|| (dt != DisplayType.UUID && DisplayType.isUUID(dt)) ) {
+			if (   (dt != DisplayType.ID	&& dt != DisplayType.RecordID	&& DisplayType.isID(dt)  )
+				|| (dt != DisplayType.UUID	&& dt != DisplayType.RecordUU	&& DisplayType.isUUID(dt)) ) {
 				MColumn col = MColumn.get(p_info.getColumn(i).AD_Column_ID);
 				if ("AD_Client_ID".equals(col.getColumnName())) {
 					// ad_client_id is verified with checkValidClient


### PR DESCRIPTION
[IDEMPIERE-6684](https://idempiere.atlassian.net/browse/IDEMPIERE-6684) Unable to save a record via Rest API when a column is set to Record UUID display type


# Pull Request Checklist

- [X] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [X] My code follows the best practices of this project
- [X] I have performed a self-review of my own code
- [X] My code is easy to understand and review. 
- [X] I have checked my code and corrected any misspellings
- [X] In hard-to-understand areas, I have commented my code.
- [X] My changes generate no new warnings
### Tests
- [X] I have tested the direct scenario that my code is solving
- [X] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.



[IDEMPIERE-6684]: https://idempiere.atlassian.net/browse/IDEMPIERE-6684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ