### PR TITLE
IDEMPIERE-6649 Upgrade Jetty to 12.0.24 and add support for Bouncy Ca…

### DIFF
--- a/org.idempiere.p2.targetplatform/base.target
+++ b/org.idempiere.p2.targetplatform/base.target
@@ -31,7 +31,7 @@
       <unit id="org.eclipse.equinox.p2.repository" version="2.7.100.v20230710-0621-bcfips"/>
       <unit id="org.apache.pdfbox" version="2.0.22.bcfips"/>
       <unit id="com.github.librepdf.openpdf" version="1.3.39.bcfips"/>
-      <repository id="repackaged" location="https://idempiere.github.io/binary.file/p2.repackaged/12.0.0"/>
+      <repository id="repackaged" location="https://idempiere.github.io/binary.file/p2.repackaged/12.0.1"/>
     </location>
     <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">
       <unit id="org.eclipse.osgi" version="3.18.500.v20230801-1826"/>

--- a/org.idempiere.p2.targetplatform/base.tpd
+++ b/org.idempiere.p2.targetplatform/base.tpd
@@ -16,7 +16,7 @@ location zk "https://idempiere.github.io/binary.file/p2.zk/10.0.1" {
 }
 
 //location repackaged "http://localhost:8083/p2.repackaged" {
-location repackaged "https://idempiere.github.io/binary.file/p2.repackaged/12.0.0" {
+location repackaged "https://idempiere.github.io/binary.file/p2.repackaged/12.0.1" {
 	// 2.3.3.v2021090100, dependency of com.sun.xml.ws.jaxws-rt_2.3.5, org.idempiere.webservices, 
 	// wrapped.org.apache.cxf.cxf-rt-ws-transfer_3.6.3
 	jakarta.xml.ws-api

--- a/org.idempiere.p2.targetplatform/org.idempiere.p2.targetplatform.target
+++ b/org.idempiere.p2.targetplatform/org.idempiere.p2.targetplatform.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
-<target name="idempiere-12" sequenceNumber="20250809">
+<target name="idempiere-12" sequenceNumber="20251007">
   <locations>
 	  <location type="Target" uri="file:${project_loc:/org.idempiere.p2.targetplatform}/base.target"/>
 	  <location type="Target" uri="file:${project_loc:/org.idempiere.p2.targetplatform}/maven.locations.target"/>


### PR DESCRIPTION
…stle FIPS 140-3 Level 1 compliance bundles

- Fix local cache issue, remove the need to use -U when upgrading from earlier build.

https://idempiere.atlassian.net/browse/IDEMPIERE-6649

# Pull Request Checklist

- [ ] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [ ] My code follows the best practices of this project
- [ ] I have performed a self-review of my own code
- [ ] My code is easy to understand and review. 
- [ ] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [ ] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

