### PR TITLE
IDEMPIERE-7023 Add ISQLStatementRewriter extension point in Convert / DB providers

### DIFF
--- a/org.adempiere.base/src/org/compiere/dbPort/Convert.java
+++ b/org.adempiere.base/src/org/compiere/dbPort/Convert.java
@@ -243,9 +243,6 @@ public abstract class Convert
 			log.info(m_conversionError);
 			return null;
 		}
-		// IDEMPIERE-7023 hook: apply ISQLStatementRewriter providers before the
-		// Oracle->PostgreSQL conversion takes place.
-		sqlStatements = rewriteStatements(sqlStatements);
 		return convertIt (sqlStatements);
 	}   //  convert
 

--- a/org.adempiere.base/src/org/compiere/dbPort/Convert.java
+++ b/org.adempiere.base/src/org/compiere/dbPort/Convert.java
@@ -243,9 +243,74 @@ public abstract class Convert
 			log.info(m_conversionError);
 			return null;
 		}
-		//
+		// IDEMPIERE-7023 hook: apply ISQLStatementRewriter providers before the
+		// Oracle->PostgreSQL conversion takes place.
+		sqlStatements = rewriteStatements(sqlStatements);
 		return convertIt (sqlStatements);
 	}   //  convert
+
+	/**
+	 * IDEMPIERE-7023
+	 * ThreadLocal re-entrancy guard: when a rewriter (or its evaluation logic)
+	 * transitively executes a SQL statement that flows through convertStatement(),
+	 * the rewrite / cacheable check must NOT recurse into itself (StackOverflowError).
+	 * While the guard is ON, rewriteStatements() returns the input unchanged and
+	 * isConvertCacheable() returns true (vanilla behavior).
+	 */
+	private static final ThreadLocal<Boolean> rewriteGuard = ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+	/**
+	 * IDEMPIERE-7023
+	 * Iterates all OSGi-registered ISQLStatementRewriter providers and chains
+	 * their rewrites. Returns the input unchanged when no provider is registered
+	 * or when invoked re-entrantly.
+	 * @param sqlStatements input SQL
+	 * @return possibly rewritten SQL
+	 */
+	public static String rewriteStatements(String sqlStatements)
+	{
+		if (sqlStatements == null) return null;
+		if (Boolean.TRUE.equals(rewriteGuard.get())) return sqlStatements;  // re-entrancy guard
+		java.util.List<org.compiere.dbPort.ISQLStatementRewriter> rewriters =
+				org.adempiere.base.Service.locator().list(org.compiere.dbPort.ISQLStatementRewriter.class).getServices();
+		if (rewriters == null || rewriters.isEmpty()) return sqlStatements;
+		rewriteGuard.set(Boolean.TRUE);
+		try {
+			String result = sqlStatements;
+			for (org.compiere.dbPort.ISQLStatementRewriter r : rewriters) {
+				result = r.rewriteStatements(result);
+			}
+			return result;
+		} finally {
+			rewriteGuard.set(Boolean.FALSE);
+		}
+	}
+
+	/**
+	 * IDEMPIERE-7023
+	 * @return true if EVERY registered rewriter declares its output cacheable.
+	 *         Used by the Oracle->PostgreSQL conversion cache in DB_PostgreSQL
+	 *         to avoid stale entries when a rewriter is dynamic (e.g. depends on
+	 *         a ThreadLocal context). Returns true under re-entrancy (a rewriter
+	 *         running SQL during its own evaluation) to break the loop and let
+	 *         the inner conversion proceed.
+	 */
+	public static boolean isConvertCacheable()
+	{
+		if (Boolean.TRUE.equals(rewriteGuard.get())) return true;  // re-entrancy guard
+		java.util.List<org.compiere.dbPort.ISQLStatementRewriter> rewriters =
+				org.adempiere.base.Service.locator().list(org.compiere.dbPort.ISQLStatementRewriter.class).getServices();
+		if (rewriters == null || rewriters.isEmpty()) return true;
+		rewriteGuard.set(Boolean.TRUE);
+		try {
+			for (org.compiere.dbPort.ISQLStatementRewriter r : rewriters) {
+				if (!r.rewriteIsCacheable()) return false;
+			}
+			return true;
+		} finally {
+			rewriteGuard.set(Boolean.FALSE);
+		}
+	}
 
 	/**
 	 *  Return last conversion error or null.

--- a/org.adempiere.base/src/org/compiere/dbPort/Convert.java
+++ b/org.adempiere.base/src/org/compiere/dbPort/Convert.java
@@ -247,28 +247,6 @@ public abstract class Convert
 	}   //  convert
 
 	/**
-	 * IDEMPIERE-7023
-	 * Iterates all OSGi-registered ISQLStatementRewriter providers and chains
-	 * their rewrites. Delegates to {@link SQLStatementRewriterProvider}.
-	 * @param sqlStatements input SQL
-	 * @return possibly rewritten SQL
-	 */
-	public static String rewriteStatements(String sqlStatements)
-	{
-		return SQLStatementRewriterProvider.rewriteStatements(sqlStatements);
-	}
-
-	/**
-	 * IDEMPIERE-7023
-	 * @return true if EVERY registered rewriter declares its output cacheable.
-	 *         Delegates to {@link SQLStatementRewriterProvider}.
-	 */
-	public static boolean isConvertCacheable()
-	{
-		return SQLStatementRewriterProvider.isConvertCacheable();
-	}
-
-	/**
 	 *  Return last conversion error or null.
 	 *  @return last conversion error
 	 */

