### PR TITLE
IDEMPIERE-6724 Report Performance Issue with Date Parameters and MQuery TRUNC()

### DIFF
--- a/migration/iD13/oracle/202511171122_IDEMPIERE-6724.sql
+++ b/migration/iD13/oracle/202511171122_IDEMPIERE-6724.sql
@@ -1,0 +1,10 @@
+-- 
+SELECT register_migration_script('202511171122_IDEMPIERE-6724.sql') FROM dual;
+
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Nov 17, 2025, 11:23:32 AM BRT
+INSERT INTO AD_SysConfig (AD_SysConfig_ID,AD_Client_ID,AD_Org_ID,Created,Updated,CreatedBy,UpdatedBy,IsActive,Name,Value,Description,EntityType,ConfigurationLevel,AD_SysConfig_UU) VALUES (nextidfunc(50009,'N'),0,0,TO_TIMESTAMP('2025-11-17 11:23:32','YYYY-MM-DD HH24:MI:SS'),TO_TIMESTAMP('2025-11-17 11:23:32','YYYY-MM-DD HH24:MI:SS'),100,100,'Y','TRUNC_REPORT_DATE_FIELD','N','Y/N - Defines if TRUNC will be used in the Date type field of the report','D','S','019a9233-1488-794a-adc4-fdde6e16ac76')
+;
+

--- a/migration/iD13/oracle/202511171122_IDEMPIERE-6724.sql
+++ b/migration/iD13/oracle/202511171122_IDEMPIERE-6724.sql
@@ -4,7 +4,7 @@ SELECT register_migration_script('202511171122_IDEMPIERE-6724.sql') FROM dual;
 SET SQLBLANKLINES ON
 SET DEFINE OFF
 
--- Nov 17, 2025, 11:23:32 AM BRT
-INSERT INTO AD_SysConfig (AD_SysConfig_ID,AD_Client_ID,AD_Org_ID,Created,Updated,CreatedBy,UpdatedBy,IsActive,Name,Value,Description,EntityType,ConfigurationLevel,AD_SysConfig_UU) VALUES (nextidfunc(50009,'N'),0,0,TO_TIMESTAMP('2025-11-17 11:23:32','YYYY-MM-DD HH24:MI:SS'),TO_TIMESTAMP('2025-11-17 11:23:32','YYYY-MM-DD HH24:MI:SS'),100,100,'Y','TRUNC_REPORT_DATE_FIELD','N','Y/N - Defines if TRUNC will be used in the Date type field of the report','D','S','019a9233-1488-794a-adc4-fdde6e16ac76')
+-- Nov 26, 2025, 9:21:13 AM BRT
+INSERT INTO AD_SysConfig (AD_SysConfig_ID,AD_Client_ID,AD_Org_ID,Created,Updated,CreatedBy,UpdatedBy,IsActive,Name,Value,Description,EntityType,ConfigurationLevel,AD_SysConfig_UU) VALUES (200287,0,0,TO_TIMESTAMP('2025-11-26 09:21:13','YYYY-MM-DD HH24:MI:SS'),TO_TIMESTAMP('2025-11-26 09:21:13','YYYY-MM-DD HH24:MI:SS'),100,100,'Y','TRUNC_REPORT_DATE_FIELD','Y','Y/N - Defines if TRUNC will be used in the Date type field of the report','D','S','019ac01c-55cc-7b55-850c-05d5327c7276')
 ;
 

--- a/migration/iD13/postgresql/202511171122_IDEMPIERE-6724.sql
+++ b/migration/iD13/postgresql/202511171122_IDEMPIERE-6724.sql
@@ -1,7 +1,7 @@
 -- 
 SELECT register_migration_script('202511171122_IDEMPIERE-6724.sql') FROM dual;
 
