### PR TITLE
IDEMPIERE-6960 Back-dated costing incorrectly updates other lots when Costing Level = Batch/Lot

### DIFF
--- a/org.adempiere.base.process/src/org/compiere/process/ImportInventory.java
+++ b/org.adempiere.base.process/src/org/compiere/process/ImportInventory.java
@@ -525,7 +525,7 @@ public class ImportInventory extends SvrProcess implements ImportProcess
 		String costingLevel = product.getCostingLevel(acctSchema);
 		int costOrgID = p_AD_OrgTrx_ID;
 		int costASI = line.getM_AttributeSetInstance_ID();
-		MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(costOrgID, costASI, costingLevel);
+		MCost.CostingKey costKey = MCost.CostingKey.resolve(costOrgID, costASI, costingLevel);
 		costOrgID = costKey.AD_Org_ID();
 		costASI = costKey.M_AttributeSetInstance_ID();
 		MCost cost = MCost.get (product, costASI

--- a/org.adempiere.base.process/src/org/compiere/process/ImportInventory.java
+++ b/org.adempiere.base.process/src/org/compiere/process/ImportInventory.java
@@ -535,14 +535,9 @@ public class ImportInventory extends SvrProcess implements ImportProcess
 
 		int costOrgID = p_AD_OrgTrx_ID;
 		int costASI = line.getM_AttributeSetInstance_ID();
-		if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel)){
-			costOrgID = 0;
-			costASI = 0;
-		} else if (MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel)) { 
-			costASI = 0;
-		} else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel)) {
-			costOrgID = 0;
-		}
+		MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(costOrgID, costASI, costingLevel);
+		costOrgID = costKey.AD_Org_ID();
+		costASI = costKey.M_AttributeSetInstance_ID();
 		MCost cost = MCost.get (product, costASI
 				, acctSchema, costOrgID, p_M_CostElement_ID, get_TrxName());
 		if (cost.is_new())

--- a/org.adempiere.base.process/src/org/compiere/process/ImportInventory.java
+++ b/org.adempiere.base.process/src/org/compiere/process/ImportInventory.java
@@ -36,7 +36,6 @@ import org.compiere.model.MInventory;
 import org.compiere.model.MInventoryLine;
 import org.compiere.model.MProcessPara;
 import org.compiere.model.MProduct;
-import org.compiere.model.MProductCategoryAcct;
 import org.compiere.model.ModelValidationEngine;
 import org.compiere.model.X_I_Inventory;
 import org.compiere.util.AdempiereUserError;
@@ -523,16 +522,7 @@ public class ImportInventory extends SvrProcess implements ImportProcess
 
 	protected void updateCosting(X_I_Inventory imp, MProduct product,
 			MInventoryLine line) {
-		String costingLevel = null;
-		if(product.getM_Product_Category_ID() > 0){
-			MProductCategoryAcct pca = MProductCategoryAcct.get(getCtx(), product.getM_Product_Category_ID(), p_C_AcctSchema_ID, get_TrxName());
-			costingLevel = pca.getCostingLevel();
-			if (costingLevel == null) {
-				costingLevel = acctSchema.getCostingLevel();
-			}
-
-		}
-
+		String costingLevel = product.getCostingLevel(acctSchema);
 		int costOrgID = p_AD_OrgTrx_ID;
 		int costASI = line.getM_AttributeSetInstance_ID();
 		MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(costOrgID, costASI, costingLevel);

--- a/org.adempiere.base/src/org/compiere/model/MCost.java
+++ b/org.adempiere.base/src/org/compiere/model/MCost.java
@@ -60,7 +60,7 @@ public class MCost extends X_M_Cost implements ICostInfo
 	/**
 	 * generated serial id
 	 */
-	private static final long serialVersionUID = 7669971447038015333L;
+	private static final long serialVersionUID = -1554882384162646674L;
 
 	/**
 	 * @param product
@@ -123,15 +123,9 @@ public class MCost extends X_M_Cost implements ICostInfo
 			String trxName)
 	{
 		String CostingLevel = product.getCostingLevel(as);
-		if (MAcctSchema.COSTINGLEVEL_Client.equals(CostingLevel))
-		{
-			AD_Org_ID = 0;
-			M_AttributeSetInstance_ID = 0;
-		}
-		else if (MAcctSchema.COSTINGLEVEL_Organization.equals(CostingLevel))
-			M_AttributeSetInstance_ID = 0;
-		else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(CostingLevel))
-			AD_Org_ID = 0;
+		MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, CostingLevel);
+		AD_Org_ID = costKey.AD_Org_ID();
+		M_AttributeSetInstance_ID = costKey.M_AttributeSetInstance_ID();
 		//	Costing Method
 		if (costingMethod == null)
 		{
@@ -1943,4 +1937,26 @@ public class MCost extends X_M_Cost implements ICostInfo
 		this.isSkipAverageCostingQtyCheck = isSkipAverageCostingQtyCheck;
 	}
 	
+	public record CostingLevelKey(int AD_Org_ID, int M_AttributeSetInstance_ID)
+	{
+		public static CostingLevelKey resolve(int AD_Org_ID, int M_AttributeSetInstance_ID, String costingLevel)
+		{
+			if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
+			{
+				AD_Org_ID = 0;
+				M_AttributeSetInstance_ID = 0;
+			}
+			else if (MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel))
+				M_AttributeSetInstance_ID = 0;
+			else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel))
+				AD_Org_ID = 0;
+
+			return new CostingLevelKey(AD_Org_ID, M_AttributeSetInstance_ID);
+		}
+		
+		public boolean isBatchLotZeroASI(String costingLevel)
+		{
+			return MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel) && M_AttributeSetInstance_ID == 0;
+		}
+	}
 }	//	MCost

--- a/org.adempiere.base/src/org/compiere/model/MCost.java
+++ b/org.adempiere.base/src/org/compiere/model/MCost.java
@@ -1937,8 +1937,38 @@ public class MCost extends X_M_Cost implements ICostInfo
 		this.isSkipAverageCostingQtyCheck = isSkipAverageCostingQtyCheck;
 	}
 	
+	/**
+	 * Represents a resolved (AD_Org_ID, M_AttributeSetInstance_ID) key pair after applying
+	 * costing-level normalization rules. Depending on the product's costing level
+	 * ({@link MAcctSchema#COSTINGLEVEL_Client}, {@link MAcctSchema#COSTINGLEVEL_Organization},
+	 * or {@link MAcctSchema#COSTINGLEVEL_BatchLot}), one or both of the raw org/ASI values
+	 * supplied by the caller are zeroed out to match the granularity at which cost is tracked.
+	 * <p>
+	 * Callers should always obtain instances via {@link #resolve(int, int, String)} rather
+	 * than constructing this record directly, to ensure the normalization rules are applied
+	 * consistently.
+	 *
+	 * @param AD_Org_ID                 the resolved org ID (zeroed for Client and BatchLot costing levels)
+	 * @param M_AttributeSetInstance_ID the resolved ASI ID (zeroed for Client and Organization costing levels)
+	 */
 	public record CostingLevelKey(int AD_Org_ID, int M_AttributeSetInstance_ID)
 	{
+		/**
+		 * Resolves the org/ASI key pair for the given costing level, zeroing out
+		 * whichever fields are not significant at that costing granularity:
+		 * <ul>
+		 *   <li>{@code Client} - both AD_Org_ID and M_AttributeSetInstance_ID are zeroed</li>
+		 *   <li>{@code Organization} - only M_AttributeSetInstance_ID is zeroed</li>
+		 *   <li>{@code BatchLot} - only AD_Org_ID is zeroed; ASI is preserved since cost
+		 *       is tracked per lot</li>
+		 * </ul>
+		 * Any other costing level is passed through unchanged.
+		 *
+		 * @param AD_Org_ID                 the raw org ID before normalization
+		 * @param M_AttributeSetInstance_ID the raw ASI ID before normalization
+		 * @param costingLevel              one of the {@code MAcctSchema.COSTINGLEVEL_*} constants
+		 * @return a new {@code CostingLevelKey} with fields normalized per the costing level
+		 */
 		public static CostingLevelKey resolve(int AD_Org_ID, int M_AttributeSetInstance_ID, String costingLevel)
 		{
 			if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
@@ -1954,6 +1984,16 @@ public class MCost extends X_M_Cost implements ICostInfo
 			return new CostingLevelKey(AD_Org_ID, M_AttributeSetInstance_ID);
 		}
 		
+		/**
+		 * Checks whether this key is invalid for BatchLot costing due to a missing ASI.
+		 * BatchLot-level costing requires a specific attribute set instance (lot) to
+		 * record cost against; a resolved ASI of 0 means no lot could be determined,
+		 * and callers should typically treat this as "no cost record available" rather
+		 * than falling back to a client/org-level lookup.
+		 *
+		 * @param costingLevel one of the {@code MAcctSchema.COSTINGLEVEL_*} constants
+		 * @return {@code true} if costingLevel is BatchLot and M_AttributeSetInstance_ID is 0
+		 */
 		public boolean isBatchLotZeroASI(String costingLevel)
 		{
 			return MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel) && M_AttributeSetInstance_ID == 0;

--- a/org.adempiere.base/src/org/compiere/model/MCost.java
+++ b/org.adempiere.base/src/org/compiere/model/MCost.java
@@ -1985,14 +1985,22 @@ public class MCost extends X_M_Cost implements ICostInfo
 		}
 		
 		/**
-		 * Checks whether this key is invalid for BatchLot costing due to a missing ASI.
+		 * Indicates whether cost lookup/processing should be skipped for this key because
 		 * BatchLot-level costing requires a specific attribute set instance (lot) to
-		 * record cost against; a resolved ASI of 0 means no lot could be determined,
-		 * and callers should typically treat this as "no cost record available" rather
-		 * than falling back to a client/org-level lookup.
+		 * associate cost with, and none could be resolved (M_AttributeSetInstance_ID is 0).
+		 * <p>
+		 * When this returns {@code true}, callers should abort the current cost lookup or
+		 * costing-record retrieval and return {@code null} (or otherwise skip processing),
+		 * rather than falling back to a client- or organization-level cost record — no
+		 * BatchLot-level cost record can exist without a lot to key it against.
+		 * <p>
+		 * Used by {@link MProduct#getCostInfo(MAcctSchema, int, int, String, Timestamp)} and
+		 * {@link MProduct#getCostingRecord(MAcctSchema, int, int, String)} as an early-exit
+		 * guard before resolving cost elements or cost records.
 		 *
 		 * @param costingLevel one of the {@code MAcctSchema.COSTINGLEVEL_*} constants
-		 * @return {@code true} if costingLevel is BatchLot and M_AttributeSetInstance_ID is 0
+		 * @return {@code true} if costingLevel is BatchLot and no ASI (lot) could be resolved,
+		 *         meaning the caller should skip cost processing and return {@code null}
 		 */
 		public boolean isBatchLotZeroASI(String costingLevel)
 		{

--- a/org.adempiere.base/src/org/compiere/model/MCost.java
+++ b/org.adempiere.base/src/org/compiere/model/MCost.java
@@ -123,7 +123,7 @@ public class MCost extends X_M_Cost implements ICostInfo
 			String trxName)
 	{
 		String CostingLevel = product.getCostingLevel(as);
-		MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, CostingLevel);
+		MCost.CostingKey costKey = MCost.CostingKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, CostingLevel);
 		AD_Org_ID = costKey.AD_Org_ID();
 		M_AttributeSetInstance_ID = costKey.M_AttributeSetInstance_ID();
 		//	Costing Method