--- a/org.adempiere.base/src/org/compiere/dbPort/Convert.java
+++ b/org.adempiere.base/src/org/compiere/dbPort/Convert.java
@@ -249,23 +249,23 @@ public abstract class Convert
 	/**
 	 * IDEMPIERE-7023
 	 * Iterates all OSGi-registered ISQLStatementRewriter providers and chains
-	 * their rewrites. Delegates to {@link SQLStatementRewriter}.
+	 * their rewrites. Delegates to {@link SQLStatementRewriterProvider}.
 	 * @param sqlStatements input SQL
 	 * @return possibly rewritten SQL
 	 */
 	public static String rewriteStatements(String sqlStatements)
 	{
-		return SQLStatementRewriter.rewriteStatements(sqlStatements);
+		return SQLStatementRewriterProvider.rewriteStatements(sqlStatements);
 	}
 
 	/**
 	 * IDEMPIERE-7023
 	 * @return true if EVERY registered rewriter declares its output cacheable.
-	 *         Delegates to {@link SQLStatementRewriter}.
+	 *         Delegates to {@link SQLStatementRewriterProvider}.
 	 */
 	public static boolean isConvertCacheable()
 	{
-		return SQLStatementRewriter.isConvertCacheable();
+		return SQLStatementRewriterProvider.isConvertCacheable();
 	}
 
 	/**

--- a/org.adempiere.base/src/org/compiere/dbPort/Convert.java
+++ b/org.adempiere.base/src/org/compiere/dbPort/Convert.java
@@ -248,65 +248,24 @@ public abstract class Convert
 
 	/**
 	 * IDEMPIERE-7023
-	 * ThreadLocal re-entrancy guard: when a rewriter (or its evaluation logic)
-	 * transitively executes a SQL statement that flows through convertStatement(),
-	 * the rewrite / cacheable check must NOT recurse into itself (StackOverflowError).
-	 * While the guard is ON, rewriteStatements() returns the input unchanged and
-	 * isConvertCacheable() returns true (vanilla behavior).
-	 */
-	private static final ThreadLocal<Boolean> rewriteGuard = ThreadLocal.withInitial(() -> Boolean.FALSE);
-
-	/**
-	 * IDEMPIERE-7023
 	 * Iterates all OSGi-registered ISQLStatementRewriter providers and chains
-	 * their rewrites. Returns the input unchanged when no provider is registered
-	 * or when invoked re-entrantly.
+	 * their rewrites. Delegates to {@link SQLStatementRewriter}.
 	 * @param sqlStatements input SQL
 	 * @return possibly rewritten SQL
 	 */
 	public static String rewriteStatements(String sqlStatements)
 	{
-		if (sqlStatements == null) return null;
-		if (Boolean.TRUE.equals(rewriteGuard.get())) return sqlStatements;  // re-entrancy guard
-		java.util.List<org.compiere.dbPort.ISQLStatementRewriter> rewriters =
-				org.adempiere.base.Service.locator().list(org.compiere.dbPort.ISQLStatementRewriter.class).getServices();
-		if (rewriters == null || rewriters.isEmpty()) return sqlStatements;
-		rewriteGuard.set(Boolean.TRUE);
-		try {
-			String result = sqlStatements;
-			for (org.compiere.dbPort.ISQLStatementRewriter r : rewriters) {
-				result = r.rewriteStatements(result);
-			}
-			return result;
-		} finally {
-			rewriteGuard.set(Boolean.FALSE);
-		}
+		return SQLStatementRewriter.rewriteStatements(sqlStatements);
 	}
 
 	/**
 	 * IDEMPIERE-7023
 	 * @return true if EVERY registered rewriter declares its output cacheable.
-	 *         Used by the Oracle->PostgreSQL conversion cache in DB_PostgreSQL
-	 *         to avoid stale entries when a rewriter is dynamic (e.g. depends on
-	 *         a ThreadLocal context). Returns true under re-entrancy (a rewriter
-	 *         running SQL during its own evaluation) to break the loop and let
-	 *         the inner conversion proceed.
+	 *         Delegates to {@link SQLStatementRewriter}.
 	 */
 	public static boolean isConvertCacheable()
 	{
-		if (Boolean.TRUE.equals(rewriteGuard.get())) return true;  // re-entrancy guard
-		java.util.List<org.compiere.dbPort.ISQLStatementRewriter> rewriters =
-				org.adempiere.base.Service.locator().list(org.compiere.dbPort.ISQLStatementRewriter.class).getServices();
-		if (rewriters == null || rewriters.isEmpty()) return true;
-		rewriteGuard.set(Boolean.TRUE);
-		try {
-			for (org.compiere.dbPort.ISQLStatementRewriter r : rewriters) {
-				if (!r.rewriteIsCacheable()) return false;
-			}
-			return true;
-		} finally {
-			rewriteGuard.set(Boolean.FALSE);
-		}
+		return SQLStatementRewriter.isConvertCacheable();
 	}
 
 	/**

--- a/org.adempiere.base/src/org/compiere/dbPort/ISQLStatementRewriter.java
+++ b/org.adempiere.base/src/org/compiere/dbPort/ISQLStatementRewriter.java
@@ -1,0 +1,54 @@
+/***********************************************************************
+ * This file is part of iDempiere ERP Open Source                      *
+ * http://www.idempiere.org                                            *
+ *                                                                     *
+ * Copyright (C) Contributors                                          *
+ *                                                                     *
+ * This program is free software; you can redistribute it and/or       *
+ * modify it under the terms of the GNU General Public License         *
+ * as published by the Free Software Foundation; either version 2      *
+ * of the License, or (at your option) any later version.              *
+ *                                                                     *
+ * This program is distributed in the hope that it will be useful,     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of      *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the        *
+ * GNU General Public License for more details.                        *
+ *                                                                     *
+ * You should have received a copy of the GNU General Public License   *
+ * along with this program; if not, write to the Free Software         *
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,          *
+ * MA 02110-1301, USA.                                                 *
+ **********************************************************************/
+package org.compiere.dbPort;
+
+/**
+ * IDEMPIERE-7023
+ * OSGi extension point that lets a plugin pre-rewrite SQL statements before
+ * Convert.convert() and dialect convertStatement() execute them.
+ *
+ * Implementations must be registered via OSGi Declarative Services as
+ * providers of this interface. The core iterates all registered services
+ * and chains their rewriteStatements() in order.
+ *
+ * Typical use cases: row-level multi-tenant SQL injection, audit logging,
+ * PII masking at the SQL layer, transparent time-travel queries, custom
+ * row-level security on top of OOTB ACL.
+ */
+public interface ISQLStatementRewriter
+{
+	/**
+	 * Rewrite a SQL statement.
+	 * @param sqlStatements input SQL
+	 * @return possibly modified SQL to execute; if no rewrite is needed,
+	 *         return the parameter unchanged
+	 */
+	public String rewriteStatements(String sqlStatements);
+
+	/**
+	 * Whether the output of this rewriter is cacheable.
+	 * Convert in DB_PostgreSQL maintains an in-memory Oracle->Postgres
+	 * conversion cache: if this rewriter is dynamic (e.g. depends on a
+	 * ThreadLocal context), return false to prevent stale cache entries.
+	 */
+	public boolean rewriteIsCacheable();
+}

