### PR TITLE
IDEMPIERE-6552 SSO with OIDC enforces a login form

### DIFF
--- a/migration/iD14/oracle/202607261257_IDEMPIERE-6552.sql
+++ b/migration/iD14/oracle/202607261257_IDEMPIERE-6552.sql
@@ -1,0 +1,41 @@
+-- IDEMPIERE-6552 Make OIDC force login configurable by provider
+SELECT register_migration_script('202607261257_IDEMPIERE-6552.sql') FROM dual;
+
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Jul 26, 2026, 12:57:59 PM CEST
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,ColumnName,Name,Description,Help,PrintName,EntityType,AD_Element_UU) VALUES (204119,0,0,'Y',TO_TIMESTAMP('2026-07-26 12:57:59','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-07-26 12:57:59','YYYY-MM-DD HH24:MI:SS'),100,'IsForceLogin','Force Login','Require the OpenID Connect provider to reauthenticate the user','When enabled, the authorization request includes prompt=login. Disable it to allow reuse of an existing provider session or remember-me cookie.','Force Login','D','019f9e13-18e2-7ff2-9bbe-1725dd523b37')
+;
+
+-- Jul 26, 2026, 1:01:27 PM CEST
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,IsHtml,IsPartitionKey) VALUES (217653,0,'Force Login','Require the OpenID Connect provider to reauthenticate the user','When enabled, the authorization request includes prompt=login. Disable it to allow reuse of an existing provider session or remember-me cookie.',200360,'IsForceLogin','Y',1,'N','N','Y','N','N',0,'N',20,0,0,'Y',TO_TIMESTAMP('2026-07-26 13:01:26','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-07-26 13:01:26','YYYY-MM-DD HH24:MI:SS'),100,204119,'Y','N','D','N','N','N','Y','019f9e16-43b8-7be9-8aa4-d07eb1c80e6c','Y',0,'N','N','N','N')
+;
+
+-- Jul 26, 2026, 1:02:00 PM CEST
+ALTER TABLE SSO_PrincipalConfig ADD IsForceLogin CHAR(1) DEFAULT 'Y' CHECK (IsForceLogin IN ('Y','N')) NOT NULL
+;
+
+-- Jul 26, 2026, 1:05:19 PM CEST
+ALTER TABLE SSO_PrincipalConfig MODIFY IsForceLogin CHAR(1) DEFAULT 'Y'
+;
+
+-- Jul 26, 2026, 1:05:19 PM CEST
+UPDATE SSO_PrincipalConfig SET IsForceLogin='Y' WHERE IsForceLogin IS NULL
+;
+
+-- Jul 26, 2026, 1:08:07 PM CEST
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan) VALUES (209238,'Force Login','Require the OpenID Connect provider to reauthenticate the user','When enabled, the authorization request includes prompt=login. Disable it to allow reuse of an existing provider session or remember-me cookie.',200328,217653,'Y',1,160,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2026-07-26 13:08:07','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-07-26 13:08:07','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','019f9e1c-611a-700a-baa0-441627d8c858','Y',160,2,2)
+;
+
+-- Jul 26, 2026, 1:10:01 PM CEST
+UPDATE AD_Field SET DisplayLogic='@SSO_Provider@=''OIDC''',Updated=TO_TIMESTAMP('2026-07-26 13:10:01','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=209238
+;
+
+-- Jul 26, 2026, 1:12:11 PM CEST
+UPDATE AD_Field SET SeqNo=130,Updated=TO_TIMESTAMP('2026-07-26 13:12:11','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207414
+;
+
+-- Jul 26, 2026, 1:12:11 PM CEST
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=140, XPosition=2,Updated=TO_TIMESTAMP('2026-07-26 13:12:11','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=209238
+;

--- a/migration/iD14/postgresql/202607261257_IDEMPIERE-6552.sql
+++ b/migration/iD14/postgresql/202607261257_IDEMPIERE-6552.sql
@@ -1,0 +1,38 @@
+-- IDEMPIERE-6552 Make OIDC force login configurable by provider
+SELECT register_migration_script('202607261257_IDEMPIERE-6552.sql') FROM dual;
+
+-- Jul 26, 2026, 12:57:59 PM CEST
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,ColumnName,Name,Description,Help,PrintName,EntityType,AD_Element_UU) VALUES (204119,0,0,'Y',TO_TIMESTAMP('2026-07-26 12:57:59','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-07-26 12:57:59','YYYY-MM-DD HH24:MI:SS'),100,'IsForceLogin','Force Login','Require the OpenID Connect provider to reauthenticate the user','When enabled, the authorization request includes prompt=login. Disable it to allow reuse of an existing provider session or remember-me cookie.','Force Login','D','019f9e13-18e2-7ff2-9bbe-1725dd523b37')
+;
+
+-- Jul 26, 2026, 1:01:27 PM CEST
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,IsHtml,IsPartitionKey) VALUES (217653,0,'Force Login','Require the OpenID Connect provider to reauthenticate the user','When enabled, the authorization request includes prompt=login. Disable it to allow reuse of an existing provider session or remember-me cookie.',200360,'IsForceLogin','Y',1,'N','N','Y','N','N',0,'N',20,0,0,'Y',TO_TIMESTAMP('2026-07-26 13:01:26','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-07-26 13:01:26','YYYY-MM-DD HH24:MI:SS'),100,204119,'Y','N','D','N','N','N','Y','019f9e16-43b8-7be9-8aa4-d07eb1c80e6c','Y',0,'N','N','N','N')
+;
+
+-- Jul 26, 2026, 1:02:00 PM CEST
+ALTER TABLE SSO_PrincipalConfig ADD COLUMN IsForceLogin CHAR(1) DEFAULT 'Y' CHECK (IsForceLogin IN ('Y','N')) NOT NULL
+;
+
+-- Jul 26, 2026, 1:05:19 PM CEST
+INSERT INTO t_alter_column values('sso_principalconfig','IsForceLogin','CHAR(1)',null,'Y')
+;
+
+-- Jul 26, 2026, 1:05:19 PM CEST
+UPDATE SSO_PrincipalConfig SET IsForceLogin='Y' WHERE IsForceLogin IS NULL
+;
+
+-- Jul 26, 2026, 1:08:07 PM CEST
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan) VALUES (209238,'Force Login','Require the OpenID Connect provider to reauthenticate the user','When enabled, the authorization request includes prompt=login. Disable it to allow reuse of an existing provider session or remember-me cookie.',200328,217653,'Y',1,160,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2026-07-26 13:08:07','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-07-26 13:08:07','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','019f9e1c-611a-700a-baa0-441627d8c858','Y',160,2,2)
+;
+
+-- Jul 26, 2026, 1:10:01 PM CEST
+UPDATE AD_Field SET DisplayLogic='@SSO_Provider@=''OIDC''',Updated=TO_TIMESTAMP('2026-07-26 13:10:01','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=209238
+;
+
+-- Jul 26, 2026, 1:12:11 PM CEST
+UPDATE AD_Field SET SeqNo=130,Updated=TO_TIMESTAMP('2026-07-26 13:12:11','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207414
+;
+
+-- Jul 26, 2026, 1:12:11 PM CEST
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=140, XPosition=2,Updated=TO_TIMESTAMP('2026-07-26 13:12:11','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=209238
+;

--- a/org.adempiere.base/src/org/compiere/model/I_SSO_PrincipalConfig.java
+++ b/org.adempiere.base/src/org/compiere/model/I_SSO_PrincipalConfig.java
@@ -22,7 +22,7 @@ import org.compiere.util.KeyNamePair;
 
 /** Generated Interface for SSO_PrincipalConfig
  *  @author iDempiere (generated) 
- *  @version Release 13
+ *  @version Release 14
  */
 public interface I_SSO_PrincipalConfig 
 {
@@ -103,6 +103,19 @@ public interface I_SSO_PrincipalConfig
 	  * Default value
 	  */
 	public boolean isDefault();
+
+    /** Column name IsForceLogin */
+    public static final String COLUMNNAME_IsForceLogin = "IsForceLogin";
+
+	/** Set Force Login.
+	  * Require the OpenID Connect provider to reauthenticate the user
+	  */
+	public void setIsForceLogin (boolean IsForceLogin);
+
+	/** Get Force Login.
+	  * Require the OpenID Connect provider to reauthenticate the user
+	  */
+	public boolean isForceLogin();
 
     /** Column name Name */
     public static final String COLUMNNAME_Name = "Name";

--- a/org.adempiere.base/src/org/compiere/model/X_SSO_PrincipalConfig.java
+++ b/org.adempiere.base/src/org/compiere/model/X_SSO_PrincipalConfig.java
@@ -22,7 +22,7 @@ import java.util.Properties;
 
 /** Generated Model for SSO_PrincipalConfig
  *  @author iDempiere (generated)
- *  @version Release 13 - $Id$ */
+ *  @version Release 14 - $Id$ */
 @org.adempiere.base.Model(table="SSO_PrincipalConfig")
 public class X_SSO_PrincipalConfig extends PO implements I_SSO_PrincipalConfig, I_Persistent
 {
@@ -30,7 +30,7 @@ public class X_SSO_PrincipalConfig extends PO implements I_SSO_PrincipalConfig, 
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20260309L;
+	private static final long serialVersionUID = 20260726L;
 
     /** Standard Constructor */
     public X_SSO_PrincipalConfig (Properties ctx, int SSO_PrincipalConfig_ID, String trxName)
@@ -38,6 +38,8 @@ public class X_SSO_PrincipalConfig extends PO implements I_SSO_PrincipalConfig, 
       super (ctx, SSO_PrincipalConfig_ID, trxName);
       /** if (SSO_PrincipalConfig_ID == 0)
         {
+			setIsForceLogin (true);
+// Y
 			setSSO_PrincipalConfig_ID (0);
 			setSSO_Provider (null);
         } */
@@ -49,6 +51,8 @@ public class X_SSO_PrincipalConfig extends PO implements I_SSO_PrincipalConfig, 
       super (ctx, SSO_PrincipalConfig_ID, trxName, virtualColumns);
       /** if (SSO_PrincipalConfig_ID == 0)
         {
+			setIsForceLogin (true);
+// Y
 			setSSO_PrincipalConfig_ID (0);
 			setSSO_Provider (null);
         } */
@@ -60,6 +64,8 @@ public class X_SSO_PrincipalConfig extends PO implements I_SSO_PrincipalConfig, 
       super (ctx, SSO_PrincipalConfig_UU, trxName);
       /** if (SSO_PrincipalConfig_UU == null)
         {
+			setIsForceLogin (true);
+// Y
 			setSSO_PrincipalConfig_ID (0);
 			setSSO_Provider (null);
         } */
@@ -71,6 +77,8 @@ public class X_SSO_PrincipalConfig extends PO implements I_SSO_PrincipalConfig, 
       super (ctx, SSO_PrincipalConfig_UU, trxName, virtualColumns);
       /** if (SSO_PrincipalConfig_UU == null)
         {
+			setIsForceLogin (true);
+// Y
 			setSSO_PrincipalConfig_ID (0);
 			setSSO_Provider (null);
         } */
@@ -118,6 +126,29 @@ public class X_SSO_PrincipalConfig extends PO implements I_SSO_PrincipalConfig, 
 	public boolean isDefault()
 	{
 		Object oo = get_Value(COLUMNNAME_IsDefault);
+		if (oo != null)
+		{
+			 if (oo instanceof Boolean)
+				 return ((Boolean)oo).booleanValue();
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	/** Set Force Login.
+		@param IsForceLogin Require the OpenID Connect provider to reauthenticate the user
+	*/
+	public void setIsForceLogin (boolean IsForceLogin)
+	{
+		set_Value (COLUMNNAME_IsForceLogin, Boolean.valueOf(IsForceLogin));
+	}
+
+	/** Get Force Login.
+		@return Require the OpenID Connect provider to reauthenticate the user
+	  */
+	public boolean isForceLogin()
+	{
+		Object oo = get_Value(COLUMNNAME_IsForceLogin);
 		if (oo != null)
 		{
 			 if (oo instanceof Boolean)

--- a/org.idempiere.ui.sso.oidc/src/org/idempiere/ui/sso/oidc/service/OIDCPrincipalService.java
+++ b/org.idempiere.ui.sso.oidc/src/org/idempiere/ui/sso/oidc/service/OIDCPrincipalService.java
@@ -288,7 +288,6 @@ public class OIDCPrincipalService implements ISSOPrincipalService {
 					new URI(getRedirectURL(principalConfig, redirectMode))) 
 			    .state(new State())
 			    .nonce(new Nonce())
-			    .prompt(new Prompt(Prompt.Type.LOGIN)) 
 			    .endpointURI(getMetaData().getAuthorizationEndpointURI())
 			    .build();
 		} catch (URISyntaxException e) {

--- a/org.idempiere.ui.sso.oidc/src/org/idempiere/ui/sso/oidc/service/OIDCPrincipalService.java
+++ b/org.idempiere.ui.sso.oidc/src/org/idempiere/ui/sso/oidc/service/OIDCPrincipalService.java
@@ -281,15 +281,17 @@ public class OIDCPrincipalService implements ISSOPrincipalService {
 			throws IOException {		
 		AuthenticationRequest authRequest = null;
 		try {
-			authRequest = new AuthenticationRequest.Builder(
+			AuthenticationRequest.Builder builder = new AuthenticationRequest.Builder(
 					new ResponseType(AUTHENTICATION_CODE_PARAMETER),		      
 					new Scope("openid", "profile", "email"),
 					new ClientID(principalConfig.getSSO_ApplicationClientID()),
 					new URI(getRedirectURL(principalConfig, redirectMode))) 
 			    .state(new State())
 			    .nonce(new Nonce())
-			    .endpointURI(getMetaData().getAuthorizationEndpointURI())
-			    .build();
+			    .endpointURI(getMetaData().getAuthorizationEndpointURI());
+			if (principalConfig.isForceLogin())
+				builder.prompt(new Prompt(Prompt.Type.LOGIN));
+			authRequest = builder.build();
 		} catch (URISyntaxException e) {
 			throw new RuntimeException(e);
 		} catch (GeneralException e) {


### PR DESCRIPTION
## Description

OIDC authentication currently adds `prompt=login` to every authorization request. This forces the identity provider to display a login form even when an existing session or remember-me cookie is available.

This change makes that behavior configurable per SSO principal configuration through the new **Force Login** flag. Existing configurations default to enabled, preserving the current logout behavior. Administrators can disable it for providers where an existing authenticated session or remember-me cookie should be reused.

JIRA: https://idempiere.atlassian.net/browse/IDEMPIERE-6552

## Root cause

`OIDCPrincipalService` unconditionally set `Prompt.Type.LOGIN` when building the authorization request. Removing it globally would fix remember-me behavior, but can cause problems in the logout flow for providers that require forced reauthentication.

## Changes

- Add the `IsForceLogin` setting to `SSO_PrincipalConfig`.
- Default the setting to enabled for backward compatibility.
- Show **Force Login** only for OIDC provider configurations.
- Add `prompt=login` only when **Force Login** is enabled.

## Impact

Each OIDC provider configuration can now choose the appropriate behavior:

- Enabled: preserve the existing forced-login behavior.
- Disabled: allow the provider to reuse an existing authenticated session or remember-me cookie.

## Validation

- Verified the generated model and interface changes.
- Verified Oracle and PostgreSQL migration scripts.
- `git diff --check` passes.

## How to test

1. Apply the migration and open an OIDC SSO principal configuration.
2. Verify that **Force Login** is visible for OIDC and enabled by default.
3. With **Force Login** enabled, start OIDC login and verify that the provider requires authentication.
4. Disable **Force Login**, establish a persistent provider session, and start OIDC login again.
5. Verify that the provider can reuse the existing session instead of forcing the login form.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable **Force Login** setting for OIDC single sign-on providers.
  * The setting is available in the provider configuration and defaults to enabled.
  * The option is displayed only for OIDC providers.

* **Bug Fixes**
  * OIDC authentication no longer always forces the login prompt, allowing the identity provider’s existing session to be used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->