--- Nov 17, 2025, 11:23:32 AM BRT
-INSERT INTO AD_SysConfig (AD_SysConfig_ID,AD_Client_ID,AD_Org_ID,Created,Updated,CreatedBy,UpdatedBy,IsActive,Name,Value,Description,EntityType,ConfigurationLevel,AD_SysConfig_UU) VALUES (nextidfunc(50009,'N'),0,0,TO_TIMESTAMP('2025-11-17 11:23:32','YYYY-MM-DD HH24:MI:SS'),TO_TIMESTAMP('2025-11-17 11:23:32','YYYY-MM-DD HH24:MI:SS'),100,100,'Y','TRUNC_REPORT_DATE_FIELD','N','Y/N - Defines if TRUNC will be used in the Date type field of the report','D','S','019a9233-1488-794a-adc4-fdde6e16ac76')
+-- Nov 26, 2025, 9:21:13 AM BRT
+INSERT INTO AD_SysConfig (AD_SysConfig_ID,AD_Client_ID,AD_Org_ID,Created,Updated,CreatedBy,UpdatedBy,IsActive,Name,Value,Description,EntityType,ConfigurationLevel,AD_SysConfig_UU) VALUES (200287,0,0,TO_TIMESTAMP('2025-11-26 09:21:13','YYYY-MM-DD HH24:MI:SS'),TO_TIMESTAMP('2025-11-26 09:21:13','YYYY-MM-DD HH24:MI:SS'),100,100,'Y','TRUNC_REPORT_DATE_FIELD','Y','Y/N - Defines if TRUNC will be used in the Date type field of the report','D','S','019ac01c-55cc-7b55-850c-05d5327c7276')
 ;
 

--- a/migration/iD13/postgresql/202511171122_IDEMPIERE-6724.sql
+++ b/migration/iD13/postgresql/202511171122_IDEMPIERE-6724.sql
@@ -1,0 +1,7 @@
+-- 
+SELECT register_migration_script('202511171122_IDEMPIERE-6724.sql') FROM dual;
+
+-- Nov 17, 2025, 11:23:32 AM BRT
+INSERT INTO AD_SysConfig (AD_SysConfig_ID,AD_Client_ID,AD_Org_ID,Created,Updated,CreatedBy,UpdatedBy,IsActive,Name,Value,Description,EntityType,ConfigurationLevel,AD_SysConfig_UU) VALUES (nextidfunc(50009,'N'),0,0,TO_TIMESTAMP('2025-11-17 11:23:32','YYYY-MM-DD HH24:MI:SS'),TO_TIMESTAMP('2025-11-17 11:23:32','YYYY-MM-DD HH24:MI:SS'),100,100,'Y','TRUNC_REPORT_DATE_FIELD','N','Y/N - Defines if TRUNC will be used in the Date type field of the report','D','S','019a9233-1488-794a-adc4-fdde6e16ac76')
+;
+

