### PR TITLE
Fix: remove VSCode specific resource filters from .project files

### DIFF
--- a/org.idempiere.acct/.project
+++ b/org.idempiere.acct/.project
@@ -36,15 +36,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1774448868880</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/org.idempiere.extension.manager/.project
+++ b/org.idempiere.extension.manager/.project
@@ -36,15 +36,4 @@
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1773842098762</id>
-			<name></name>
-			<type>30</type>
-			<matcher>
-				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>


### PR DESCRIPTION
These filters (__CREATED_BY_JAVA_LANGUAGE_SERVER__) were accidentally committed in upstream and cause constant local modifications for developers using VSCode without these specific settings.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Eclipse project configuration by removing resource filtering rules from project files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->