### PR TITLE
IDEMPIERE-6793 MRole.isShowAcct returns false when Accounting Extension not installed

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MRole.java
+++ b/org.adempiere.base/src/org/compiere/model/MRole.java
@@ -47,6 +47,7 @@ import org.compiere.util.Trace;
 import org.compiere.util.Util;
 import org.compiere.wf.MWorkflow;
 import org.compiere.wf.MWorkflowAccess;
+import org.idempiere.acct.AcctModelServices;
 import org.idempiere.cache.ImmutablePOSupport;
 import org.idempiere.cache.POCopyCache;
 
@@ -3528,6 +3529,13 @@ public final class MRole extends X_AD_Role implements ImmutablePOSupport
 			predefinedContextVariables.append(get_Value(COLUMNNAME_PredefinedContextVariables).toString());
 		}
 		return predefinedContextVariables.toString();
+	}
+
+	@Override
+	public boolean isShowAcct() {
+		if (!AcctModelServices.isAccountingAvailable())
+			return false;
+		return super.isShowAcct();
 	}
 
 }	//	MRole


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-6793

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Accounting features will now only display when the accounting module is available in the system, preventing display of unavailable functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->