### PR TITLE
IDEMPIERE-7062 Sales Order changing documentNo even when the sequence is the same

### DIFF
--- a/org.adempiere.base.callout/src/org/compiere/model/CalloutOrder.java
+++ b/org.adempiere.base.callout/src/org/compiere/model/CalloutOrder.java
@@ -59,7 +59,7 @@ public class CalloutOrder extends CalloutEngine
 	 *  @param mTab     Model Tab
 	 *  @param mField   Model Field
 	 *  @param value    The new value
-	 *  @param value    The old value
+	 *  @param oldValue The old value
 	 *  @return Error message or ""
 	 */
 	public String docType (Properties ctx, int WindowNo, GridTab mTab, GridField mField, Object value, Object oldValue)

--- a/org.adempiere.base.callout/src/org/compiere/model/CalloutOrder.java
+++ b/org.adempiere.base.callout/src/org/compiere/model/CalloutOrder.java
@@ -59,9 +59,10 @@ public class CalloutOrder extends CalloutEngine
 	 *  @param mTab     Model Tab
 	 *  @param mField   Model Field
 	 *  @param value    The new value
+	 *  @param value    The old value
 	 *  @return Error message or ""
 	 */
-	public String docType (Properties ctx, int WindowNo, GridTab mTab, GridField mField, Object value)
+	public String docType (Properties ctx, int WindowNo, GridTab mTab, GridField mField, Object value, Object oldValue)
 	{
 		Integer C_DocType_ID = (Integer)value;		//	Actually C_DocTypeTarget_ID
 		if (C_DocType_ID == null || C_DocType_ID.intValue() == 0)
@@ -73,7 +74,9 @@ public class CalloutOrder extends CalloutEngine
 		boolean newDocNo = (oldDocNo == null);
 		if (!newDocNo && oldDocNo.startsWith("<") && oldDocNo.endsWith(">"))
 			newDocNo = true;
-		Integer oldC_DocType_ID = (Integer)mTab.getValue("C_DocType_ID");
+		Integer oldC_DocType_ID = (Integer)oldValue;
+		if (oldC_DocType_ID == null)
+			oldC_DocType_ID = 0;
 
 		String sql = "SELECT d.DocSubTypeSO,d.HasCharges,"			//	1..2
 			+ "d.IsDocNoControlled,"     //  3


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-7062

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order document number behavior when the document type is changed.
  * The system now correctly uses the previously selected document type when determining whether to recreate or adjust the existing order document number, avoiding unnecessary or incorrect updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->