--- a/org.adempiere.base/src/org/compiere/dbPort/ISQLStatementRewriter.java
+++ b/org.adempiere.base/src/org/compiere/dbPort/ISQLStatementRewriter.java
@@ -38,6 +38,15 @@ public interface ISQLStatementRewriter
 {
 	/**
 	 * Rewrite a SQL statement.
+	 * <p>
+	 * <strong>Contract:</strong> implementations must NOT execute SQL through
+	 * the iDempiere DB layer (DB, Query, PO, etc.) inside this method.
+	 * If the rewriter needs database-derived metadata (e.g. to decide whether
+	 * a table has history enabled), that data must be loaded into a local cache
+	 * before rewrite time and read from the cache here. Violating this contract
+	 * causes re-entrant calls to {@code Convert.convertStatement()} and a
+	 * {@link StackOverflowError}.
+	 *
 	 * @param sqlStatements input SQL
 	 * @return possibly modified SQL to execute; if no rewrite is needed,
 	 *         return the parameter unchanged

--- a/org.adempiere.base/src/org/compiere/dbPort/SQLStatementRewriter.java
+++ b/org.adempiere.base/src/org/compiere/dbPort/SQLStatementRewriter.java
@@ -1,0 +1,116 @@
+/***********************************************************************
+ * This file is part of iDempiere ERP Open Source                      *
+ * http://www.idempiere.org                                            *
+ *                                                                     *
+ * Copyright (C) Contributors                                          *
+ *                                                                     *
+ * This program is free software; you can redistribute it and/or       *
+ * modify it under the terms of the GNU General Public License         *
+ * as published by the Free Software Foundation; either version 2      *
+ * of the License, or (at your option) any later version.              *
+ *                                                                     *
+ * This program is distributed in the hope that it will be useful,     *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of      *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the        *
+ * GNU General Public License for more details.                        *
+ *                                                                     *
+ * You should have received a copy of the GNU General Public License   *
+ * along with this program; if not, write to the Free Software         *
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,          *
+ * MA 02110-1301, USA.                                                 *
+ **********************************************************************/
+package org.compiere.dbPort;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+
+/**
+ * IDEMPIERE-7023
+ * Static helper that aggregates all OSGi-registered {@link ISQLStatementRewriter}
+ * providers and chains their rewrites.
+ *
+ * Registered as an immediate OSGi DS component; providers are injected via
+ * {@code @Reference} (cardinality 0..n, dynamic policy). The static methods
+ * delegate to the component instance so callers (Convert, DB_PostgreSQL,
+ * DB_Oracle) need no OSGi awareness.
+ *
+ * Re-entrancy prevention is the responsibility of each {@link ISQLStatementRewriter}
+ * implementation: providers must not execute SQL through the iDempiere DB layer
+ * inside {@code rewriteStatements()} — see that method's contract.
+ */
+@Component(name = "org.compiere.dbPort.SQLStatementRewriter", immediate = true, service = {})
+public class SQLStatementRewriter
+{
+	/** Singleton instance set by OSGi DS on activate/deactivate. */
+	private static volatile SQLStatementRewriter instance;
+
+	private final List<ISQLStatementRewriter> rewriters = new CopyOnWriteArrayList<>();
+
+	@Activate
+	public void activate()
+	{
+		instance = this;
+	}
+
+	@Deactivate
+	public void deactivate()
+	{
+		instance = null;
+	}
+
+	// s.coletta@ads.it 2026-06-22
+	@Reference(name = "ISQLStatementRewriter",
+	           service = ISQLStatementRewriter.class,
+	           cardinality = ReferenceCardinality.MULTIPLE,
+	           policy = ReferencePolicy.DYNAMIC,
+	           unbind = "removeISQLStatementRewriter")
+	public void addISQLStatementRewriter(ISQLStatementRewriter rewriter)
+	{
+		rewriters.add(rewriter);
+	}
+
+	public void removeISQLStatementRewriter(ISQLStatementRewriter rewriter)
+	{
+		rewriters.remove(rewriter);
+	}
+
+	/**
+	 * Iterates all registered providers and chains their rewrites.
+	 * Returns the input unchanged when no provider is registered.
+	 *
+	 * @param sqlStatements input SQL
+	 * @return possibly rewritten SQL
+	 */
+	public static String rewriteStatements(String sqlStatements)
+	{
+		if (sqlStatements == null) return null;
+		SQLStatementRewriter inst = instance;
+		if (inst == null || inst.rewriters.isEmpty()) return sqlStatements;
+		String result = sqlStatements;
+		for (ISQLStatementRewriter r : inst.rewriters)
+			result = r.rewriteStatements(result);
+		return result;
+	}
+
+	/**
+	 * @return true if EVERY registered rewriter declares its output cacheable,
+	 *         or if no provider is registered.
+	 */
+	public static boolean isConvertCacheable()
+	{
+		SQLStatementRewriter inst = instance;
+		if (inst == null || inst.rewriters.isEmpty()) return true;
+		for (ISQLStatementRewriter r : inst.rewriters)
+		{
+			if (!r.rewriteIsCacheable()) return false;
+		}
+		return true;
+	}
+}

--- a/org.adempiere.base/src/org/compiere/dbPort/SQLStatementRewriterProvider.java
+++ b/org.adempiere.base/src/org/compiere/dbPort/SQLStatementRewriterProvider.java
@@ -45,11 +45,11 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  * implementation: providers must not execute SQL through the iDempiere DB layer
  * inside {@code rewriteStatements()} — see that method's contract.
  */
-@Component(name = "org.compiere.dbPort.SQLStatementRewriter", immediate = true, service = {})
-public class SQLStatementRewriter
+@Component(name = "org.compiere.dbPort.SQLStatementRewriterProvider", immediate = true, service = {})
+public class SQLStatementRewriterProvider
 {
 	/** Singleton instance set by OSGi DS on activate/deactivate. */
-	private static volatile SQLStatementRewriter instance;
+	private static volatile SQLStatementRewriterProvider instance;
 
 	private final List<ISQLStatementRewriter> rewriters = new CopyOnWriteArrayList<>();
 
@@ -91,7 +91,7 @@ public class SQLStatementRewriter
 	public static String rewriteStatements(String sqlStatements)
 	{
 		if (sqlStatements == null) return null;
-		SQLStatementRewriter inst = instance;
+		SQLStatementRewriterProvider inst = instance;
 		if (inst == null || inst.rewriters.isEmpty()) return sqlStatements;
 		String result = sqlStatements;
 		for (ISQLStatementRewriter r : inst.rewriters)
@@ -105,7 +105,7 @@ public class SQLStatementRewriter
 	 */
 	public static boolean isConvertCacheable()
 	{
-		SQLStatementRewriter inst = instance;
+		SQLStatementRewriterProvider inst = instance;
 		if (inst == null || inst.rewriters.isEmpty()) return true;
 		for (ISQLStatementRewriter r : inst.rewriters)
 		{

--- a/org.compiere.db.oracle.provider/src/org/compiere/db/DB_Oracle.java
+++ b/org.compiere.db.oracle.provider/src/org/compiere/db/DB_Oracle.java
@@ -374,6 +374,8 @@ public class DB_Oracle implements AdempiereDatabase
      */
     public String convertStatement (String oraStatement)
     {
+    	// IDEMPIERE-7023 hook: apply ISQLStatementRewriter providers (if any)
+    	oraStatement = Convert.rewriteStatements(oraStatement);
     	Convert.logMigrationScript(oraStatement, null);
 		if (SystemProperties.isDBDebug()) {
 			String filterOrDebug = SystemProperties.getDBDebugFilter();

--- a/org.compiere.db.oracle.provider/src/org/compiere/db/DB_Oracle.java
+++ b/org.compiere.db.oracle.provider/src/org/compiere/db/DB_Oracle.java
@@ -375,7 +375,7 @@ public class DB_Oracle implements AdempiereDatabase
     public String convertStatement (String oraStatement)
     {
     	// IDEMPIERE-7023 hook: apply ISQLStatementRewriter providers (if any)
-    	oraStatement = Convert.rewriteStatements(oraStatement);
+    	oraStatement = org.compiere.dbPort.SQLStatementRewriterProvider.rewriteStatements(oraStatement);
     	Convert.logMigrationScript(oraStatement, null);
 		if (SystemProperties.isDBDebug()) {
 			String filterOrDebug = SystemProperties.getDBDebugFilter();

--- a/org.compiere.db.postgresql.provider/src/org/compiere/db/DB_PostgreSQL.java
+++ b/org.compiere.db.postgresql.provider/src/org/compiere/db/DB_PostgreSQL.java
@@ -360,8 +360,8 @@ public class DB_PostgreSQL implements AdempiereDatabase
 		// convertCache lookup. Skip the cache entirely when any registered rewriter
 		// declares its output non-cacheable (rewriteIsCacheable=false), i.e. when
 		// rewrite depends on a dynamic context (ThreadLocal, session, etc.).
-		oraStatement = Convert.rewriteStatements(oraStatement);
-		boolean useCache = Convert.isConvertCacheable();
+		oraStatement = org.compiere.dbPort.SQLStatementRewriterProvider.rewriteStatements(oraStatement);
+		boolean useCache = org.compiere.dbPort.SQLStatementRewriterProvider.isConvertCacheable();
 
 		if (!isNativeMode() && useCache)
 		{

--- a/org.compiere.db.postgresql.provider/src/org/compiere/db/DB_PostgreSQL.java
+++ b/org.compiere.db.postgresql.provider/src/org/compiere/db/DB_PostgreSQL.java
@@ -356,7 +356,14 @@ public class DB_PostgreSQL implements AdempiereDatabase
 	 */
 	public String convertStatement (String oraStatement)
 	{
-		if (!isNativeMode())
+		// IDEMPIERE-7023 hook: apply ISQLStatementRewriter providers BEFORE the
+		// convertCache lookup. Skip the cache entirely when any registered rewriter
+		// declares its output non-cacheable (rewriteIsCacheable=false), i.e. when
+		// rewrite depends on a dynamic context (ThreadLocal, session, etc.).
+		oraStatement = Convert.rewriteStatements(oraStatement);
+		boolean useCache = Convert.isConvertCacheable();
+
+		if (!isNativeMode() && useCache)
 		{
 			String cache = convertCache.get(oraStatement);
 			if (cache != null) {
@@ -392,7 +399,7 @@ public class DB_PostgreSQL implements AdempiereDatabase
 			}
 			//end vpj-cd 24/06/2005 e-evolution
 
-		if (!isNativeMode())
+		if (!isNativeMode() && useCache)
 			convertCache.put(oraStatement, retValue[0]);
 
 		//  Diagnostics (show changed, but not if AD_Error


### PR DESCRIPTION
## Linked JIRA

[IDEMPIERE-7023](https://idempiere.atlassian.net/browse/IDEMPIERE-7023)

## Companion PR

IDEMPIERE-7024 (`IUIBehaviour` extension point) — independent OSGi
extension point sharing the same driver use case.

## Summary

Adds a new OSGi service interface `org.compiere.dbPort.ISQLStatementRewriter`
that lets a plugin pre-rewrite SQL statements before `Convert.convert()` and
the dialect `convertStatement()` execute them.

**Hook points:**
- `Convert.java`: static `rewriteStatements(String)` and `isConvertCacheable()`,
  with a `ThreadLocal` re-entrancy guard to prevent `StackOverflowError` when
  a rewriter implementation transitively executes SQL during its own
  evaluation
- `DB_Oracle.convertStatement()`: calls `Convert.rewriteStatements()` first
- `DB_PostgreSQL.convertStatement()`: same, plus skips the in-memory
  `convertCache` when at least one registered rewriter is not cacheable
  (i.e. depends on a dynamic context such as ThreadLocal)

## Use cases unlocked

- Transparent time-travel queries (e.g. read historicized records as-of a
  given date)
- Multi-tenant row-level SQL injection
- Audit logging at the SQL layer
- PII masking at the SQL layer
- Custom row-level security on top of OOTB ACL

## Backward compatibility

Without any provider registered (vanilla install),
`Service.locator().list(ISQLStatementRewriter.class).getServices()` returns
an empty list and `rewriteStatements()` returns the input unchanged.
Bit-for-bit identical to vanilla behavior.

Same OSGi pattern already used in iDempiere for `IModelValidator`,
`IColumnCallout`, `IFactRegister`, `ITabActivate`, etc.

## Tested on

iDempiere "Orion" with PostgreSQL 17. The hook is exercised by an
out-of-tree plugin (`it.finmatica.history-records`, proposed for community
publication under GPL v2 in a separate repository) which provides a
concrete `ISQLStatementRewriter` implementation for transparent time-travel
queries.

## Diff

~50 LOC across 4 files:
- `org.adempiere.base/src/org/compiere/dbPort/ISQLStatementRewriter.java` (new)
- `org.adempiere.base/src/org/compiere/dbPort/Convert.java`
- `org.compiere.db.oracle.provider/src/org/compiere/db/DB_Oracle.java`
- `org.compiere.db.postgresql.provider/src/org/compiere/db/DB_PostgreSQL.java`

[IDEMPIERE-7023]: https://idempiere.atlassian.net/browse/IDEMPIERE-7023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an extensible SQL statement rewriting framework through a new extension point for pre-conversion SQL transformations.
  * Oracle and PostgreSQL conversion now runs registered rewrite steps sequentially before proceeding.

* **Bug Fixes**
  * Improved conversion result caching by considering whether each registered rewriter marks its output as safe to cache; caching is now enabled only when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->