@@ -1938,11 +1938,12 @@ public class MCost extends X_M_Cost implements ICostInfo
 	}
 	
 	/**
-	 * Represents a resolved (AD_Org_ID, M_AttributeSetInstance_ID) key pair after applying
-	 * costing-level normalization rules. Depending on the product's costing level
-	 * ({@link MAcctSchema#COSTINGLEVEL_Client}, {@link MAcctSchema#COSTINGLEVEL_Organization},
-	 * or {@link MAcctSchema#COSTINGLEVEL_BatchLot}), one or both of the raw org/ASI values
-	 * supplied by the caller are zeroed out to match the granularity at which cost is tracked.
+	 * Represents a resolved (AD_Org_ID, M_AttributeSetInstance_ID) key pair, derived by applying
+	 * costing-level normalization rules, used to look up or create {@code MCost}/{@code MCostHistory}
+	 * records. Depending on the product's costing level ({@link MAcctSchema#COSTINGLEVEL_Client},
+	 * {@link MAcctSchema#COSTINGLEVEL_Organization}, or {@link MAcctSchema#COSTINGLEVEL_BatchLot}),
+	 * one or both of the raw org/ASI values supplied by the caller are zeroed out to match the
+	 * granularity at which cost is tracked.
 	 * <p>
 	 * Callers should always obtain instances via {@link #resolve(int, int, String)} rather
 	 * than constructing this record directly, to ensure the normalization rules are applied
@@ -1951,7 +1952,7 @@ public class MCost extends X_M_Cost implements ICostInfo
 	 * @param AD_Org_ID                 the resolved org ID (zeroed for Client and BatchLot costing levels)
 	 * @param M_AttributeSetInstance_ID the resolved ASI ID (zeroed for Client and Organization costing levels)
 	 */
-	public record CostingLevelKey(int AD_Org_ID, int M_AttributeSetInstance_ID)
+	public record CostingKey(int AD_Org_ID, int M_AttributeSetInstance_ID)
 	{
 		/**
 		 * Resolves the org/ASI key pair for the given costing level, zeroing out
@@ -1967,9 +1968,9 @@ public class MCost extends X_M_Cost implements ICostInfo
 		 * @param AD_Org_ID                 the raw org ID before normalization
 		 * @param M_AttributeSetInstance_ID the raw ASI ID before normalization
 		 * @param costingLevel              one of the {@code MAcctSchema.COSTINGLEVEL_*} constants
-		 * @return a new {@code CostingLevelKey} with fields normalized per the costing level
+		 * @return a new {@code CostingKey} with fields normalized per the costing level
 		 */
-		public static CostingLevelKey resolve(int AD_Org_ID, int M_AttributeSetInstance_ID, String costingLevel)
+		public static CostingKey resolve(int AD_Org_ID, int M_AttributeSetInstance_ID, String costingLevel)
 		{
 			if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
 			{
@@ -1981,12 +1982,12 @@ public class MCost extends X_M_Cost implements ICostInfo
 			else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel))
 				AD_Org_ID = 0;
 
-			return new CostingLevelKey(AD_Org_ID, M_AttributeSetInstance_ID);
+			return new CostingKey(AD_Org_ID, M_AttributeSetInstance_ID);
 		}
-		
+
 		/**
-		 * Indicates whether cost lookup/processing should be skipped for this key because
-		 * BatchLot-level costing requires a specific attribute set instance (lot) to
+		 * Indicates whether cost lookup/processing should be skipped entirely for this key,
+		 * because BatchLot-level costing requires a specific attribute set instance (lot) to
 		 * associate cost with, and none could be resolved (M_AttributeSetInstance_ID is 0).
 		 * <p>
 		 * When this returns {@code true}, callers should abort the current cost lookup or
@@ -2002,7 +2003,7 @@ public class MCost extends X_M_Cost implements ICostInfo
 		 * @return {@code true} if costingLevel is BatchLot and no ASI (lot) could be resolved,
 		 *         meaning the caller should skip cost processing and return {@code null}
 		 */
-		public boolean isBatchLotZeroASI(String costingLevel)
+		public boolean isSkipCostingProcessing(String costingLevel)
 		{
 			return MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel) && M_AttributeSetInstance_ID == 0;
 		}

--- a/org.adempiere.base/src/org/compiere/model/MCostDetail.java
+++ b/org.adempiere.base/src/org/compiere/model/MCostDetail.java
@@ -1346,7 +1346,7 @@ public class MCostDetail extends X_M_CostDetail
 		//	Org Element
 		int Org_ID = getAD_Org_ID();
 		int M_ASI_ID = getM_AttributeSetInstance_ID();
-		MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(Org_ID, M_ASI_ID, CostingLevel);
+		MCost.CostingKey costKey = MCost.CostingKey.resolve(Org_ID, M_ASI_ID, CostingLevel);
 		Org_ID = costKey.AD_Org_ID();
 		M_ASI_ID = costKey.M_AttributeSetInstance_ID();
 

--- a/org.adempiere.base/src/org/compiere/model/MCostDetail.java
+++ b/org.adempiere.base/src/org/compiere/model/MCostDetail.java
@@ -1346,15 +1346,9 @@ public class MCostDetail extends X_M_CostDetail
 		//	Org Element
 		int Org_ID = getAD_Org_ID();
 		int M_ASI_ID = getM_AttributeSetInstance_ID();
-		if (MAcctSchema.COSTINGLEVEL_Client.equals(CostingLevel))
-		{
-			Org_ID = 0;
-			M_ASI_ID = 0;
-		}
-		else if (MAcctSchema.COSTINGLEVEL_Organization.equals(CostingLevel))
-			M_ASI_ID = 0;
-		else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(CostingLevel))
-			Org_ID = 0;
+		MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(Org_ID, M_ASI_ID, CostingLevel);
+		Org_ID = costKey.AD_Org_ID();
+		M_ASI_ID = costKey.M_AttributeSetInstance_ID();
 
 		//	Create Material Cost elements
 		if (getM_CostElement_ID() == 0)

--- a/org.adempiere.base/src/org/compiere/model/MInOut.java
+++ b/org.adempiere.base/src/org/compiere/model/MInOut.java
@@ -3514,7 +3514,7 @@ public class MInOut extends X_M_InOut implements DocAction, IDocsPostProcess
 				int M_AttributeSetInstance_ID = sLine.getM_AttributeSetInstance_ID();
 				MProduct product = new MProduct(sLine.getCtx(), sLine.getM_Product_ID(), sLine.get_TrxName());
 				String costingLevel = product.getCostingLevel(as);
-				MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
+				MCost.CostingKey costKey = MCost.CostingKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
 				AD_Org_ID = costKey.AD_Org_ID();
 				M_AttributeSetInstance_ID = costKey.M_AttributeSetInstance_ID();
 				
@@ -3570,7 +3570,7 @@ public class MInOut extends X_M_InOut implements DocAction, IDocsPostProcess
 			int M_AttributeSetInstance_ID = sLine.getM_AttributeSetInstance_ID();
 			MProduct product = new MProduct(sLine.getCtx(), sLine.getM_Product_ID(), sLine.get_TrxName());
 			String costingLevel = product.getCostingLevel(as);
-			MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
+			MCost.CostingKey costKey = MCost.CostingKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
 			AD_Org_ID = costKey.AD_Org_ID();
 			M_AttributeSetInstance_ID = costKey.M_AttributeSetInstance_ID();
 			

