### PR TITLE
IDEMPIERE-7068: Quick Entry broken for new parent record

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/GridTab.java
+++ b/org.adempiere.base/src/org/compiere/model/GridTab.java
@@ -710,7 +710,8 @@ public class GridTab implements DataStatusListener, Evaluatee, Serializable
 				m_linkValue = value;
 				//	Check validity
 				if (value.length() == 0 || (effectiveLinkColumnName.endsWith("_ID") && "0".equals(value)
-					&& getParentTab() != null && getParentTab().isNew()))
+					&& getParentTab() != null && getParentTab().isNew()
+					&& !"Y".equals(Env.getContext(m_vo.ctx, m_vo.WindowNo, "_QUICK_ENTRY_MODE_"))))
 				{
 					//parent is new, can't retrieve detail
 					m_parentNeedSave = true;


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-7068

# Pull Request Checklist

- [X] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [X] My code follows the best practices of this project
- [X] I have performed a self-review of my own code
- [X] My code is easy to understand and review. 
- [X] I have checked my code and corrected any misspellings
- [X] In hard-to-understand areas, I have commented my code.
- [X] My changes generate no new warnings
### Tests
- [X] I have tested the direct scenario that my code is solving
- [X] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [X] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

* **Bug Fixes**
  * Fixed detail-tab retrieval during quick-entry workflows when the parent record is new and the linkage is through an `*_ID` column with a `0` value.
  * Updated the query behavior to avoid unnecessarily requiring a parent save that could block loading related detail records in quick-entry mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->