### PR TITLE
IDEMPIERE-6962: Receipt completion is slow or times out when invoice is created before receipt

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MInOut.java
+++ b/org.adempiere.base/src/org/compiere/model/MInOut.java
@@ -2100,9 +2100,11 @@ public class MInOut extends X_M_InOut implements DocAction, IDocsPostProcess
 							if (!po.isPosted())
 								addDocsPostProcess(po);
 							
-							MMatchInv[] matchInvList = MMatchInv.getInOut(getCtx(), getM_InOut_ID(), get_TrxName());
-							for (MMatchInv matchInvCreated : matchInvList)
-								addDocsPostProcess(matchInvCreated);
+							MMatchInv[] matchInvList = MMatchInv.getInOutLine(getCtx(), sLine.getM_InOutLine_ID(), get_TrxName());
+							for (MMatchInv matchInvCreated : matchInvList) {
+								if (!docsPostProcess.contains(matchInvCreated))
+									addDocsPostProcess(matchInvCreated);
+							}
 						}
 						//	Update PO with ASI
 						if (   oLine != null && oLine.getM_AttributeSetInstance_ID() == 0


### PR DESCRIPTION
xRef: [IDEMPIERE-6962](https://idempiere.atlassian.net/browse/IDEMPIERE-6962)



[IDEMPIERE-6962]: https://idempiere.atlassian.net/browse/IDEMPIERE-6962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of invoice-matching post-processing by refining record retrieval logic to use line-level details instead of header-level references.
  * Added deduplication safeguard to prevent duplicate entries from being processed during post-processing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->