--- a/org.adempiere.base/src/org/compiere/model/MInOut.java
+++ b/org.adempiere.base/src/org/compiere/model/MInOut.java
@@ -3512,15 +3512,16 @@ public class MInOut extends X_M_InOut implements DocAction, IDocsPostProcess
 			for (MInOutLine sLine : sLines) {
 				int AD_Org_ID = sLine.getAD_Org_ID();
 				int M_AttributeSetInstance_ID = sLine.getM_AttributeSetInstance_ID();
-
-				if (MAcctSchema.COSTINGLEVEL_Client.equals(as.getCostingLevel()))
+				MProduct product = new MProduct(sLine.getCtx(), sLine.getM_Product_ID(), sLine.get_TrxName());
+				String costingLevel = product.getCostingLevel(as);
+				if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
 				{
 					AD_Org_ID = 0;
 					M_AttributeSetInstance_ID = 0;
 				}
-				else if (MAcctSchema.COSTINGLEVEL_Organization.equals(as.getCostingLevel()))
+				else if (MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel))
 					M_AttributeSetInstance_ID = 0;
-				else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(as.getCostingLevel()))
+				else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel))
 					AD_Org_ID = 0;
 				
 				MCostElement ce = MCostElement.getMaterialCostElement(getCtx(), as.getCostingMethod(), AD_Org_ID);
@@ -3573,15 +3574,16 @@ public class MInOut extends X_M_InOut implements DocAction, IDocsPostProcess
 		for (MInOutLine sLine : sLines) {
 			int AD_Org_ID = sLine.getAD_Org_ID();
 			int M_AttributeSetInstance_ID = sLine.getM_AttributeSetInstance_ID();
-
-			if (MAcctSchema.COSTINGLEVEL_Client.equals(as.getCostingLevel()))
+			MProduct product = new MProduct(sLine.getCtx(), sLine.getM_Product_ID(), sLine.get_TrxName());
+			String costingLevel = product.getCostingLevel(as);
+			if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
 			{
 				AD_Org_ID = 0;
 				M_AttributeSetInstance_ID = 0;
 			}
-			else if (MAcctSchema.COSTINGLEVEL_Organization.equals(as.getCostingLevel()))
+			else if (MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel))
 				M_AttributeSetInstance_ID = 0;
-			else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(as.getCostingLevel()))
+			else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel))
 				AD_Org_ID = 0;
 			
 			MCostElement ce = MCostElement.getMaterialCostElement(getCtx(), as.getCostingMethod(), AD_Org_ID);

--- a/org.adempiere.base/src/org/compiere/model/MInOut.java
+++ b/org.adempiere.base/src/org/compiere/model/MInOut.java
@@ -3514,15 +3514,9 @@ public class MInOut extends X_M_InOut implements DocAction, IDocsPostProcess
 				int M_AttributeSetInstance_ID = sLine.getM_AttributeSetInstance_ID();
 				MProduct product = new MProduct(sLine.getCtx(), sLine.getM_Product_ID(), sLine.get_TrxName());
 				String costingLevel = product.getCostingLevel(as);
-				if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
-				{
-					AD_Org_ID = 0;
-					M_AttributeSetInstance_ID = 0;
-				}
-				else if (MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel))
-					M_AttributeSetInstance_ID = 0;
-				else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel))
-					AD_Org_ID = 0;
+				MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
+				AD_Org_ID = costKey.AD_Org_ID();
+				M_AttributeSetInstance_ID = costKey.M_AttributeSetInstance_ID();
 				
 				MCostElement ce = MCostElement.getMaterialCostElement(getCtx(), as.getCostingMethod(), AD_Org_ID);
 				
@@ -3576,15 +3570,9 @@ public class MInOut extends X_M_InOut implements DocAction, IDocsPostProcess
 			int M_AttributeSetInstance_ID = sLine.getM_AttributeSetInstance_ID();
 			MProduct product = new MProduct(sLine.getCtx(), sLine.getM_Product_ID(), sLine.get_TrxName());
 			String costingLevel = product.getCostingLevel(as);
-			if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
-			{
-				AD_Org_ID = 0;
-				M_AttributeSetInstance_ID = 0;
-			}
-			else if (MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel))
-				M_AttributeSetInstance_ID = 0;
-			else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel))
-				AD_Org_ID = 0;
+			MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
+			AD_Org_ID = costKey.AD_Org_ID();
+			M_AttributeSetInstance_ID = costKey.M_AttributeSetInstance_ID();
 			
 			MCostElement ce = MCostElement.getMaterialCostElement(getCtx(), as.getCostingMethod(), AD_Org_ID);
 			

--- a/org.adempiere.base/src/org/compiere/model/MInventory.java
+++ b/org.adempiere.base/src/org/compiere/model/MInventory.java
@@ -1315,15 +1315,16 @@ public class MInventory extends X_M_Inventory implements DocAction
 		for (MInventoryLine iLine : iLines) {
 			int AD_Org_ID = iLine.getAD_Org_ID();
 			int M_AttributeSetInstance_ID = iLine.getM_AttributeSetInstance_ID();
-
-			if (MAcctSchema.COSTINGLEVEL_Client.equals(as.getCostingLevel()))
+			MProduct product = new MProduct(iLine.getCtx(), iLine.getM_Product_ID(), iLine.get_TrxName());
+			String costingLevel = product.getCostingLevel(as);
+			if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
 			{
 				AD_Org_ID = 0;
 				M_AttributeSetInstance_ID = 0;
 			}
-			else if (MAcctSchema.COSTINGLEVEL_Organization.equals(as.getCostingLevel()))
+			else if (MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel))
 				M_AttributeSetInstance_ID = 0;
-			else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(as.getCostingLevel()))
+			else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel))
 				AD_Org_ID = 0;
 			
 			MCostElement ce = MCostElement.getMaterialCostElement(getCtx(), as.getCostingMethod(), AD_Org_ID);

--- a/org.adempiere.base/src/org/compiere/model/MInventory.java
+++ b/org.adempiere.base/src/org/compiere/model/MInventory.java
@@ -1317,15 +1317,9 @@ public class MInventory extends X_M_Inventory implements DocAction
 			int M_AttributeSetInstance_ID = iLine.getM_AttributeSetInstance_ID();
 			MProduct product = new MProduct(iLine.getCtx(), iLine.getM_Product_ID(), iLine.get_TrxName());
 			String costingLevel = product.getCostingLevel(as);
-			if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
-			{
-				AD_Org_ID = 0;
-				M_AttributeSetInstance_ID = 0;
-			}
-			else if (MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel))
-				M_AttributeSetInstance_ID = 0;
-			else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel))
-				AD_Org_ID = 0;
+			MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
+			AD_Org_ID = costKey.AD_Org_ID();
+			M_AttributeSetInstance_ID = costKey.M_AttributeSetInstance_ID();
 			
 			MCostElement ce = MCostElement.getMaterialCostElement(getCtx(), as.getCostingMethod(), AD_Org_ID);
 			

--- a/org.adempiere.base/src/org/compiere/model/MInventory.java
+++ b/org.adempiere.base/src/org/compiere/model/MInventory.java
@@ -1317,7 +1317,7 @@ public class MInventory extends X_M_Inventory implements DocAction
 			int M_AttributeSetInstance_ID = iLine.getM_AttributeSetInstance_ID();
 			MProduct product = new MProduct(iLine.getCtx(), iLine.getM_Product_ID(), iLine.get_TrxName());
 			String costingLevel = product.getCostingLevel(as);
-			MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
+			MCost.CostingKey costKey = MCost.CostingKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
 			AD_Org_ID = costKey.AD_Org_ID();
 			M_AttributeSetInstance_ID = costKey.M_AttributeSetInstance_ID();
 			

--- a/org.adempiere.base/src/org/compiere/model/MInventoryLine.java
+++ b/org.adempiere.base/src/org/compiere/model/MInventoryLine.java
@@ -595,15 +595,9 @@ public class MInventoryLine extends X_M_InventoryLine
 		int M_AttributeSetInstance_ID = getM_AttributeSetInstance_ID();
 		MProduct product = new MProduct(getCtx(), getM_Product_ID(), get_TrxName());
 		String costingLevel = product.getCostingLevel(as);
-		if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
-		{
-			AD_Org_ID = 0;
-			M_AttributeSetInstance_ID = 0;
-		}
-		else if (MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel))
-			M_AttributeSetInstance_ID = 0;
-		else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel))
-			AD_Org_ID = 0;
+		MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
+		AD_Org_ID = costKey.AD_Org_ID();
+		M_AttributeSetInstance_ID = costKey.M_AttributeSetInstance_ID();
 		MCostElement ce = MCostElement.getMaterialCostElement(getCtx(), inventory.getCostingMethod(), AD_Org_ID);
 		
 		MCostHistory history = null;

--- a/org.adempiere.base/src/org/compiere/model/MInventoryLine.java
+++ b/org.adempiere.base/src/org/compiere/model/MInventoryLine.java
@@ -593,14 +593,16 @@ public class MInventoryLine extends X_M_InventoryLine
 		}
 		int AD_Org_ID = getAD_Org_ID();
 		int M_AttributeSetInstance_ID = getM_AttributeSetInstance_ID();
-		if (MAcctSchema.COSTINGLEVEL_Client.equals(as.getCostingLevel()))
+		MProduct product = new MProduct(getCtx(), getM_Product_ID(), get_TrxName());
+		String costingLevel = product.getCostingLevel(as);
+		if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
 		{
 			AD_Org_ID = 0;
 			M_AttributeSetInstance_ID = 0;
 		}
-		else if (MAcctSchema.COSTINGLEVEL_Organization.equals(as.getCostingLevel()))
+		else if (MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel))
 			M_AttributeSetInstance_ID = 0;
-		else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(as.getCostingLevel()))
+		else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel))
 			AD_Org_ID = 0;
 		MCostElement ce = MCostElement.getMaterialCostElement(getCtx(), inventory.getCostingMethod(), AD_Org_ID);
 		

