### PR TITLE
IDEMPIERE-6690 Error when clicking UU-based reference field with null value - org.postgresql.util.PSQLException: ERROR: operator does not exist: character varying = integer

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MZoomCondition.java
+++ b/org.adempiere.base/src/org/compiere/model/MZoomCondition.java
@@ -270,14 +270,13 @@ public class MZoomCondition extends X_AD_ZoomCondition implements ImmutablePOSup
 							StringBuilder sql = new StringBuilder("SELECT ").append(parentTab.getKeyColumnName())
 									.append(" FROM ").append(parentTab.getTableName())
 									.append(" WHERE ").append(parentTab.getKeyColumnName()).append("=");
-							if (parentTab.getKeyColumnName().endsWith("_UU"))
+							if (parentTab.getKeyColumnName().endsWith("_UU")) {
 								sql.append(DB.TO_STRING(parentctxid));
-							else
+								parentId = DB.getSQLValueStringEx(null, sql.toString());
+							} else {
 								sql.append(parentctxid);
-							if (parentTab.getKeyColumnName().endsWith("_UU"))
-								parentId = DB.getSQLValueString(null, sql.toString());
-							else
-								parentId = DB.getSQLValue(null, sql.toString());
+								parentId = DB.getSQLValueEx(null, sql.toString());
+							}
 						}
 						if (parentId == null)
 							return 0;

--- a/org.adempiere.base/src/org/compiere/model/MZoomCondition.java
+++ b/org.adempiere.base/src/org/compiere/model/MZoomCondition.java
@@ -267,8 +267,17 @@ public class MZoomCondition extends X_AD_ZoomCondition implements ImmutablePOSup
 						// no parent link -- search in context of window
 						String parentctxid = Env.getContext(Env.getCtx(), windowNo, parentTab.getKeyColumnName());
 						if (! Util.isEmpty(parentctxid)) {
-							parentId = DB.getSQLValue(null, "SELECT " + parentTab.getKeyColumnName() + " FROM " + parentTab.getTableName() 
-									+ " WHERE " + parentTab.getKeyColumnName() + "=" + parentctxid);
+							StringBuilder sql = new StringBuilder("SELECT ").append(parentTab.getKeyColumnName())
+									.append(" FROM ").append(parentTab.getTableName())
+									.append(" WHERE ").append(parentTab.getKeyColumnName()).append("=");
+							if (parentTab.getKeyColumnName().endsWith("_UU"))
+								sql.append(DB.TO_STRING(parentctxid));
+							else
+								sql.append(parentctxid);
+							if (parentTab.getKeyColumnName().endsWith("_UU"))
+								parentId = DB.getSQLValueString(null, sql.toString());
+							else
+								parentId = DB.getSQLValue(null, sql.toString());
 						}
 						if (parentId == null)
 							return 0;

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/AEnv.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/AEnv.java
@@ -429,7 +429,7 @@ public final class AEnv
             return;
 		// still null means the field is empty or not selected item
 		if (value == null)
-			value = -1;
+			value = DisplayType.isUUID(lookup.getDisplayType()) ? "" : -1;
         //
         MQuery zoomQuery = new MQuery();   //  ColumnName might be changed in MTab.validateQuery
 		String column = lookup.getColumnName();


### PR DESCRIPTION
[IDEMPIERE-6690](https://idempiere.atlassian.net/browse/IDEMPIERE-6690) Error when clicking UU-based reference field with null value - org.postgresql.util.PSQLException: ERROR: operator does not exist: character varying = integer


# Pull Request Checklist

- [X] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [X] My code follows the best practices of this project
- [X] I have performed a self-review of my own code
- [X] My code is easy to understand and review. 
- [X] I have checked my code and corrected any misspellings
- [X] In hard-to-understand areas, I have commented my code.
- [X] My changes generate no new warnings
### Tests
- [X] I have tested the direct scenario that my code is solving
- [X] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.



[IDEMPIERE-6690]: https://idempiere.atlassian.net/browse/IDEMPIERE-6690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