--- a/org.adempiere.base/src/org/compiere/model/MQuery.java
+++ b/org.adempiere.base/src/org/compiere/model/MQuery.java
@@ -255,7 +255,7 @@ public class MQuery implements Serializable, Cloneable
 				//	Date
 				else if (P_Date != null || P_Date_To != null)
 				{
-					boolean truncDate = MSysConfig.getBooleanValue(MSysConfig.TRUNC_REPORT_DATE_FIELD, false);
+					boolean truncDate = MSysConfig.getBooleanValue(MSysConfig.TRUNC_REPORT_DATE_FIELD, true);
 					boolean isDateTimeField = Reference_ID == DisplayType.DateTime || Reference_ID == DisplayType.Date;
 					String paramName = (isDateTimeField && !truncDate) ? ParameterName : "TRUNC(" + ParameterName + ")";
 

--- a/org.adempiere.base/src/org/compiere/model/MQuery.java
+++ b/org.adempiere.base/src/org/compiere/model/MQuery.java
@@ -255,7 +255,7 @@ public class MQuery implements Serializable, Cloneable
 				//	Date
 				else if (P_Date != null || P_Date_To != null)
 				{
-					String paramName = (Reference_ID == DisplayType.DateTime) ? ParameterName
+					String paramName = (Reference_ID == DisplayType.DateTime || Reference_ID == DisplayType.Date) ? ParameterName
 							: "TRUNC(" + ParameterName + ")";
 
 					if (P_Date_To == null)

--- a/org.adempiere.base/src/org/compiere/model/MQuery.java
+++ b/org.adempiere.base/src/org/compiere/model/MQuery.java
@@ -255,8 +255,9 @@ public class MQuery implements Serializable, Cloneable
 				//	Date
 				else if (P_Date != null || P_Date_To != null)
 				{
-					String paramName = (Reference_ID == DisplayType.DateTime || Reference_ID == DisplayType.Date) ? ParameterName
-							: "TRUNC(" + ParameterName + ")";
+					boolean truncDate = MSysConfig.getBooleanValue(MSysConfig.TRUNC_REPORT_DATE_FIELD, false);
+					boolean isDateTimeField = Reference_ID == DisplayType.DateTime || Reference_ID == DisplayType.Date;
+					String paramName = (isDateTimeField && !truncDate) ? ParameterName : "TRUNC(" + ParameterName + ")";
 
 					if (P_Date_To == null)
 					{

--- a/org.adempiere.base/src/org/compiere/model/MQuery.java
+++ b/org.adempiere.base/src/org/compiere/model/MQuery.java
@@ -256,9 +256,9 @@ public class MQuery implements Serializable, Cloneable
 				else if (P_Date != null || P_Date_To != null)
 				{
 					boolean truncDate = MSysConfig.getBooleanValue(MSysConfig.TRUNC_REPORT_DATE_FIELD, true);
-					boolean isDateTimeField = Reference_ID == DisplayType.DateTime || Reference_ID == DisplayType.Date;
-					String paramName = (isDateTimeField && !truncDate) ? ParameterName : "TRUNC(" + ParameterName + ")";
-
+					String paramName = (Reference_ID == DisplayType.Date && truncDate) ?
+						"TRUNC(" + ParameterName + ")" : ParameterName;
+					
 					if (P_Date_To == null)
 					{
 						parameterMap.put(ParameterName, DisplayType.getDateFormat().format(P_Date));

--- a/org.adempiere.base/src/org/compiere/model/MSysConfig.java
+++ b/org.adempiere.base/src/org/compiere/model/MSysConfig.java
@@ -209,6 +209,7 @@ public class MSysConfig extends X_AD_SysConfig
     public static final String TAX_LOOKUP_SERVICE = "TAX_LOOKUP_SERVICE";
     public static final String TOP_MARGIN_PIXELS_FOR_HEADER = "TOP_MARGIN_PIXELS_FOR_HEADER";
     public static final String TRACE_ALL_TRX_CONNECTION_GET = "TRACE_ALL_TRX_CONNECTION_GET";
+    public static final String TRUNC_REPORT_DATE_FIELD = "TRUNC_REPORT_DATE_FIELD";
     public static final String TRX_AUTOSET_DISPLAY_NAME = "TRX_AUTOSET_DISPLAY_NAME";
     public static final String TWOPACK_COMMIT_DDL = "2PACK_COMMIT_DDL";
     public static final String TWOPACK_HANDLE_TRANSLATIONS = "2PACK_HANDLE_TRANSLATIONS";


### PR DESCRIPTION
…ry TRUNC()

[Report Performance Issue with Date Parameters and MQuery TRUNC()](https://idempiere.atlassian.net/browse/IDEMPIERE-6724)


# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [] In hard-to-understand areas, I have commented my code.
- [] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [ ] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a system setting to control truncation of date fields in reports; a migration registers and inserts this configuration.

* **Bug Fixes**
  * Improved date-parameter handling so Date and DateTime restrictions are treated consistently and respect the new setting, producing more reliable date-based filters and report results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->