--- a/org.adempiere.base/src/org/compiere/model/MInventoryLine.java
+++ b/org.adempiere.base/src/org/compiere/model/MInventoryLine.java
@@ -595,7 +595,7 @@ public class MInventoryLine extends X_M_InventoryLine
 		int M_AttributeSetInstance_ID = getM_AttributeSetInstance_ID();
 		MProduct product = new MProduct(getCtx(), getM_Product_ID(), get_TrxName());
 		String costingLevel = product.getCostingLevel(as);
-		MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
+		MCost.CostingKey costKey = MCost.CostingKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
 		AD_Org_ID = costKey.AD_Org_ID();
 		M_AttributeSetInstance_ID = costKey.M_AttributeSetInstance_ID();
 		MCostElement ce = MCostElement.getMaterialCostElement(getCtx(), inventory.getCostingMethod(), AD_Org_ID);

--- a/org.adempiere.base/src/org/compiere/model/MInvoice.java
+++ b/org.adempiere.base/src/org/compiere/model/MInvoice.java
@@ -3561,7 +3561,7 @@ public class MInvoice extends X_C_Invoice implements DocAction, IDocsPostProcess
 			int M_AttributeSetInstance_ID = iLine.getM_AttributeSetInstance_ID();
 			MProduct product = new MProduct(iLine.getCtx(), iLine.getM_Product_ID(), iLine.get_TrxName());
 			String costingLevel = product.getCostingLevel(as);
-			MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
+			MCost.CostingKey costKey = MCost.CostingKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
 			AD_Org_ID = costKey.AD_Org_ID();
 			M_AttributeSetInstance_ID = costKey.M_AttributeSetInstance_ID();
 			

--- a/org.adempiere.base/src/org/compiere/model/MInvoice.java
+++ b/org.adempiere.base/src/org/compiere/model/MInvoice.java
@@ -3559,15 +3559,16 @@ public class MInvoice extends X_C_Invoice implements DocAction, IDocsPostProcess
 			
 			int AD_Org_ID = iLine.getAD_Org_ID();
 			int M_AttributeSetInstance_ID = iLine.getM_AttributeSetInstance_ID();
-
-			if (MAcctSchema.COSTINGLEVEL_Client.equals(as.getCostingLevel()))
+			MProduct product = new MProduct(iLine.getCtx(), iLine.getM_Product_ID(), iLine.get_TrxName());
+			String costingLevel = product.getCostingLevel(as);
+			if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
 			{
 				AD_Org_ID = 0;
 				M_AttributeSetInstance_ID = 0;
 			}
-			else if (MAcctSchema.COSTINGLEVEL_Organization.equals(as.getCostingLevel()))
+			else if (MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel))
 				M_AttributeSetInstance_ID = 0;
-			else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(as.getCostingLevel()))
+			else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel))
 				AD_Org_ID = 0;
 			
 			MCostElement ce = MCostElement.getMaterialCostElement(getCtx(), as.getCostingMethod(), AD_Org_ID);

--- a/org.adempiere.base/src/org/compiere/model/MInvoice.java
+++ b/org.adempiere.base/src/org/compiere/model/MInvoice.java
@@ -3561,15 +3561,9 @@ public class MInvoice extends X_C_Invoice implements DocAction, IDocsPostProcess
 			int M_AttributeSetInstance_ID = iLine.getM_AttributeSetInstance_ID();
 			MProduct product = new MProduct(iLine.getCtx(), iLine.getM_Product_ID(), iLine.get_TrxName());
 			String costingLevel = product.getCostingLevel(as);
-			if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
-			{
-				AD_Org_ID = 0;
-				M_AttributeSetInstance_ID = 0;
-			}
-			else if (MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel))
-				M_AttributeSetInstance_ID = 0;
-			else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel))
-				AD_Org_ID = 0;
+			MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
+			AD_Org_ID = costKey.AD_Org_ID();
+			M_AttributeSetInstance_ID = costKey.M_AttributeSetInstance_ID();
 			
 			MCostElement ce = MCostElement.getMaterialCostElement(getCtx(), as.getCostingMethod(), AD_Org_ID);
 			

--- a/org.adempiere.base/src/org/compiere/model/MProduct.java
+++ b/org.adempiere.base/src/org/compiere/model/MProduct.java
@@ -1076,7 +1076,7 @@ public class MProduct extends X_M_Product implements ImmutablePOSupport
 	public String getCostingLevel(MAcctSchema as)
 	{
 		MProductCategoryAcct pca = MProductCategoryAcct.get(getCtx(), getM_Product_Category_ID(), as.get_ID(), get_TrxName());
-		String costingLevel = pca.getCostingLevel();
+		String costingLevel = pca != null ? pca.getCostingLevel() : null;
 		if (costingLevel == null)
 		{
 			costingLevel = as.getCostingLevel();
@@ -1092,7 +1092,7 @@ public class MProduct extends X_M_Product implements ImmutablePOSupport
 	public String getCostingMethod(MAcctSchema as)
 	{
 		MProductCategoryAcct pca = MProductCategoryAcct.get(getCtx(), getM_Product_Category_ID(), as.get_ID(), get_TrxName());
-		String costingMethod = pca.getCostingMethod();
+		String costingMethod = pca != null ? pca.getCostingMethod() : null;
 		if (costingMethod == null)
 		{
 			costingMethod = as.getCostingMethod();

--- a/org.adempiere.base/src/org/compiere/model/MProduct.java
+++ b/org.adempiere.base/src/org/compiere/model/MProduct.java
@@ -1121,19 +1121,11 @@ public class MProduct extends X_M_Product implements ImmutablePOSupport
 	public MCost getCostingRecord(MAcctSchema as, int AD_Org_ID, int M_ASI_ID, String costingMethod)
 	{
 		String costingLevel = getCostingLevel(as);
-		if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
-		{
-			AD_Org_ID = 0;
-			M_ASI_ID = 0;
-		}
-		else if (MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel))
-			M_ASI_ID = 0;
-		else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel))
-		{
-			AD_Org_ID = 0;
-			if (M_ASI_ID == 0)
-				return null;
-		}
+		MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_ASI_ID, costingLevel);
+		if (costKey.isBatchLotZeroASI(costingLevel))
+			return null;
+		AD_Org_ID = costKey.AD_Org_ID();
+		M_ASI_ID = costKey.M_AttributeSetInstance_ID();
 		MCostElement ce = MCostElement.getMaterialCostElement(getCtx(), costingMethod, AD_Org_ID);
 		if (ce == null) {
 			return null;
@@ -1153,19 +1145,11 @@ public class MProduct extends X_M_Product implements ImmutablePOSupport
 	public ICostInfo getCostInfo(MAcctSchema as, int AD_Org_ID, int M_ASI_ID, String costingMethod, Timestamp dateAcct)
 	{		
 		String costingLevel = getCostingLevel(as);
-		if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
-		{
-			AD_Org_ID = 0;
-			M_ASI_ID = 0;
-		}
-		else if (MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel))
-			M_ASI_ID = 0;
-		else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel))
-		{
-			AD_Org_ID = 0;
-			if (M_ASI_ID == 0)
-				return null;
-		}
+		MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_ASI_ID, costingLevel);
+		if (costKey.isBatchLotZeroASI(costingLevel))
+			return null;
+		AD_Org_ID = costKey.AD_Org_ID();
+		M_ASI_ID = costKey.M_AttributeSetInstance_ID();
 		MCostElement ce = MCostElement.getMaterialCostElement(getCtx(), costingMethod, AD_Org_ID);
 		if (ce == null) {
 			return null;

--- a/org.adempiere.base/src/org/compiere/model/MProduct.java
+++ b/org.adempiere.base/src/org/compiere/model/MProduct.java
@@ -1121,8 +1121,8 @@ public class MProduct extends X_M_Product implements ImmutablePOSupport
 	public MCost getCostingRecord(MAcctSchema as, int AD_Org_ID, int M_ASI_ID, String costingMethod)
 	{
 		String costingLevel = getCostingLevel(as);
-		MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_ASI_ID, costingLevel);
-		if (costKey.isBatchLotZeroASI(costingLevel))
+		MCost.CostingKey costKey = MCost.CostingKey.resolve(AD_Org_ID, M_ASI_ID, costingLevel);
+		if (costKey.isSkipCostingProcessing(costingLevel))
 			return null;
 		AD_Org_ID = costKey.AD_Org_ID();
 		M_ASI_ID = costKey.M_AttributeSetInstance_ID();
@@ -1145,8 +1145,8 @@ public class MProduct extends X_M_Product implements ImmutablePOSupport
 	public ICostInfo getCostInfo(MAcctSchema as, int AD_Org_ID, int M_ASI_ID, String costingMethod, Timestamp dateAcct)
 	{		
 		String costingLevel = getCostingLevel(as);
-		MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_ASI_ID, costingLevel);
-		if (costKey.isBatchLotZeroASI(costingLevel))
+		MCost.CostingKey costKey = MCost.CostingKey.resolve(AD_Org_ID, M_ASI_ID, costingLevel);
+		if (costKey.isSkipCostingProcessing(costingLevel))
 			return null;
 		AD_Org_ID = costKey.AD_Org_ID();
 		M_ASI_ID = costKey.M_AttributeSetInstance_ID();

--- a/org.adempiere.base/src/org/compiere/model/MProjectIssue.java
+++ b/org.adempiere.base/src/org/compiere/model/MProjectIssue.java
@@ -516,15 +516,9 @@ public class MProjectIssue extends X_C_ProjectIssue implements DocAction, DocOpt
 		int M_AttributeSetInstance_ID = getM_AttributeSetInstance_ID();
 		MProduct product = new MProduct(getCtx(), getM_Product_ID(), get_TrxName());
 		String costingLevel = product.getCostingLevel(as);
-		if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
-		{
-			AD_Org_ID = 0;
-			M_AttributeSetInstance_ID = 0;
-		}
-		else if (MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel))
-			M_AttributeSetInstance_ID = 0;
-		else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel))
-			AD_Org_ID = 0;
+		MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
+		AD_Org_ID = costKey.AD_Org_ID();
+		M_AttributeSetInstance_ID = costKey.M_AttributeSetInstance_ID();
 		
 		MCostElement ce = MCostElement.getMaterialCostElement(getCtx(), as.getCostingMethod(), AD_Org_ID);
 		

