### PR TITLE
IDEMPIERE-6551 Use client language for SSO login

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/LoginWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/LoginWindow.java
@@ -52,6 +52,7 @@ import org.adempiere.webui.sso.filter.SSOWebUIFilter;
 import org.adempiere.webui.theme.ThemeManager;
 import org.adempiere.webui.util.UserPreference;
 import org.adempiere.webui.util.ZkSSOUtils;
+import org.compiere.model.MClient;
 import org.compiere.model.MSysConfig;
 import org.compiere.model.MUser;
 import org.compiere.util.CLogger;
@@ -157,21 +158,25 @@ public class LoginWindow extends Window implements EventListener<Event>
 			boolean isEmailLogin = MSysConfig.getBooleanValue(MSysConfig.USE_EMAIL_FOR_LOGIN, false);
 			if (Util.isEmpty(username))
 				throw new AdempiereException("No Apps " + (isEmailLogin ? "Email" : "User"));
+
+			Login login = new Login(ctx);
+			KeyNamePair[] clients = login.getClients(username, null, null, token, tenant);
+			if (language == null && clients != null && clients.length > 0)
+				language = MClient.get(ctx, clients[0].getKey()).getLanguage();
 			if (language == null)
 				language = Language.getBaseLanguage();
 
 			Env.setContext(ctx, UserPreference.LANGUAGE_NAME, language.getName());
+			Env.setContext(ctx, Env.LANGUAGE, language.getAD_Language());
 			Locale locale = language.getLocale();
 			getDesktop().getSession().setAttribute(Attributes.PREFERRED_LOCALE, locale);
 
-			Login login = new Login(ctx);
 			boolean isShowRolePanel = MSysConfig.getBooleanValue(MSysConfig.SSO_SELECT_ROLE, true);
 			
 			// show role panel when change role 
 			if(getDesktop().getSession().hasAttribute(SSOUtils.ISCHANGEROLE_REQUEST))
 				isShowRolePanel = isShowRolePanel || (boolean) getDesktop().getSession().getAttribute(SSOUtils.ISCHANGEROLE_REQUEST);
 			
-			KeyNamePair[] clients = login.getClients(username, null, null, token, tenant);
 			if (clients != null)
 				loginOk(username, isShowRolePanel, clients, true);
 			else

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/LoginWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/LoginWindow.java
@@ -161,7 +161,7 @@ public class LoginWindow extends Window implements EventListener<Event>
 
 			Login login = new Login(ctx);
 			KeyNamePair[] clients = login.getClients(username, null, null, token, tenant);
-			if (language == null && clients != null && clients.length > 0)
+			if (language == null && clients != null && clients.length == 1)
 				language = MClient.get(ctx, clients[0].getKey()).getLanguage();
 			if (language == null)
 				language = Language.getBaseLanguage();

--- a/org.idempiere.ui.sso.oidc/src/org/idempiere/ui/sso/oidc/service/OIDCPrincipalService.java
+++ b/org.idempiere.ui.sso.oidc/src/org/idempiere/ui/sso/oidc/service/OIDCPrincipalService.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Locale;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -113,6 +115,28 @@ public class OIDCPrincipalService implements ISSOPrincipalService {
 
 	@Override
 	public Language getLanguage(Object principalObject) throws ParseException {
+		if (principalObject instanceof UserInfo userInfo) {
+			String localeClaim = userInfo.getLocale();
+			if (!Util.isEmpty(localeClaim, true)) {
+				Locale locale = Locale.forLanguageTag(localeClaim.trim().replace('_', '-'));
+				if (!Util.isEmpty(locale.getLanguage(), true)) {
+					ArrayList<String> loginLanguages = Env.getLoginLanguages();
+					StringBuilder languageCode = new StringBuilder(locale.getLanguage());
+					if (!Util.isEmpty(locale.getCountry(), true))
+						languageCode.append('_').append(locale.getCountry());
+
+					Language language = Language.getLanguage(languageCode.toString());
+					if (loginLanguages.contains(language.getAD_Language()))
+						return language;
+
+					// Fall back from a regional locale (for example de_DE) to an
+					// active login language with the same ISO language (for example de).
+					language = Language.getLanguage(locale.getLanguage());
+					if (loginLanguages.contains(language.getAD_Language()))
+						return language;
+				}
+			}
+		}
 		return null;
 	}
 

--- a/org.idempiere.ui.sso.oidc/src/org/idempiere/ui/sso/oidc/service/OIDCPrincipalService.java
+++ b/org.idempiere.ui.sso.oidc/src/org/idempiere/ui/sso/oidc/service/OIDCPrincipalService.java
@@ -113,7 +113,7 @@ public class OIDCPrincipalService implements ISSOPrincipalService {
 
 	@Override
 	public Language getLanguage(Object principalObject) throws ParseException {
-		return Language.getBaseLanguage();
+		return null;
 	}
 
 	@Override


### PR DESCRIPTION
## Description

SSO providers can optionally supply a login language through `ISSOPrincipalService`. The OIDC provider now reads the standard `locale` claim returned by the UserInfo endpoint. If no supported locale is supplied, iDempiere uses the language configured for the client in `AD_Client.AD_Language`.

JIRA: https://idempiere.atlassian.net/browse/IDEMPIERE-6551

## Root cause

`OIDCPrincipalService.getLanguage()` did not evaluate the OIDC UserInfo locale and always returned `null`. The common SSO login flow could therefore only use its client-language and base-language fallbacks.

## Changes

- Read the standard OIDC `locale` claim from `UserInfo`.
- Normalize BCP 47 locale tags such as `de-DE` to iDempiere language identifiers such as `de_DE`.
- Accept only active languages configured as login locales.
- Fall back from a regional locale to an active login language with the same ISO language.
- Return `null` for missing, invalid, or unsupported locale claims.
- Use `AD_Client.AD_Language` when the provider supplies no supported language.
- Retain the base language as the final fallback.
- Do not send a locale to the OIDC provider.

## Impact

OIDC providers such as Keycloak can control the iDempiere login language through the standard UserInfo `locale` claim. Existing client-language and base-language fallback behavior remains unchanged.

## Validation

- `git diff --check` passes.
- The PR update contains only the focused OIDC locale mapping in addition to the existing login fallback changes.
- Attempted `mvn -pl org.idempiere.ui.sso.oidc -am -DskipTests package`; Maven stopped before compilation because `org.idempiere.p2.targetplatform:13.0.0-SNAPSHOT` could not be resolved.

## How to test

1. Configure Keycloak to include a `locale` claim such as `de-DE` in the UserInfo response.
2. Ensure the corresponding iDempiere language is active and marked as a login locale.
3. Log in through OIDC and verify that role selection and the application UI use that language.
4. Test a missing or unsupported locale claim and verify fallback to the client language.
5. Verify fallback to the base language when neither provider nor client supplies a usable language.
