### PR TITLE
IDEMPIERE-7038 iDempiere master/release-13 not compatible with Eclipse 2026-06

### DIFF
--- a/org.adempiere.base-feature/feature.xml
+++ b/org.adempiere.base-feature/feature.xml
@@ -366,10 +366,6 @@
          version="0.0.0"/>
 
    <plugin
-         id="javax.xml"
-         version="0.0.0"/>
-
-   <plugin
          id="org.eclipse.osgi"
          version="0.0.0"/>
 

--- a/org.adempiere.base/OSGI-INF/org.adempiere.base.PayScheduleManager.xml
+++ b/org.adempiere.base/OSGI-INF/org.adempiere.base.PayScheduleManager.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.adempiere.base.PayScheduleManager" immediate="true">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.adempiere.base.PayScheduleManager">
+   <service>
+      <provide interface="org.adempiere.base.PayScheduleManager"/>
+   </service>
    <implementation class="org.adempiere.base.PayScheduleManager"/>
    <reference bind="bindPayScheduleManager" cardinality="0..n" interface="org.adempiere.base.IPayScheduleManager" name="IPayScheduleManager" policy="dynamic" unbind="unbindPayScheduleManager"/>
 </scr:component>

--- a/org.adempiere.base/src/org/adempiere/base/PayScheduleManager.java
+++ b/org.adempiere.base/src/org/adempiere/base/PayScheduleManager.java
@@ -54,8 +54,9 @@ public class PayScheduleManager
 		cardinality = ReferenceCardinality.MULTIPLE,
 		policy = ReferencePolicy.DYNAMIC,
 		bind = "bindPayScheduleManager",