--- a/org.adempiere.base/src/org/compiere/model/MProjectIssue.java
+++ b/org.adempiere.base/src/org/compiere/model/MProjectIssue.java
@@ -516,7 +516,7 @@ public class MProjectIssue extends X_C_ProjectIssue implements DocAction, DocOpt
 		int M_AttributeSetInstance_ID = getM_AttributeSetInstance_ID();
 		MProduct product = new MProduct(getCtx(), getM_Product_ID(), get_TrxName());
 		String costingLevel = product.getCostingLevel(as);
-		MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
+		MCost.CostingKey costKey = MCost.CostingKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
 		AD_Org_ID = costKey.AD_Org_ID();
 		M_AttributeSetInstance_ID = costKey.M_AttributeSetInstance_ID();
 		

--- a/org.adempiere.base/src/org/compiere/model/MProjectIssue.java
+++ b/org.adempiere.base/src/org/compiere/model/MProjectIssue.java
@@ -514,15 +514,16 @@ public class MProjectIssue extends X_C_ProjectIssue implements DocAction, DocOpt
 		
 		int AD_Org_ID = getAD_Org_ID();
 		int M_AttributeSetInstance_ID = getM_AttributeSetInstance_ID();
-
-		if (MAcctSchema.COSTINGLEVEL_Client.equals(as.getCostingLevel()))
+		MProduct product = new MProduct(getCtx(), getM_Product_ID(), get_TrxName());
+		String costingLevel = product.getCostingLevel(as);
+		if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
 		{
 			AD_Org_ID = 0;
 			M_AttributeSetInstance_ID = 0;
 		}
-		else if (MAcctSchema.COSTINGLEVEL_Organization.equals(as.getCostingLevel()))
+		else if (MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel))
 			M_AttributeSetInstance_ID = 0;
-		else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(as.getCostingLevel()))
+		else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel))
 			AD_Org_ID = 0;
 		
 		MCostElement ce = MCostElement.getMaterialCostElement(getCtx(), as.getCostingMethod(), AD_Org_ID);

--- a/org.idempiere.acct/src/org/idempiere/acct/doc/DocManager.java
+++ b/org.idempiere.acct/src/org/idempiere/acct/doc/DocManager.java
@@ -682,6 +682,7 @@ public class DocManager {
 			MProduct product = new MProduct(Env.getCtx(), bdcd.getM_Product_ID(), trxName);
 			String costingLevel = product.getCostingLevel(as);	        
 			boolean isBatchLot = MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel);
