### PR TITLE
IDEMPIERE-6643 Refinement of WebSocket Server Push - restore back websocket as default for r14

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/DelegatingServerPush.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/DelegatingServerPush.java
@@ -28,6 +28,7 @@ import java.util.logging.Level;
 
 import org.compiere.model.SystemProperties;
 import org.compiere.util.CLogger;
+import org.compiere.util.Util;
 import org.idempiere.ui.zk.websocket.WebSocketServerPush;
 import org.zkoss.zk.ui.Desktop;
 import org.zkoss.zk.ui.DesktopUnavailableException;
@@ -74,11 +75,16 @@ public class DelegatingServerPush implements ServerPush {
 	 */
 	private ServerPush createDelegate() {
 		String pushType = SystemProperties.getZKServerPush();
+		if (pushType != null)
+			pushType = pushType.trim();
 
 		if (ATMOSPHERE.equalsIgnoreCase(pushType)) {
 			if (log.isLoggable(Level.INFO)) log.info("Using AtmosphereServerPush");
 			return new AtmosphereServerPush();
 		}
+
+		if (!Util.isEmpty(pushType) && !WEBSOCKET.equalsIgnoreCase(pushType))
+			log.warning("Unsupported org.idempiere.ui.zk.serverpush value '" + pushType + "', using WebSocketServerPush");
 
 		// Default to WebSocket
 		if (log.isLoggable(Level.INFO)) log.info("Using WebSocketServerPush");

--- a/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/DelegatingServerPush.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/DelegatingServerPush.java
@@ -42,9 +42,9 @@ import fi.jawsy.jawwa.zk.atmosphere.AtmosphereServerPush;
  * Delegating ServerPush implementation that switches between
  * WebSocketServerPush and AtmosphereServerPush based on JVM parameter.
  * <p>
- * Usage: Set the JVM parameter
- * {@code -Dorg.idempiere.ui.zk.serverpush=atmosphere} to use AtmosphereServerPush (or leave it unset as this is the default),
- * or {@code -Dorg.idempiere.ui.zk.serverpush=websocket} to use WebSocketServerPush.
+ * Usage: Set the JVM parameter {@code -Dorg.idempiere.ui.zk.serverpush=atmosphere}
+ * to use AtmosphereServerPush, or {@code -Dorg.idempiere.ui.zk.serverpush=websocket}
+ * (or leave unset) to use WebSocketServerPush (default).
  * </p>
  * 
  * @author Carlos Ruiz - globalqss
@@ -70,24 +70,19 @@ public class DelegatingServerPush implements ServerPush {
 
 	/**
 	 * Creates the appropriate ServerPush implementation based on JVM parameter.
-	 * @return ServerPush implementation (AtmosphereServerPush by default)
+	 * @return ServerPush implementation (WebSocketServerPush by default)
 	 */
 	private ServerPush createDelegate() {
 		String pushType = SystemProperties.getZKServerPush();
 
-		if (WEBSOCKET.equalsIgnoreCase(pushType)) {
-			if (log.isLoggable(Level.INFO)) log.info("Using WebSocketServerPush");
-			return new WebSocketServerPush();
+		if (ATMOSPHERE.equalsIgnoreCase(pushType)) {
+			if (log.isLoggable(Level.INFO)) log.info("Using AtmosphereServerPush");
+			return new AtmosphereServerPush();
 		}
 
-		if (pushType != null && !ATMOSPHERE.equalsIgnoreCase(pushType)) {
-			log.warning("Unsupported value for org.idempiere.ui.zk.serverpush: " + pushType
-					+ " - defaulting to AtmosphereServerPush");
-		}
-
-		// Default to Atmosphere
-		if (log.isLoggable(Level.INFO)) log.info("Using AtmosphereServerPush");
-		return new AtmosphereServerPush();
+		// Default to WebSocket
+		if (log.isLoggable(Level.INFO)) log.info("Using WebSocketServerPush");
+		return new WebSocketServerPush();
 	}
 
 	/**

--- a/org.adempiere.ui.zk/WEB-INF/zk.xml
+++ b/org.adempiere.ui.zk/WEB-INF/zk.xml
@@ -67,7 +67,7 @@
 		comet - org.zkoss.zkmax.ui.comet.CometServerPush ( enterprise edition only )
 	-->
 
-	<!-- set JVM -Dorg.idempiere.ui.zk.serverpush to atmosphere (default) or websocket -->
+	<!-- set JVM -Dorg.idempiere.ui.zk.serverpush to atmosphere or websocket (default) -->
 	<device-config>
 		<device-type>ajax</device-type>
 		<server-push-class>org.idempiere.ui.zk.DelegatingServerPush</server-push-class>


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-6643?focusedCommentId=70167

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Default server push now uses WebSocket for real-time client-server communication.
  * Configuration docs clarified to list supported push options and the new default.
  * Configuration behavior simplified: empty or unspecified values fall back to WebSocket; unsupported non-empty values are logged and also fall back to WebSocket.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->