-		unbind = "unbindPayScheduleManager"
-	)
+		unbind = "unbindPayScheduleManager",
+		name = "IPayScheduleManager"
+		)
 	public synchronized void bindPayScheduleManager(IPayScheduleManager<?> manager, Map<String, Object> properties)
 	{
 		int ranking = 0;

--- a/org.adempiere.base/src/org/adempiere/base/StorageValidatorProvider.java
+++ b/org.adempiere.base/src/org/adempiere/base/StorageValidatorProvider.java
@@ -53,7 +53,8 @@ public class StorageValidatorProvider {
 		service = IStorageValidator.class,
 		cardinality = ReferenceCardinality.MULTIPLE,
 		policy = ReferencePolicy.DYNAMIC,
-		unbind = "unbindStorageValidator"
+		unbind = "unbindStorageValidator",
+		name = "IStorageValidator"
 	)
 	public synchronized void bindStorageValidator(IStorageValidator validator, Map<String, Object> properties) {
 		if (validator == null)

--- a/org.adempiere.server-feature/server.product.functionaltest.launch
+++ b/org.adempiere.server-feature/server.product.functionaltest.launch
@@ -147,7 +147,6 @@
         <setEntry value="javax.servlet.jsp.jstl-api@default:default"/>
         <setEntry value="javax.validation.api@default:default"/>
         <setEntry value="javax.websocket-api@default:default"/>
-        <setEntry value="javax.xml@default:default"/>
         <setEntry value="jaxen@default:default"/>
         <setEntry value="joda-time@default:default"/>
         <setEntry value="json@default:default"/>

--- a/org.adempiere.server-feature/server.product.launch
+++ b/org.adempiere.server-feature/server.product.launch
@@ -147,7 +147,6 @@
         <setEntry value="javax.servlet.jsp.jstl-api@default:default"/>
         <setEntry value="javax.validation.api@default:default"/>
         <setEntry value="javax.websocket-api@default:default"/>
-        <setEntry value="javax.xml@default:default"/>
         <setEntry value="jaxen@default:default"/>
         <setEntry value="joda-time@default:default"/>
         <setEntry value="json@default:default"/>

--- a/org.idempiere.hazelcast.service/OSGI-INF/org.idempiere.hazelcast.service.Activator.xml
+++ b/org.idempiere.hazelcast.service/OSGI-INF/org.idempiere.hazelcast.service.Activator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" activate="activate" deactivate="deactivate" immediate="true" name="org.idempiere.hazelcast.service.Activator">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" deactivate="deactivate" immediate="true" name="org.idempiere.hazelcast.service.Activator">
    <reference cardinality="1..1" field="distributedCondition" interface="org.osgi.service.condition.Condition" name="distributedCondition" target="(osgi.condition.id=distributed.provider.hazelcast)"/>
    <implementation class="org.idempiere.hazelcast.service.Activator"/>
 </scr:component>

--- a/org.idempiere.p2.profile/core/core.product.launch
+++ b/org.idempiere.p2.profile/core/core.product.launch
@@ -147,7 +147,6 @@
         <setEntry value="javax.servlet.jsp.jstl-api@default:default"/>
         <setEntry value="javax.validation.api@default:default"/>
         <setEntry value="javax.websocket-api@default:default"/>
-        <setEntry value="javax.xml@default:default"/>
         <setEntry value="jaxen@default:default"/>
         <setEntry value="joda-time@default:default"/>
         <setEntry value="json@default:default"/>

--- a/org.idempiere.p2.profile/extended/extended.product.launch
+++ b/org.idempiere.p2.profile/extended/extended.product.launch
@@ -147,7 +147,6 @@
         <setEntry value="javax.servlet.jsp.jstl-api@default:default"/>
         <setEntry value="javax.validation.api@default:default"/>
         <setEntry value="javax.websocket-api@default:default"/>
-        <setEntry value="javax.xml@default:default"/>
         <setEntry value="jaxen@default:default"/>
         <setEntry value="joda-time@default:default"/>
         <setEntry value="json@default:default"/>

--- a/org.idempiere.p2.targetplatform/base.target
+++ b/org.idempiere.p2.targetplatform/base.target
@@ -142,7 +142,6 @@
       <unit id="org.w3c.dom.smil" version="1.0.1.v200903091627"/>
       <unit id="org.w3c.dom.svg" version="1.1.0.v201011041433"/>
       <unit id="org.w3c.dom.events" version="3.0.0.draft20060413_v201105210656"/>
-      <unit id="javax.xml" version="1.3.4.v201005080400"/>
       <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220302172233/repository"/>
     </location>
     <location includeMode="slicer" includeAllPlatforms="true" includeSource="true" includeConfigurePhase="true" type="InstallableUnit">

--- a/org.idempiere.p2.targetplatform/base.tpd
+++ b/org.idempiere.p2.targetplatform/base.tpd
@@ -160,8 +160,6 @@ location "https://download.eclipse.org/tools/orbit/downloads/drops/R202203021722
 	org.w3c.dom.smil
 	org.w3c.dom.svg
 	org.w3c.dom.events
-	// 1.3.4
-	javax.xml	
 }
 
 location jasperstudio "https://idempiere.github.io/binary.file/p2.repackaged/jasperstudio/6.17.0" {

--- a/org.idempiere.redis.service/OSGI-INF/org.idempiere.redis.service.Activator.xml
+++ b/org.idempiere.redis.service/OSGI-INF/org.idempiere.redis.service.Activator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" activate="activate" deactivate="deactivate" immediate="true" name="org.idempiere.redis.service.Activator">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" deactivate="deactivate" immediate="true" name="org.idempiere.redis.service.Activator">
    <reference cardinality="1..1" field="distributedCondition" interface="org.osgi.service.condition.Condition" name="distributedCondition" target="(osgi.condition.id=distributed.provider.redis)"/>
    <implementation class="org.idempiere.redis.service.Activator"/>
 </scr:component>

--- a/org.idempiere.redis.service/OSGI-INF/org.idempiere.redis.service.CacheServiceImpl.xml
+++ b/org.idempiere.redis.service/OSGI-INF/org.idempiere.redis.service.CacheServiceImpl.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" activate="activate" enabled="true" immediate="true" name="org.idempiere.redis.service.CacheServiceImpl">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" enabled="true" immediate="true" name="org.idempiere.redis.service.CacheServiceImpl">
    <service>
       <provide interface="org.idempiere.distributed.ICacheService"/>
    </service>

--- a/org.idempiere.redis.service/OSGI-INF/org.idempiere.redis.service.ClusterServiceImpl.xml
+++ b/org.idempiere.redis.service/OSGI-INF/org.idempiere.redis.service.ClusterServiceImpl.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" activate="activate" deactivate="deactivate" enabled="true" immediate="true" name="org.idempiere.redis.service.ClusterServiceImpl">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.3.0" deactivate="deactivate" enabled="true" immediate="true" name="org.idempiere.redis.service.ClusterServiceImpl">
    <service>
       <provide interface="org.idempiere.distributed.IClusterService"/>
    </service>


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-7038

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [ ] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the `javax.xml` unit/bundle from the Eclipse target platform and OSGi launch configuration bundle lists to streamline the selected runtime contents.
* **Refactor**
  * Updated OSGi service reference metadata for payment schedule and storage validation bindings to improve service identification without changing binding/unbinding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->