### PR TITLE
IDEMPIERE-6972 Doc_Inventory posting fails with "No Costs for <product>" when a physical inventory contains a zero-difference line for a batch/lot-costed product

### DIFF
--- a/org.idempiere.acct/src/org/idempiere/acct/doc/Doc_Inventory.java
+++ b/org.idempiere.acct/src/org/idempiere/acct/doc/Doc_Inventory.java
@@ -165,9 +165,9 @@ public class Doc_Inventory extends Doc
 				qtyDiff = line.getQtyCount().subtract(line.getQtyBook());
 			else if (MDocType.DOCSUBTYPEINV_CostAdjustment.equals(docSubTypeInv))
 				amtDiff = line.getNewCostPrice().subtract(line.getCurrentCostPrice());
-			//	don't skip, nothing to post but there might be changes in the costing
-//			if (qtyDiff.signum() == 0 && amtDiff.signum() == 0)
-//				continue;
+			//	nothing to post
+			if (qtyDiff.signum() == 0 && amtDiff.signum() == 0)
+				continue;
 			//
 			DocLine docLine = new DocLine (line, this);
 			docLine.setQty (qtyDiff, false);		// -5 => -5

--- a/org.idempiere.test/src/org/idempiere/test/model/InventoryTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/InventoryTest.java
@@ -274,11 +274,72 @@ public class InventoryTest extends AbstractTestCase {
 		}
 	}
 	