+			boolean isOrgLevel = MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel);
 						
 			StringBuilder updateSql = new StringBuilder();
 			if (DB.isOracle()) {
@@ -705,6 +706,8 @@ public class DocManager {
 				updateSql.append("  AND t.M_Product_ID = ? ");
 				if (isBatchLot) {
 	                updateSql.append("  AND t.M_AttributeSetInstance_ID = ? ");
+	            } else if (isOrgLevel) {
+	            	updateSql.append("  AND t.AD_Org_ID = ? ");
 	            }
 				updateSql.append("  AND ( ");
 				updateSql.append("    t.DateAcct > base_cd.DateAcct ");
@@ -744,6 +747,8 @@ public class DocManager {
 				updateSql.append("  AND t.M_Product_ID = ? ");
 				if (isBatchLot) {
 	                updateSql.append("  AND t.M_AttributeSetInstance_ID = ? ");
+	            } else if (isOrgLevel) {
+	            	updateSql.append("  AND t.AD_Org_ID = ? ");
 	            }
 				updateSql.append("  AND ( ");
 				updateSql.append("    t.DateAcct > (SELECT DateAcct FROM base_cd) ");
@@ -767,6 +772,8 @@ public class DocManager {
 	        params.add(bdcd.getM_Product_ID());
 	        if (isBatchLot) {
 	            params.add(bdcd.getM_AttributeSetInstance_ID());
+	        } else if (isOrgLevel) {
+	        	params.add(bdcd.getAD_Org_ID());
 	        }
 	        params.add(bdcd.getDateAcct());
 			noUpdate += DB.executeUpdateEx(updateSql.toString(), params.toArray(), trxName);

--- a/org.idempiere.acct/src/org/idempiere/acct/doc/DocManager.java
+++ b/org.idempiere.acct/src/org/idempiere/acct/doc/DocManager.java
@@ -39,6 +39,7 @@ import org.compiere.model.MInvoice;
 import org.compiere.model.MInvoiceLine;
 import org.compiere.model.MMatchInv;
 import org.compiere.model.MMatchPO;
+import org.compiere.model.MProduct;
 import org.compiere.model.MTable;
 import org.compiere.model.Query;
 import org.compiere.util.AdempiereUserError;
@@ -676,6 +677,12 @@ public class DocManager {
 		// set all the cost detail records after the back-date transaction to unprocessed
 		int noUpdate = 0;
 		for (MCostDetail bdcd : bdcds) {
+			// get costing level for product
+			MAcctSchema as = MAcctSchema.get(Env.getCtx(), bdcd.getC_AcctSchema_ID());
+			MProduct product = new MProduct(Env.getCtx(), bdcd.getM_Product_ID(), trxName);
+			String costingLevel = product.getCostingLevel(as);	        
+			boolean isBatchLot = MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel);
+						
 			StringBuilder updateSql = new StringBuilder();
 			if (DB.isOracle()) {
 				updateSql.append("MERGE INTO M_CostDetail t ");
@@ -696,6 +703,9 @@ public class DocManager {
 				updateSql.append("  t.AD_Client_ID = ? ");
 				updateSql.append("  AND t.C_AcctSchema_ID = ? ");
 				updateSql.append("  AND t.M_Product_ID = ? ");
+				if (isBatchLot) {
+	                updateSql.append("  AND t.M_AttributeSetInstance_ID = ? ");
+	            }
 				updateSql.append("  AND ( ");
 				updateSql.append("    t.DateAcct > base_cd.DateAcct ");
 				updateSql.append("    OR ( ");
@@ -732,6 +742,9 @@ public class DocManager {
 				updateSql.append("  t.AD_Client_ID = ? ");
 				updateSql.append("  AND t.C_AcctSchema_ID = ? ");
 				updateSql.append("  AND t.M_Product_ID = ? ");
+				if (isBatchLot) {
+	                updateSql.append("  AND t.M_AttributeSetInstance_ID = ? ");
+	            }
 				updateSql.append("  AND ( ");
 				updateSql.append("    t.DateAcct > (SELECT DateAcct FROM base_cd) ");
 				updateSql.append("    OR ( ");
@@ -747,9 +760,16 @@ public class DocManager {
 				updateSql.append("  AND t.DateAcct >= ? ");
 				updateSql.append("  AND t.Processed = 'Y' ");
 			}
-			noUpdate += DB.executeUpdateEx(updateSql.toString(), 
-					new Object[] {bdcd.getM_CostDetail_ID(), bdcd.getAD_Client_ID(), bdcd.getC_AcctSchema_ID(), bdcd.getM_Product_ID(), bdcd.getDateAcct()}, 
-					trxName);
+			List<Object> params = new ArrayList<Object>();
+	        params.add(bdcd.getM_CostDetail_ID());
+	        params.add(bdcd.getAD_Client_ID());
+	        params.add(bdcd.getC_AcctSchema_ID());
+	        params.add(bdcd.getM_Product_ID());
+	        if (isBatchLot) {
+	            params.add(bdcd.getM_AttributeSetInstance_ID());
+	        }
+	        params.add(bdcd.getDateAcct());
+			noUpdate += DB.executeUpdateEx(updateSql.toString(), params.toArray(), trxName);
 			if (s_log.isLoggable(Level.INFO))
 				s_log.info("Update cost detail to unprocessed: " + noUpdate);
 		}

--- a/org.idempiere.acct/src/org/idempiere/acct/doc/Doc_Inventory.java
+++ b/org.idempiere.acct/src/org/idempiere/acct/doc/Doc_Inventory.java
@@ -258,15 +258,9 @@ public class Doc_Inventory extends Doc
 				product = line.getProduct();
 				int orgId = line.getAD_Org_ID();
 				int asiId = line.getM_AttributeSetInstance_ID();
-				if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
-				{
-					orgId = 0;
-					asiId = 0;
-				}
-				else if (MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel))
-					asiId = 0;
-				else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel))
-					orgId = 0;
+				MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(orgId, asiId, costingLevel);
+				orgId = costKey.AD_Org_ID();
+				asiId = costKey.M_AttributeSetInstance_ID();
 				MCostElement ce = MCostElement.getMaterialCostElement(getCtx(), docCostingMethod, orgId);
 				MCostDetail cd = MCostDetail.getInventory(as, product.getM_Product_ID(), asiId, line.get_ID(), ce.getM_CostElement_ID(), getTrxName());
 				ICostInfo cost = MCost.getCostInfo(product, asiId, as, 

--- a/org.idempiere.acct/src/org/idempiere/acct/doc/Doc_Inventory.java
+++ b/org.idempiere.acct/src/org/idempiere/acct/doc/Doc_Inventory.java
@@ -258,7 +258,7 @@ public class Doc_Inventory extends Doc
 				product = line.getProduct();
 				int orgId = line.getAD_Org_ID();
 				int asiId = line.getM_AttributeSetInstance_ID();
-				MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(orgId, asiId, costingLevel);
+				MCost.CostingKey costKey = MCost.CostingKey.resolve(orgId, asiId, costingLevel);
 				orgId = costKey.AD_Org_ID();
 				asiId = costKey.M_AttributeSetInstance_ID();
 				MCostElement ce = MCostElement.getMaterialCostElement(getCtx(), docCostingMethod, orgId);

--- a/org.idempiere.acct/src/org/idempiere/acct/doc/Doc_Invoice.java
+++ b/org.idempiere.acct/src/org/idempiere/acct/doc/Doc_Invoice.java
@@ -1173,7 +1173,7 @@ public class Doc_Invoice extends Doc
 							int M_AttributeSetInstance_ID = lca.getM_AttributeSetInstance_ID();
 							MProduct product = new MProduct(lca.getCtx(), lca.getM_Product_ID(), lca.get_TrxName());
 							String costingLevel = product.getCostingLevel(as);
-							MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
+							MCost.CostingKey costKey = MCost.CostingKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
 							AD_Org_ID = costKey.AD_Org_ID();
 							M_AttributeSetInstance_ID = costKey.M_AttributeSetInstance_ID();
 							
@@ -1267,7 +1267,7 @@ public class Doc_Invoice extends Doc
 					int M_AttributeSetInstance_ID = lca.getM_AttributeSetInstance_ID();
 					MProduct product = new MProduct(lca.getCtx(), lca.getM_Product_ID(), lca.get_TrxName());
 					String costingLevel = product.getCostingLevel(as);
-					MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
+					MCost.CostingKey costKey = MCost.CostingKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
 					AD_Org_ID = costKey.AD_Org_ID();
 					M_AttributeSetInstance_ID = costKey.M_AttributeSetInstance_ID();
 					String key = lca.getM_Product_ID()+"_"+M_AttributeSetInstance_ID;

--- a/org.idempiere.acct/src/org/idempiere/acct/doc/Doc_Invoice.java
+++ b/org.idempiere.acct/src/org/idempiere/acct/doc/Doc_Invoice.java
@@ -1173,16 +1173,9 @@ public class Doc_Invoice extends Doc
 							int M_AttributeSetInstance_ID = lca.getM_AttributeSetInstance_ID();
 							MProduct product = new MProduct(lca.getCtx(), lca.getM_Product_ID(), lca.get_TrxName());
 							String costingLevel = product.getCostingLevel(as);
-
-							if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
-							{
-								AD_Org_ID = 0;
-								M_AttributeSetInstance_ID = 0;
-							}
-							else if (MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel))
-								M_AttributeSetInstance_ID = 0;
-							else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel))
-								AD_Org_ID = 0;
+							MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
+							AD_Org_ID = costKey.AD_Org_ID();
+							M_AttributeSetInstance_ID = costKey.M_AttributeSetInstance_ID();
 							
 							MCostDetail cd = MCostDetail.getInvoice(as, lca.getM_Product_ID(), M_AttributeSetInstance_ID, 
 									C_InvoiceLine_ID, lca.getM_CostElement_ID(), getDateAcct(), getTrxName());
@@ -1274,16 +1267,9 @@ public class Doc_Invoice extends Doc
 					int M_AttributeSetInstance_ID = lca.getM_AttributeSetInstance_ID();
 					MProduct product = new MProduct(lca.getCtx(), lca.getM_Product_ID(), lca.get_TrxName());
 					String costingLevel = product.getCostingLevel(as);
-
-					if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
-					{
-						AD_Org_ID = 0;
-						M_AttributeSetInstance_ID = 0;
-					}
-					else if (MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel))
-						M_AttributeSetInstance_ID = 0;
-					else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel))
-						AD_Org_ID = 0;
+					MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
+					AD_Org_ID = costKey.AD_Org_ID();
+					M_AttributeSetInstance_ID = costKey.M_AttributeSetInstance_ID();
 					String key = lca.getM_Product_ID()+"_"+M_AttributeSetInstance_ID;
 					if (!costDetailAmtMap.containsKey(key)) {
 						costDetailAmtMap.put(key, BigDecimal.ZERO);

--- a/org.idempiere.acct/src/org/idempiere/acct/doc/Doc_Invoice.java
+++ b/org.idempiere.acct/src/org/idempiere/acct/doc/Doc_Invoice.java
@@ -47,6 +47,7 @@ import org.compiere.model.MLandedCostAllocation;
 import org.compiere.model.MOrderLandedCost;
 import org.compiere.model.MOrderLandedCostAllocation;
 import org.compiere.model.MOrderLine;
+import org.compiere.model.MProduct;
 import org.compiere.model.MTax;
 import org.compiere.model.ProductCost;
 import org.compiere.model.Query;
@@ -1170,15 +1171,17 @@ public class Doc_Invoice extends Doc
 						{
 							int AD_Org_ID = lca.getAD_Org_ID();
 							int M_AttributeSetInstance_ID = lca.getM_AttributeSetInstance_ID();
+							MProduct product = new MProduct(lca.getCtx(), lca.getM_Product_ID(), lca.get_TrxName());
+							String costingLevel = product.getCostingLevel(as);
 
-							if (MAcctSchema.COSTINGLEVEL_Client.equals(as.getCostingLevel()))
+							if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
 							{
 								AD_Org_ID = 0;
 								M_AttributeSetInstance_ID = 0;
 							}
-							else if (MAcctSchema.COSTINGLEVEL_Organization.equals(as.getCostingLevel()))
+							else if (MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel))
 								M_AttributeSetInstance_ID = 0;
-							else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(as.getCostingLevel()))
+							else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel))
 								AD_Org_ID = 0;
 							
 							MCostDetail cd = MCostDetail.getInvoice(as, lca.getM_Product_ID(), M_AttributeSetInstance_ID, 
@@ -1269,15 +1272,17 @@ public class Doc_Invoice extends Doc
 					costDetailQty = BigDecimal.ZERO;
 					int AD_Org_ID = lca.getAD_Org_ID();
 					int M_AttributeSetInstance_ID = lca.getM_AttributeSetInstance_ID();
+					MProduct product = new MProduct(lca.getCtx(), lca.getM_Product_ID(), lca.get_TrxName());
+					String costingLevel = product.getCostingLevel(as);
 
-					if (MAcctSchema.COSTINGLEVEL_Client.equals(as.getCostingLevel()))
+					if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel))
 					{
 						AD_Org_ID = 0;
 						M_AttributeSetInstance_ID = 0;
 					}
-					else if (MAcctSchema.COSTINGLEVEL_Organization.equals(as.getCostingLevel()))
+					else if (MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel))
 						M_AttributeSetInstance_ID = 0;
