### PR TITLE
IDEMPIERE-6685 MColumn.getReferenceTableName not working for ChosenMu…

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MColumn.java
+++ b/org.adempiere.base/src/org/compiere/model/MColumn.java
@@ -1042,7 +1042,7 @@ public class MColumn extends X_AD_Column implements ImmutablePOSupport
 		if (!column.isKey() && !column.getColumnName().equals(PO.getUUIDColumnName(table.getTableName())) && !column.isVirtualColumn())
 		{
 			int refid = column.getAD_Reference_ID();
-			if (!DisplayType.isList(refid))
+			if (!DisplayType.isList(refid) && !DisplayType.isMultiID(refid))
 			{
 				String referenceTableName = column.getReferenceTableName();
 				if (referenceTableName != null)
@@ -1282,7 +1282,7 @@ public class MColumn extends X_AD_Column implements ImmutablePOSupport
 				return "";
 
 			int refid = column.getAD_Reference_ID();
-			if (!DisplayType.isList(refid))
+			if (!DisplayType.isList(refid) && !DisplayType.isMultiID(refid))
 			{
 				String referenceTableName = column.getReferenceTableName();
 				if (referenceTableName != null)


### PR DESCRIPTION
…ltipleSelectionTable and ChosenMultipleSelectionSearch

- do not generate fk for multi selection column

https://idempiere.atlassian.net/browse/IDEMPIERE-6685

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