-	private void createPOAndMRForProduct(int productId) {
-		createPOAndMRForProduct(productId, null);
+	/**
+	 * IDEMPIERE-6972
+	 * Doc_Inventory posting fails with "No Costs for <product>" when a physical inventory 
+	 * contains a zero-difference line for a batch/lot-costed product
+	 */
+	@Test
+	public void testZeroDifferenceInventoryLine() {
+		MClient client = MClient.get(Env.getCtx());
+		MAcctSchema as = client.getAcctSchema();
+		MProduct product = new MProduct(Env.getCtx(), DictionaryIDs.M_Product.FERTILIZER_50.id, getTrxName());
+
+		MAttributeSetInstance asi1 = new MAttributeSetInstance(Env.getCtx(), 0, getTrxName());
+		asi1.setM_AttributeSet_ID(product.getM_AttributeSet_ID());
+		asi1.setLot("asi1");
+		asi1.setDescription();
+		asi1.saveEx();
+		
+		MAttributeSetInstance asi2 = new MAttributeSetInstance(Env.getCtx(), 0, getTrxName());
+		asi2.setM_AttributeSet_ID(product.getM_AttributeSet_ID());
+		asi2.setLot("asi2");
+		asi2.setDescription();
+		asi2.saveEx();
+		
+		createPOAndMRForProduct(DictionaryIDs.M_Product.FERTILIZER_50.id, asi1, Env.ONEHUNDRED);
+		createPOAndMRForProduct(DictionaryIDs.M_Product.FERTILIZER_50.id, asi2, Env.ONEHUNDRED);
+		
+		MInventory inventory = new MInventory(Env.getCtx(), 0, getTrxName());
+		inventory.setC_DocType_ID(DictionaryIDs.C_DocType.MATERIAL_PHYSICAL_INVENTORY.id);
+		inventory.setCostingMethod(as.getCostingMethod());
+		inventory.saveEx();
+		
+		// Qty Count <> Qty Book
+		MInventoryLine line1 = new MInventoryLine(
+				inventory,
+				DictionaryIDs.M_Locator.HQ.id, 
+				product.getM_Product_ID(),
+				asi1.get_ID(),
+				Env.ONE, // QtyBook
+				Env.ONEHUNDRED); // QtyCount
+		line1.saveEx();
+		
+		// Qty Count = Qty Book
+		MInventoryLine line2 = new MInventoryLine(
+				inventory,
+				DictionaryIDs.M_Locator.HQ.id, 
+				product.getM_Product_ID(),
+				asi2.get_ID(),
+				Env.ONEHUNDRED, // QtyBook
+				Env.ONEHUNDRED); // QtyCount
+		line2.saveEx();
+		
+		ProcessInfo info = MWorkflow.runDocumentActionWorkflow(inventory, DocAction.ACTION_Complete);
+		assertFalse(info.isError(), info.getSummary());
+		inventory.load(getTrxName());
+		assertEquals(DocAction.STATUS_Completed, inventory.getDocStatus());
+		if (!inventory.isPosted()) {
+			String error = DocumentEngine.postImmediate(Env.getCtx(), inventory.getAD_Client_ID(), inventory.get_Table_ID(), inventory.get_ID(), false, getTrxName());
+			assertNull(error, error);
+		}
 	}
 	
-	private void createPOAndMRForProduct(int productId, MAttributeSetInstance asi) {
+	private void createPOAndMRForProduct(int productId) {
+		createPOAndMRForProduct(productId, null, BigDecimal.ONE);
+	}
+	
+	private void createPOAndMRForProduct(int productId, MAttributeSetInstance asi, BigDecimal qty) {
 		MOrder order = new MOrder(Env.getCtx(), 0, getTrxName());
 		order.setBPartner(MBPartner.get(Env.getCtx(), DictionaryIDs.C_BPartner.PATIO.id));
 		order.setC_DocTypeTarget_ID(DictionaryIDs.C_DocType.PURCHASE_ORDER.id);
@@ -294,7 +355,7 @@ public class InventoryTest extends AbstractTestCase {
 		MOrderLine line1 = new MOrderLine(order);
 		line1.setLine(10);
 		line1.setProduct(new MProduct(Env.getCtx(), productId, getTrxName()));
-		line1.setQty(new BigDecimal("1"));
+		line1.setQty(qty);
 		line1.setDatePromised(today);
 		line1.saveEx();
 		
@@ -309,8 +370,8 @@ public class InventoryTest extends AbstractTestCase {
 		receipt1.saveEx();
 
 		MInOutLine receiptLine1 = new MInOutLine(receipt1);
-		receiptLine1.setOrderLine(line1, 0, new BigDecimal("1"));
-		receiptLine1.setQty(new BigDecimal("1"));
+		receiptLine1.setOrderLine(line1, 0, qty);
+		receiptLine1.setQty(qty);
 		if (asi != null)
 			receiptLine1.setM_AttributeSetInstance_ID(asi.get_ID());
 		receiptLine1.saveEx();

--- a/org.idempiere.test/src/org/idempiere/test/model/InventoryTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/InventoryTest.java
@@ -280,7 +280,7 @@ public class InventoryTest extends AbstractTestCase {
 	 * MR2, Product1, ASI2, Qty=100
 	 * Physical Inventory
 	 * 	Line1, Product1, ASI1, QtyBook=1, QtyCount=100
-	 * 	Line2, Product1, ASI1, QtyBook=100, QtyCount=100
+	 * 	Line2, Product1, ASI2, QtyBook=100, QtyCount=100
 	 */
 	@Test
 	public void testZeroDifferenceInventoryLine() {

--- a/org.idempiere.test/src/org/idempiere/test/model/InventoryTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/InventoryTest.java
@@ -276,8 +276,11 @@ public class InventoryTest extends AbstractTestCase {
 	
 	/**
 	 * IDEMPIERE-6972
-	 * Doc_Inventory posting fails with "No Costs for <product>" when a physical inventory 
-	 * contains a zero-difference line for a batch/lot-costed product
+	 * MR1, Product1, ASI1, Qty=100
+	 * MR2, Product1, ASI2, Qty=100
+	 * Physical Inventory
+	 * 	Line1, Product1, ASI1, QtyBook=1, QtyCount=100
+	 * 	Line2, Product1, ASI1, QtyBook=100, QtyCount=100
 	 */
 	@Test
 	public void testZeroDifferenceInventoryLine() {
@@ -332,7 +335,9 @@ public class InventoryTest extends AbstractTestCase {
 		if (!inventory.isPosted()) {
 			String error = DocumentEngine.postImmediate(Env.getCtx(), inventory.getAD_Client_ID(), inventory.get_Table_ID(), inventory.get_ID(), false, getTrxName());
 			assertNull(error, error);
+			inventory.load(getTrxName());
 		}
+		assertTrue(inventory.isPosted(), "Inventory should be posted successfully");
 	}
 	
 	private void createPOAndMRForProduct(int productId) {


### PR DESCRIPTION
[IDEMPIERE-6972](https://idempiere.atlassian.net/browse/IDEMPIERE-6972) Doc_Inventory posting fails with "No Costs for <product>" when a physical inventory contains a zero-difference line for a batch/lot-costed product


# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [x] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.



[IDEMPIERE-6972]: https://idempiere.atlassian.net/browse/IDEMPIERE-6972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Inventory posting now skips lines that have zero quantity and zero amount differences for relevant inventory subtypes, preventing creation of unnecessary ledger entries.

* **Tests**
  * Added automated test validating inventory workflows with zero-difference lines, confirming completion and successful posting without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->