-					else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(as.getCostingLevel()))
+					else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel))
 						AD_Org_ID = 0;
 					String key = lca.getM_Product_ID()+"_"+M_AttributeSetInstance_ID;
 					if (!costDetailAmtMap.containsKey(key)) {

--- a/org.idempiere.acct/src/org/idempiere/acct/doc/Doc_MatchInv.java
+++ b/org.idempiere.acct/src/org/idempiere/acct/doc/Doc_MatchInv.java
@@ -2833,14 +2833,9 @@ public class Doc_MatchInv extends Doc
  	    int M_AttributeSetInstance_ID = matchInv.getM_AttributeSetInstance_ID();
  	    MProduct product = new MProduct(matchInv.getCtx(), matchInv.getM_Product_ID(), matchInv.get_TrxName());
  	    String costingLevel = product.getCostingLevel(as);
- 	    if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel)) {
- 	        AD_Org_ID = 0;
- 	        M_AttributeSetInstance_ID = 0;
- 	    } else if (MAcctSchema.COSTINGLEVEL_Organization.equals(costingLevel)) {
- 	        M_AttributeSetInstance_ID = 0;
- 	    } else if (MAcctSchema.COSTINGLEVEL_BatchLot.equals(costingLevel)) {
- 	        AD_Org_ID = 0;
- 	    }
+ 	    MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
+		AD_Org_ID = costKey.AD_Org_ID();
+		M_AttributeSetInstance_ID = costKey.M_AttributeSetInstance_ID();
 	    MCostElement ce = MCostElement.getMaterialCostElement(getCtx(), costingMethod, AD_Org_ID);
 	    if (matchInv.getReversal_ID() > 0) {
 		    MCostDetail cd = MCostDetail.getMatchInvoice(as, matchInv.getM_Product_ID(), matchInv.getM_AttributeSetInstance_ID(),

--- a/org.idempiere.acct/src/org/idempiere/acct/doc/Doc_MatchInv.java
+++ b/org.idempiere.acct/src/org/idempiere/acct/doc/Doc_MatchInv.java
@@ -2833,7 +2833,7 @@ public class Doc_MatchInv extends Doc
  	    int M_AttributeSetInstance_ID = matchInv.getM_AttributeSetInstance_ID();
  	    MProduct product = new MProduct(matchInv.getCtx(), matchInv.getM_Product_ID(), matchInv.get_TrxName());
  	    String costingLevel = product.getCostingLevel(as);
- 	    MCost.CostingLevelKey costKey = MCost.CostingLevelKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
+ 	    MCost.CostingKey costKey = MCost.CostingKey.resolve(AD_Org_ID, M_AttributeSetInstance_ID, costingLevel);
 		AD_Org_ID = costKey.AD_Org_ID();
 		M_AttributeSetInstance_ID = costKey.M_AttributeSetInstance_ID();
 	    MCostElement ce = MCostElement.getMaterialCostElement(getCtx(), costingMethod, AD_Org_ID);

--- a/org.idempiere.acct/src/org/idempiere/acct/doc/Doc_MatchInv.java
+++ b/org.idempiere.acct/src/org/idempiere/acct/doc/Doc_MatchInv.java
@@ -51,6 +51,7 @@ import org.compiere.model.MOrder;
 import org.compiere.model.MOrderLandedCost;
 import org.compiere.model.MOrderLandedCostAllocation;
 import org.compiere.model.MOrderLine;
+import org.compiere.model.MProduct;
 import org.compiere.model.MTax;
 import org.compiere.model.MUOM;
 import org.compiere.model.ProductCost;
@@ -2830,7 +2831,8 @@ public class Doc_MatchInv extends Doc
 		// Costing-level AD_Org_ID and M_AttributeSetInstance_ID
  		int AD_Org_ID = m_receiptLine.getAD_Org_ID();
  	    int M_AttributeSetInstance_ID = matchInv.getM_AttributeSetInstance_ID();
- 	    String costingLevel = as.getCostingLevel();
+ 	    MProduct product = new MProduct(matchInv.getCtx(), matchInv.getM_Product_ID(), matchInv.get_TrxName());
+ 	    String costingLevel = product.getCostingLevel(as);
  	    if (MAcctSchema.COSTINGLEVEL_Client.equals(costingLevel)) {
  	        AD_Org_ID = 0;
  	        M_AttributeSetInstance_ID = 0;

--- a/org.idempiere.test/src/org/idempiere/test/costing/BackDateAveragePOCostingTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/costing/BackDateAveragePOCostingTest.java
@@ -50,6 +50,7 @@ import java.util.stream.Stream;
 import org.compiere.model.MAccount;
 import org.compiere.model.MAcctSchema;
 import org.compiere.model.MAllocationHdr;
+import org.compiere.model.MAttributeSet;
 import org.compiere.model.MAttributeSetInstance;
 import org.compiere.model.MBPartner;
 import org.compiere.model.MCharge;
@@ -86,6 +87,7 @@ import org.compiere.model.Query;
 import org.compiere.process.DocAction;
 import org.compiere.process.DocumentEngine;
 import org.compiere.process.ProcessInfo;
+import org.compiere.util.CacheMgt;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
@@ -13235,6 +13237,161 @@ public class BackDateAveragePOCostingTest extends AbstractTestCase {
 		}		
 	}
 	
+	/**
+	 * IDEMPIERE-6960
+	 * MR1 Product1, ASI1, Qty=7500, Price=0.814 (Date2)
+	 * MR2 Product1, ASI2, Qty=18000, Price=0.814 (Date3)
+	 * MR3 Product1, ASI3, Qty=1, Price=1 (Date1) - Back Date
+	 */
+	@Test
+	public void testBatchLotCostingLevel() {
+		MAcctSchema[] ass = MAcctSchema.getClientAcctSchema(Env.getCtx(), getAD_Client_ID());
+		MClientInfo ci = MClientInfo.get(Env.getCtx(), getAD_Client_ID(), null); 
+		MAcctSchema as = ci.getMAcctSchema1();
+		
+		MAttributeSet mas = new MAttributeSet(Env.getCtx(), DictionaryIDs.M_AttributeSet.FERTILIZER_LOT.id, getTrxName());
+		mas.setMandatoryType(MAttributeSet.MANDATORYTYPE_NotMandatory);
+		mas.saveEx();
+
+		int[] backDateDays = new int[ass.length];
+		try (MockedStatic<MProduct> mockedProduct = mockStatic(MProduct.class);
+				MockedStatic<MProductCategory> mockedCategory = mockStatic(MProductCategory.class)) {	
+			backDateDays = configureAcctSchema(ass);
+			
+			Timestamp today = TimeUtil.getDay(System.currentTimeMillis());
+			Calendar cal = Calendar.getInstance();
+			cal.setTimeInMillis(today.getTime());
+			cal.add(Calendar.DAY_OF_MONTH, -3);
+			Timestamp backDate1 = new Timestamp(cal.getTimeInMillis());
+			cal.setTimeInMillis(today.getTime());
+			cal.add(Calendar.DAY_OF_MONTH, -2);
+			Timestamp backDate2  = new Timestamp(cal.getTimeInMillis());
+			cal.setTimeInMillis(today.getTime());
+			cal.add(Calendar.DAY_OF_MONTH, -1);
+			Timestamp backDate3  = new Timestamp(cal.getTimeInMillis());
+			
+			MProductCategory lotLevel = new MProductCategory(Env.getCtx(), 0, getTrxName());
+			lotLevel.setName("testBatchLotCostingLevel");
+			lotLevel.saveEx();
+			
+			mockedCategory.when(() -> MProductCategory.get(any(Properties.class), anyInt())).thenCallRealMethod();
+			mockedCategory.when(() -> MProductCategory.get(any(Properties.class), eq(lotLevel.get_ID()))).thenReturn(lotLevel);
+			
+			for (MAcctSchema as0 : ass) {						
+				MProductCategoryAcct lotLevelAcct = MProductCategoryAcct.get(lotLevel.get_ID(), as0.get_ID(), getTrxName());
+				lotLevelAcct = new MProductCategoryAcct(Env.getCtx(), lotLevelAcct, getTrxName());
+				lotLevelAcct.setCostingLevel(MAcctSchema.COSTINGLEVEL_BatchLot);
+				lotLevelAcct.saveEx();
+			}
+			CacheMgt.get().reset(MProductCategoryAcct.Table_Name);
+			for (MAcctSchema as0 : ass) {
+				MProductCategoryAcct lotLevelAcct = MProductCategoryAcct.get(lotLevel.get_ID(), as0.get_ID(), getTrxName());
+				assertEquals(MAcctSchema.COSTINGLEVEL_BatchLot, lotLevelAcct.getCostingLevel());
+			}
+			
+			MProduct product = new MProduct(Env.getCtx(), 0, getTrxName());
+			product.setM_Product_Category_ID(lotLevel.get_ID());
+			product.setName("testBatchLotCostingLevel");
+			product.setProductType(MProduct.PRODUCTTYPE_Item);
+			product.setIsStocked(true);
+			product.setIsSold(true);
+			product.setIsPurchased(true);
+			product.setC_UOM_ID(DictionaryIDs.C_UOM.EACH.id);
+			product.setC_TaxCategory_ID(DictionaryIDs.C_TaxCategory.STANDARD.id);
+			product.setM_AttributeSet_ID(DictionaryIDs.M_AttributeSet.FERTILIZER_LOT.id);
+			product.saveEx();
+			
+			mockedProduct.when(() -> MProduct.getCopy(any(Properties.class), anyInt(), any())).thenCallRealMethod();
+			mockedProduct.when(() -> MProduct.get(anyInt())).thenCallRealMethod();
+			mockedProduct.when(() -> MProduct.get(any(Properties.class), anyInt(), any())).thenCallRealMethod();
+			mockedProduct.when(() -> MProduct.get(any(Properties.class), anyInt())).thenCallRealMethod();
+			mockProductGet(mockedProduct, product);
+			
+			MPriceListVersion plv = MPriceList.get(DictionaryIDs.M_PriceList.PURCHASE.id).getPriceListVersion(null);
+			MProductPrice pp = new MProductPrice(Env.getCtx(), 0, getTrxName());
+			pp.setM_PriceList_Version_ID(plv.getM_PriceList_Version_ID());
+			pp.setM_Product_ID(product.get_ID());
+			pp.setPriceStd(new BigDecimal("0.814"));
+			pp.setPriceList(new BigDecimal("0.814"));
+			pp.saveEx();
+			
+			// MR1
+			MAttributeSetInstance asi1 = new MAttributeSetInstance(Env.getCtx(), 0, getTrxName());
+			asi1.setM_AttributeSet_ID(DictionaryIDs.M_AttributeSet.FERTILIZER_LOT.id);
+			asi1.setLot("Lot1");
+			asi1.saveEx();
+			createPOAndMRForProduct(backDate2, product.get_ID(), asi1.get_ID(), new BigDecimal("7500"), new BigDecimal("0.814"));
+			MCost cost1 = product.getCostingRecord(as, getAD_Org_ID(), asi1.get_ID(), as.getCostingMethod());
+			assertNotNull(cost1, "No MCost record found");
+ 			assertEquals(new BigDecimal("7500").setScale(2, RoundingMode.HALF_UP), cost1.getCurrentQty().setScale(2, RoundingMode.HALF_UP), "Unexpected current quantity");
+			
+			// MR2
+			MAttributeSetInstance asi2 = new MAttributeSetInstance(Env.getCtx(), 0, getTrxName());
+			asi2.setM_AttributeSet_ID(DictionaryIDs.M_AttributeSet.FERTILIZER_LOT.id);
+			asi2.setLot("Lot2");
+			asi2.saveEx();
+			createPOAndMRForProduct(backDate3, product.get_ID(), asi2.get_ID(), new BigDecimal("18000"), new BigDecimal("0.814"));
+			MCost cost2 = product.getCostingRecord(as, getAD_Org_ID(), asi2.get_ID(), as.getCostingMethod());
+			assertNotNull(cost2, "No MCost record found");
+ 			assertEquals(new BigDecimal("18000").setScale(2, RoundingMode.HALF_UP), cost2.getCurrentQty().setScale(2, RoundingMode.HALF_UP), "Unexpected current quantity");
+
+			// MR3
+			MAttributeSetInstance asi3 = new MAttributeSetInstance(Env.getCtx(), 0, getTrxName());
+			asi3.setM_AttributeSet_ID(DictionaryIDs.M_AttributeSet.FERTILIZER_LOT.id);
+			asi3.setLot("Lot3");
+			asi3.saveEx();
+			createPOAndMRForProduct(backDate1, product.get_ID(), asi3.get_ID(), new BigDecimal("1"), new BigDecimal("1"));
+			MCost cost3 = product.getCostingRecord(as, getAD_Org_ID(), asi3.get_ID(), as.getCostingMethod());
+			assertNotNull(cost3, "No MCost record found");
+ 			assertEquals(new BigDecimal("1").setScale(2, RoundingMode.HALF_UP), cost3.getCurrentQty().setScale(2, RoundingMode.HALF_UP), "Unexpected current quantity");
+ 			
+ 			cost1.load(getTrxName());
+ 			assertEquals(new BigDecimal("7500").setScale(2, RoundingMode.HALF_UP), cost1.getCurrentQty().setScale(2, RoundingMode.HALF_UP), "Unexpected current quantity"); 			
+ 			cost2.load(getTrxName());
+ 			assertEquals(new BigDecimal("18000").setScale(2, RoundingMode.HALF_UP), cost2.getCurrentQty().setScale(2, RoundingMode.HALF_UP), "Unexpected current quantity");
+ 			
+ 			BigDecimal currentQty1 = null;
+ 			BigDecimal currentQty2 = null;
+ 			BigDecimal currentQty3 = null;
+ 			for (MAcctSchema as0 : ass) {
+ 				MCost cost1a = product.getCostingRecord(as0, getAD_Org_ID(), asi1.get_ID(), MCostElement.COSTINGMETHOD_AveragePO);
+ 				MCost cost2a = product.getCostingRecord(as0, getAD_Org_ID(), asi2.get_ID(), MCostElement.COSTINGMETHOD_AveragePO);
+ 				MCost cost3a = product.getCostingRecord(as0, getAD_Org_ID(), asi3.get_ID(), MCostElement.COSTINGMETHOD_AveragePO);
+ 				MCost cost1b = product.getCostingRecord(as0, getAD_Org_ID(), asi1.get_ID(), MCostElement.COSTINGMETHOD_StandardCosting);
+ 				MCost cost2b = product.getCostingRecord(as0, getAD_Org_ID(), asi2.get_ID(), MCostElement.COSTINGMETHOD_StandardCosting);
+ 				MCost cost3b = product.getCostingRecord(as0, getAD_Org_ID(), asi3.get_ID(), MCostElement.COSTINGMETHOD_StandardCosting);
+ 				assertNotNull(cost1a, "No MCost record found");
+ 				assertNotNull(cost2a, "No MCost record found");
+ 				assertNotNull(cost3a, "No MCost record found");
+ 				assertNotNull(cost1b, "No MCost record found");
+ 				assertNotNull(cost2b, "No MCost record found");
+ 				assertNotNull(cost3b, "No MCost record found");
+ 				assertEquals(cost1a.getCurrentQty().setScale(2, RoundingMode.HALF_UP), cost1b.getCurrentQty().setScale(2, RoundingMode.HALF_UP), "Unexpected current quantity");
+ 				assertEquals(cost2a.getCurrentQty().setScale(2, RoundingMode.HALF_UP), cost2b.getCurrentQty().setScale(2, RoundingMode.HALF_UP), "Unexpected current quantity");
+ 				assertEquals(cost3a.getCurrentQty().setScale(2, RoundingMode.HALF_UP), cost3b.getCurrentQty().setScale(2, RoundingMode.HALF_UP), "Unexpected current quantity");
+ 				
+ 				if (currentQty1 == null)
+ 					currentQty1 = cost1a.getCurrentQty();
+ 				else
+ 					assertEquals(currentQty1.setScale(2, RoundingMode.HALF_UP), cost1a.getCurrentQty().setScale(2, RoundingMode.HALF_UP), "Unexpected current quantity across accounting schemas");
+ 				if (currentQty2 == null)
+ 					currentQty2 = cost2a.getCurrentQty();
+ 				else
+ 					assertEquals(currentQty2.setScale(2, RoundingMode.HALF_UP), cost2a.getCurrentQty().setScale(2, RoundingMode.HALF_UP), "Unexpected current quantity across accounting schemas");
+ 				if (currentQty3 == null)
+ 					currentQty3 = cost3a.getCurrentQty();
+ 				else
+ 					assertEquals(currentQty3.setScale(2, RoundingMode.HALF_UP), cost3a.getCurrentQty().setScale(2, RoundingMode.HALF_UP), "Unexpected current quantity across accounting schemas");
+ 				
+ 				List<MCostDetail> cds = MCostDetail.list(Env.getCtx(), "M_Product_ID=? AND Processed='N'", product.get_ID(), 0, as.getC_AcctSchema_ID(), getTrxName());
+ 				assertTrue(cds.isEmpty(), "Found unprocessed MCostDetail rows for product=" + product.get_ID() + ", acctSchema=" + as.getC_AcctSchema_ID());
+ 			}
+		} finally {
+			rollback();
+			resetAcctSchema(ass, backDateDays);
+		}
+	}
+	
 	private MProduct createProduct(String name, BigDecimal price) {
 		return createProduct(name, price, DictionaryIDs.M_Product_Category.STANDARD.id);
 	}
@@ -13270,8 +13427,12 @@ public class BackDateAveragePOCostingTest extends AbstractTestCase {
 		
 		return product;		
 	}
-		
+	
 	private MInOutLine createPOAndMRForProduct(Timestamp acctDate, int productId, BigDecimal qty, BigDecimal price) {
+		return createPOAndMRForProduct(acctDate, productId, 0, qty, price);
+	}
+		
+	private MInOutLine createPOAndMRForProduct(Timestamp acctDate, int productId, int asiId, BigDecimal qty, BigDecimal price) {
 		MOrder order = new MOrder(Env.getCtx(), 0, getTrxName());
 		order.setBPartner(MBPartner.get(Env.getCtx(), DictionaryIDs.C_BPartner.PATIO.id));
 		order.setC_DocTypeTarget_ID(DictionaryIDs.C_DocType.PURCHASE_ORDER.id);
@@ -13287,6 +13448,8 @@ public class BackDateAveragePOCostingTest extends AbstractTestCase {
 		MOrderLine orderLine = new MOrderLine(order);
 		orderLine.setLine(10);
 		orderLine.setProduct(new MProduct(Env.getCtx(), productId, getTrxName()));
+		if (asiId > 0)
+			orderLine.setM_AttributeSetInstance_ID(asiId);
 		orderLine.setQty(qty);
 		orderLine.setDatePromised(acctDate);
 		if (price != null)
@@ -13305,6 +13468,8 @@ public class BackDateAveragePOCostingTest extends AbstractTestCase {
 
 		MInOutLine receiptLine = new MInOutLine(receipt);
 		receiptLine.setOrderLine(orderLine, 0, qty);
+		if (asiId > 0)
+			receiptLine.setM_AttributeSetInstance_ID(asiId);
 		receiptLine.setQty(qty);
 		receiptLine.saveEx();
 

--- a/org.idempiere.test/src/org/idempiere/test/costing/BackDateAveragePOCostingTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/costing/BackDateAveragePOCostingTest.java
@@ -13383,8 +13383,11 @@ public class BackDateAveragePOCostingTest extends AbstractTestCase {
  				else
  					assertEquals(currentQty3.setScale(2, RoundingMode.HALF_UP), cost3a.getCurrentQty().setScale(2, RoundingMode.HALF_UP), "Unexpected current quantity across accounting schemas");
  				
- 				List<MCostDetail> cds = MCostDetail.list(Env.getCtx(), "M_Product_ID=? AND Processed='N'", product.get_ID(), 0, as.getC_AcctSchema_ID(), getTrxName());
- 				assertTrue(cds.isEmpty(), "Found unprocessed MCostDetail rows for product=" + product.get_ID() + ", acctSchema=" + as.getC_AcctSchema_ID());
+ 				for (int asiId : new int[] {asi1.get_ID(), asi2.get_ID(), asi3.get_ID()}) {
+ 					List<MCostDetail> cds = MCostDetail.list(Env.getCtx(), "M_Product_ID=? AND Processed='N'", product.get_ID(), asiId, as0.getC_AcctSchema_ID(), getTrxName());
+ 					assertTrue(cds.isEmpty(), "Found unprocessed MCostDetail rows for product=" + product.get_ID()
+ 						+ ", M_AttributeSetInstance_ID=" + asiId + ", acctSchema=" + as0.getC_AcctSchema_ID());
+ 					}
  			}
 		} finally {
 			rollback();


### PR DESCRIPTION
[IDEMPIERE-6960](https://idempiere.atlassian.net/browse/IDEMPIERE-6960) Back-dated costing incorrectly updates other lots when Costing Level = Batch/Lot

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [x] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.



[IDEMPIERE-6960]: https://idempiere.atlassian.net/browse/IDEMPIERE-6960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Back-dated inventory, invoice, shipment, project, and cost-adjustment processing now applies the correct product-specific costing scope.
  * Batch- and lot-specific costing consistently respects the matching attribute set.
  * Cost calculations and period-closed validations are more accurate for products with different costing configurations.
  * Product costing settings safely fall back to accounting defaults when specific configuration is unavailable.
* **Tests**
  * Added coverage for batch/lot costing across receipts, costing methods, and accounting schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->