### PR TITLE
IDEMPIERE-7075 Fix reservations for over-receipt reversals

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MInOut.java
+++ b/org.adempiere.base/src/org/compiere/model/MInOut.java
@@ -1693,6 +1693,7 @@ public class MInOut extends X_M_InOut implements DocAction, IDocsPostProcess
 	
 				//	Update Order Line
 				MOrderLine oLine = null;
+				BigDecimal reservationDelta = Env.ZERO;
 				if (sLine.getC_OrderLine_ID() != 0)
 				{
 					oLine = new MOrderLine (getCtx(), sLine.getC_OrderLine_ID(), get_TrxName());
@@ -1744,21 +1745,27 @@ public class MInOut extends X_M_InOut implements DocAction, IDocsPostProcess
 								toDelivered = Env.ZERO;
 						}
 					} 
+
+					reservationDelta = sLine.getMovementQty().negate();
 					
-					BigDecimal storageReservationToUpdate = sLine.getMovementQty();
-					if (oLine != null)
+					if (oLine != null && oLine.getQtyOrdered().signum() >= 0)
 					{
-						if (!isReversal()) 
-						{
-							if (storageReservationToUpdate.compareTo(oLine.getQtyReserved()) > 0) 
-								storageReservationToUpdate = oLine.getQtyReserved();
-						}
-						else
-						{
-							BigDecimal tmp = storageReservationToUpdate.negate().add(oLine.getQtyReserved());
-							if (tmp.compareTo(oLine.getQtyOrdered()) > 0)
-								storageReservationToUpdate = oLine.getQtyOrdered().subtract(oLine.getQtyReserved());
-						}
+						BigDecimal currentReserved = oLine.getQtyReserved();
+						BigDecimal targetReserved = currentReserved.add(reservationDelta);
+						BigDecimal anticipatedDelivered = oLine.getQtyDelivered();
+						if (isSOTrx())
+							anticipatedDelivered = anticipatedDelivered.add(sLine.getMovementQty());
+						BigDecimal maxReserved = oLine.getQtyOrdered().subtract(anticipatedDelivered);
+
+						if (targetReserved.signum() < 0)
+							targetReserved = Env.ZERO;
+						if (maxReserved.signum() < 0)
+							maxReserved = Env.ZERO;
+
+						if (targetReserved.compareTo(maxReserved) > 0)
+							targetReserved = maxReserved;
+
+						reservationDelta = targetReserved.subtract(currentReserved);
 					}
 					
 					//
@@ -1833,7 +1840,7 @@ public class MInOut extends X_M_InOut implements DocAction, IDocsPostProcess
 								if (!MStorageReservation.add(getCtx(), oLine.getM_Warehouse_ID(),
 										oLine.getM_Product_ID(),
 										oLine.getM_AttributeSetInstance_ID(),
-										storageReservationToUpdate.negate(),
+										reservationDelta,
 										isSOTrx(),
 										get_TrxName(), tracer))
 								{
@@ -1929,7 +1936,7 @@ public class MInOut extends X_M_InOut implements DocAction, IDocsPostProcess
 							if (!MStorageReservation.add(getCtx(), oLine.getM_Warehouse_ID(),
 									oLine.getM_Product_ID(),
 									oLine.getM_AttributeSetInstance_ID(),
-									storageReservationToUpdate.negate(), isSOTrx(), get_TrxName(), tracer))
+									reservationDelta, isSOTrx(), get_TrxName(), tracer))
 							{
 								m_processMsg = "Cannot correct Inventory Reserved " + (isSOTrx()? "Reserved [" :"Ordered [") + product.getValue() + "]";
 								return DocAction.STATUS_Invalid;
@@ -1963,12 +1970,7 @@ public class MInOut extends X_M_InOut implements DocAction, IDocsPostProcess
 				{
 					if (oLine.getQtyOrdered().signum() >= 0)
 					{
-						oLine.setQtyReserved(oLine.getQtyReserved().subtract(sLine.getMovementQty()));
-
-						if (oLine.getQtyReserved().signum() == -1)
-							oLine.setQtyReserved(Env.ZERO);
-						else if (oLine.getQtyDelivered().compareTo(oLine.getQtyOrdered()) > 0)
-							oLine.setQtyReserved(Env.ZERO);
+						oLine.setQtyReserved(oLine.getQtyReserved().add(reservationDelta));
 					}
 				}
 	

--- a/org.adempiere.base/src/org/compiere/model/MInOut.java
+++ b/org.adempiere.base/src/org/compiere/model/MInOut.java
@@ -1700,6 +1700,25 @@ public class MInOut extends X_M_InOut implements DocAction, IDocsPostProcess
 					if (log.isLoggable(Level.FINE)) log.fine("OrderLine - Reserved=" + oLine.getQtyReserved()
 						+ ", Delivered=" + oLine.getQtyDelivered());
 				}
+				if (oLine != null && oLine.getQtyOrdered().signum() >= 0)
+				{
+					BigDecimal currentReserved = oLine.getQtyReserved();
+					BigDecimal targetReserved = currentReserved.subtract(sLine.getMovementQty());
+					BigDecimal anticipatedDelivered = oLine.getQtyDelivered();
+					if (isSOTrx())
+						anticipatedDelivered = anticipatedDelivered.add(sLine.getMovementQty());
+					BigDecimal maxReserved = oLine.getQtyOrdered().subtract(anticipatedDelivered);
+
+					if (targetReserved.signum() < 0)
+						targetReserved = Env.ZERO;
+					if (maxReserved.signum() < 0)
+						maxReserved = Env.ZERO;
+
+					if (targetReserved.compareTo(maxReserved) > 0)
+						targetReserved = maxReserved;
+
+					reservationDelta = targetReserved.subtract(currentReserved);
+				}
 				boolean orderClosed = oLine != null && DocAction.STATUS_Closed.equals(oLine.getParent().getDocStatus());
 				
 	            // Load RMA Line
@@ -1746,28 +1765,6 @@ public class MInOut extends X_M_InOut implements DocAction, IDocsPostProcess
 						}
 					} 
 
-					reservationDelta = sLine.getMovementQty().negate();
-					
-					if (oLine != null && oLine.getQtyOrdered().signum() >= 0)
-					{
-						BigDecimal currentReserved = oLine.getQtyReserved();
-						BigDecimal targetReserved = currentReserved.add(reservationDelta);
-						BigDecimal anticipatedDelivered = oLine.getQtyDelivered();
-						if (isSOTrx())
-							anticipatedDelivered = anticipatedDelivered.add(sLine.getMovementQty());
-						BigDecimal maxReserved = oLine.getQtyOrdered().subtract(anticipatedDelivered);
-
-						if (targetReserved.signum() < 0)
-							targetReserved = Env.ZERO;
-						if (maxReserved.signum() < 0)
-							maxReserved = Env.ZERO;
-
-						if (targetReserved.compareTo(maxReserved) > 0)
-							targetReserved = maxReserved;
-
-						reservationDelta = targetReserved.subtract(currentReserved);
-					}
-					
 					//
 					if (sLine.getM_AttributeSetInstance_ID() == 0)
 					{

--- a/org.adempiere.base/src/org/compiere/model/MInOut.java
+++ b/org.adempiere.base/src/org/compiere/model/MInOut.java
@@ -1753,17 +1753,6 @@ public class MInOut extends X_M_InOut implements DocAction, IDocsPostProcess
 	
 					log.fine("Material Transaction");
 					MTransaction mtrx = null;
-					
-					if (!isReversal()) 
-					{
-						if (oLine != null) 
-						{
-							BigDecimal toDelivered = oLine.getQtyOrdered()
-									.subtract(oLine.getQtyDelivered());
-							if (toDelivered.signum() < 0) // IDEMPIERE-2889
-								toDelivered = Env.ZERO;
-						}
-					} 
 
 					//
 					if (sLine.getM_AttributeSetInstance_ID() == 0)
@@ -1821,8 +1810,7 @@ public class MInOut extends X_M_InOut implements DocAction, IDocsPostProcess
 							}
 						}
 												
-						if (oLine!=null && mtrx!=null && !orderClosed && 
-						   ((!isReversal() && oLine.getQtyReserved().signum() > 0) || (isReversal() && oLine.getQtyOrdered().signum() > 0)))
+						if (oLine != null && mtrx != null && !orderClosed && reservationDelta.signum() != 0)
 						{					
 							if (sLine.getC_OrderLine_ID() != 0 && oLine.getM_Product_ID() > 0)
 							{
@@ -1919,8 +1907,7 @@ public class MInOut extends X_M_InOut implements DocAction, IDocsPostProcess
 							m_processMsg = "Cannot correct Inventory OnHand [" + product.getValue() + "] - " + lastError;
 							return DocAction.STATUS_Invalid;
 						}
-						if (oLine!=null && oLine.getM_Product_ID() > 0 && !orderClosed &&
-							((!isReversal() && oLine.getQtyReserved().signum() > 0) || (isReversal() && oLine.getQtyOrdered().signum() > 0)))  
+						if (oLine != null && oLine.getM_Product_ID() > 0 && !orderClosed && reservationDelta.signum() != 0)
 						{
 							IReservationTracer tracer = null;
 							IReservationTracerFactory factory = Core.getReservationTracerFactory();

--- a/org.idempiere.test/src/org/idempiere/test/model/PurchaseOrderTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/PurchaseOrderTest.java
@@ -60,7 +60,6 @@ import org.compiere.model.Query;
 import org.compiere.process.DocAction;
 import org.compiere.process.ProcessInfo;
 import org.compiere.process.ServerProcessCtl;
-import org.compiere.util.CacheMgt;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
@@ -68,6 +67,8 @@ import org.compiere.wf.MWorkflow;
 import org.idempiere.test.AbstractTestCase;
 import org.idempiere.test.DictionaryIDs;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 /**
  * @author Carlos Ruiz - globalqss
@@ -489,13 +490,12 @@ public class PurchaseOrderTest extends AbstractTestCase {
 	public void testQtyOverReceipt() {
 		Properties ctx = Env.getCtx();
 		String trxName = getTrxName();
-		
-		DB.executeUpdateEx("UPDATE AD_SysConfig SET Value='N' WHERE AD_Client_ID=0 AND Name=?", 
-				new Object[] {MSysConfig.VALIDATE_MATCHING_TO_ORDERED_QTY}, null);
-		CacheMgt.get().reset();
 
 		BigDecimal initialQtyOrdered = getQtyOrdered(Env.getCtx(), DictionaryIDs.M_Product.ROSE_BUSH.id, getTrxName());
-		try {			
+		try (MockedStatic<MSysConfig> mocked = Mockito.mockStatic(MSysConfig.class, Mockito.CALLS_REAL_METHODS)) {
+			mocked.when(() -> MSysConfig.getBooleanValue(MSysConfig.VALIDATE_MATCHING_TO_ORDERED_QTY, true,
+					Env.getAD_Client_ID(ctx))).thenReturn(false);
+
 			MOrder order = new MOrder(ctx, 0, trxName);
 			order.setBPartner(MBPartner.get(ctx, DictionaryIDs.C_BPartner.PATIO.id));
 			order.setC_DocTypeTarget_ID(DictionaryIDs.C_DocType.PURCHASE_ORDER.id);
@@ -580,10 +580,6 @@ public class PurchaseOrderTest extends AbstractTestCase {
 			assertEquals(0, line1.getQtyDelivered().intValue(), "Wrong order line qty delivered value");
 			newQtyOrdered = getQtyOrdered(Env.getCtx(), DictionaryIDs.M_Product.ROSE_BUSH.id, getTrxName());
 			assertEquals(initialQtyOrdered.intValue()+2, newQtyOrdered.intValue(), "Quantiy Ordered not updated as expected");
-		} finally {
-			DB.executeUpdateEx("UPDATE AD_SysConfig SET Value='Y' WHERE AD_Client_ID=0 AND Name=?", 
-					new Object[] {MSysConfig.VALIDATE_MATCHING_TO_ORDERED_QTY}, null);
-			CacheMgt.get().reset();
 		}
 	}
 
@@ -591,7 +587,7 @@ public class PurchaseOrderTest extends AbstractTestCase {
 	 * https://idempiere.atlassian.net/browse/IDEMPIERE-7075
 	 */
 	@Test
-	public void testOverReceiptVoidAndOrderCloseReservation() {
+	public void testOverReceiptReversalAndOrderCloseReservation() {
 		Properties ctx = Env.getCtx();
 		String trxName = getTrxName();
 		int productId = DictionaryIDs.M_Product.ROSE_BUSH.id;
@@ -599,11 +595,10 @@ public class PurchaseOrderTest extends AbstractTestCase {
 		BigDecimal qtyReceived = new BigDecimal("303");
 		BigDecimal initialQtyOrdered = getQtyOrdered(ctx, productId, trxName);
 
-		DB.executeUpdateEx("UPDATE AD_SysConfig SET Value='N' WHERE AD_Client_ID=0 AND Name=?",
-				new Object[] {MSysConfig.VALIDATE_MATCHING_TO_ORDERED_QTY}, null);
-		CacheMgt.get().reset();
+		try (MockedStatic<MSysConfig> mocked = Mockito.mockStatic(MSysConfig.class, Mockito.CALLS_REAL_METHODS)) {
+			mocked.when(() -> MSysConfig.getBooleanValue(MSysConfig.VALIDATE_MATCHING_TO_ORDERED_QTY, true,
+					Env.getAD_Client_ID(ctx))).thenReturn(false);
 
-		try {
 			MOrder order = new MOrder(ctx, 0, trxName);
 			order.setBPartner(MBPartner.get(ctx, DictionaryIDs.C_BPartner.PATIO.id));
 			order.setC_DocTypeTarget_ID(DictionaryIDs.C_DocType.PURCHASE_ORDER.id);
@@ -651,14 +646,14 @@ public class PurchaseOrderTest extends AbstractTestCase {
 			assertEquals(0, initialQtyOrdered.compareTo(getQtyOrdered(ctx, productId, trxName)),
 					"Storage reservation not cleared by over-receipt");
 
-			info = MWorkflow.runDocumentActionWorkflow(receipt, DocAction.ACTION_Void);
+			info = MWorkflow.runDocumentActionWorkflow(receipt, DocAction.ACTION_Reverse_Correct);
 			assertFalse(info.isError(), info.getSummary());
 			receipt.load(trxName);
-			assertEquals(DocAction.STATUS_Reversed, receipt.getDocStatus(), "Material receipt not voided through reversal");
+			assertEquals(DocAction.STATUS_Reversed, receipt.getDocStatus(), "Material receipt not reversed");
 			orderLine.load(trxName);
 			assertEquals(0, qtyOrdered.compareTo(orderLine.getQtyReserved()), "Over-receipt quantity was restored as reservation");
 			assertEquals(0, initialQtyOrdered.add(qtyOrdered).compareTo(getQtyOrdered(ctx, productId, trxName)),
-					"Wrong storage reservation after voiding over-receipt");
+					"Wrong storage reservation after reversing over-receipt");
 
 			info = MWorkflow.runDocumentActionWorkflow(order, DocAction.ACTION_Close);
 			assertFalse(info.isError(), info.getSummary());
@@ -671,10 +666,6 @@ public class PurchaseOrderTest extends AbstractTestCase {
 			assertEquals(0, Env.ZERO.compareTo(orderLine.getQtyReserved()), "Order line reservation not cleared on close");
 			assertEquals(0, initialQtyOrdered.compareTo(getQtyOrdered(ctx, productId, trxName)),
 					"Closed order left a storage reservation");
-		} finally {
-			DB.executeUpdateEx("UPDATE AD_SysConfig SET Value='Y' WHERE AD_Client_ID=0 AND Name=?",
-					new Object[] {MSysConfig.VALIDATE_MATCHING_TO_ORDERED_QTY}, null);
-			CacheMgt.get().reset();
 		}
 	}
 
@@ -682,7 +673,7 @@ public class PurchaseOrderTest extends AbstractTestCase {
 	 * https://idempiere.atlassian.net/browse/IDEMPIERE-7075
 	 */
 	@Test
-	public void testPartialReceiptsOverReceiptVoidAndOrderCloseReservation() {
+	public void testPartialReceiptsOverReceiptReversalAndOrderCloseReservation() {
 		Properties ctx = Env.getCtx();
 		String trxName = getTrxName();
 		int productId = DictionaryIDs.M_Product.ROSE_BUSH.id;
@@ -692,11 +683,10 @@ public class PurchaseOrderTest extends AbstractTestCase {
 		BigDecimal openQtyAfterFirstReceipt = new BigDecimal("50");
 		BigDecimal initialQtyOrdered = getQtyOrdered(ctx, productId, trxName);
 
-		DB.executeUpdateEx("UPDATE AD_SysConfig SET Value='N' WHERE AD_Client_ID=0 AND Name=?",
-				new Object[] {MSysConfig.VALIDATE_MATCHING_TO_ORDERED_QTY}, null);
-		CacheMgt.get().reset();
+		try (MockedStatic<MSysConfig> mocked = Mockito.mockStatic(MSysConfig.class, Mockito.CALLS_REAL_METHODS)) {
+			mocked.when(() -> MSysConfig.getBooleanValue(MSysConfig.VALIDATE_MATCHING_TO_ORDERED_QTY, true,
+					Env.getAD_Client_ID(ctx))).thenReturn(false);
 
-		try {
 			MOrder order = new MOrder(ctx, 0, trxName);
 			order.setBPartner(MBPartner.get(ctx, DictionaryIDs.C_BPartner.PATIO.id));
 			order.setC_DocTypeTarget_ID(DictionaryIDs.C_DocType.PURCHASE_ORDER.id);
@@ -766,16 +756,16 @@ public class PurchaseOrderTest extends AbstractTestCase {
 			assertEquals(0, initialQtyOrdered.compareTo(getQtyOrdered(ctx, productId, trxName)),
 					"Storage reservation not cleared by over-receipt");
 
-			info = MWorkflow.runDocumentActionWorkflow(secondReceipt, DocAction.ACTION_Void);
+			info = MWorkflow.runDocumentActionWorkflow(secondReceipt, DocAction.ACTION_Reverse_Correct);
 			assertFalse(info.isError(), info.getSummary());
 			secondReceipt.load(trxName);
-			assertEquals(DocAction.STATUS_Reversed, secondReceipt.getDocStatus(), "Second material receipt not voided through reversal");
+			assertEquals(DocAction.STATUS_Reversed, secondReceipt.getDocStatus(), "Second material receipt not reversed");
 			orderLine.load(trxName);
-			assertEquals(0, firstReceiptQty.compareTo(orderLine.getQtyDelivered()), "Wrong delivered qty after voiding second receipt");
+			assertEquals(0, firstReceiptQty.compareTo(orderLine.getQtyDelivered()), "Wrong delivered qty after reversing second receipt");
 			assertEquals(0, openQtyAfterFirstReceipt.compareTo(orderLine.getQtyReserved()),
 					"Reversal restored more than the open order quantity");
 			assertEquals(0, initialQtyOrdered.add(openQtyAfterFirstReceipt).compareTo(getQtyOrdered(ctx, productId, trxName)),
-					"Wrong storage reservation after voiding second receipt");
+					"Wrong storage reservation after reversing second receipt");
 
 			info = MWorkflow.runDocumentActionWorkflow(order, DocAction.ACTION_Close);
 			assertFalse(info.isError(), info.getSummary());
@@ -788,10 +778,6 @@ public class PurchaseOrderTest extends AbstractTestCase {
 			assertEquals(0, Env.ZERO.compareTo(orderLine.getQtyReserved()), "Order line reservation not cleared on close");
 			assertEquals(0, initialQtyOrdered.compareTo(getQtyOrdered(ctx, productId, trxName)),
 					"Closed order left a storage reservation");
-		} finally {
-			DB.executeUpdateEx("UPDATE AD_SysConfig SET Value='Y' WHERE AD_Client_ID=0 AND Name=?",
-					new Object[] {MSysConfig.VALIDATE_MATCHING_TO_ORDERED_QTY}, null);
-			CacheMgt.get().reset();
 		}
 	}
 
@@ -811,11 +797,10 @@ public class PurchaseOrderTest extends AbstractTestCase {
 		BigDecimal initialQtyOrdered = getQtyOrdered(ctx, productId, trxName);
 		Timestamp today = TimeUtil.getDay(System.currentTimeMillis());
 
-		DB.executeUpdateEx("UPDATE AD_SysConfig SET Value='N' WHERE AD_Client_ID=0 AND Name=?",
-				new Object[] {MSysConfig.VALIDATE_MATCHING_TO_ORDERED_QTY}, null);
-		CacheMgt.get().reset();
+		try (MockedStatic<MSysConfig> mocked = Mockito.mockStatic(MSysConfig.class, Mockito.CALLS_REAL_METHODS)) {
+			mocked.when(() -> MSysConfig.getBooleanValue(MSysConfig.VALIDATE_MATCHING_TO_ORDERED_QTY, true,
+					Env.getAD_Client_ID(ctx))).thenReturn(false);
 
-		try {
 			MOrder firstOrder = new MOrder(ctx, 0, trxName);
 			firstOrder.setBPartner(MBPartner.get(ctx, DictionaryIDs.C_BPartner.PATIO.id));
 			firstOrder.setC_DocTypeTarget_ID(DictionaryIDs.C_DocType.PURCHASE_ORDER.id);
@@ -906,16 +891,16 @@ public class PurchaseOrderTest extends AbstractTestCase {
 			assertEquals(0, initialQtyOrdered.add(secondOrderQty).compareTo(getQtyOrdered(ctx, productId, trxName)),
 					"Over-receipt changed the other order's storage reservation");
 
-			info = MWorkflow.runDocumentActionWorkflow(overReceipt, DocAction.ACTION_Void);
+			info = MWorkflow.runDocumentActionWorkflow(overReceipt, DocAction.ACTION_Reverse_Correct);
 			assertFalse(info.isError(), info.getSummary());
 			overReceipt.load(trxName);
-			assertEquals(DocAction.STATUS_Reversed, overReceipt.getDocStatus(), "Over-receipt not voided through reversal");
+			assertEquals(DocAction.STATUS_Reversed, overReceipt.getDocStatus(), "Over-receipt not reversed");
 			firstOrderLine.load(trxName);
 			secondOrderLine.load(trxName);
-			assertEquals(0, firstOrderOpenQty.compareTo(firstOrderLine.getQtyReserved()), "Wrong first order reservation after void");
-			assertEquals(0, secondOrderQty.compareTo(secondOrderLine.getQtyReserved()), "Void changed second order line");
+			assertEquals(0, firstOrderOpenQty.compareTo(firstOrderLine.getQtyReserved()), "Wrong first order reservation after reversal");
+			assertEquals(0, secondOrderQty.compareTo(secondOrderLine.getQtyReserved()), "Reversal changed second order line");
 			assertEquals(0, initialQtyOrdered.add(firstOrderOpenQty).add(secondOrderQty)
-					.compareTo(getQtyOrdered(ctx, productId, trxName)), "Wrong combined reservation after void");
+					.compareTo(getQtyOrdered(ctx, productId, trxName)), "Wrong combined reservation after reversal");
 
 			info = MWorkflow.runDocumentActionWorkflow(firstOrder, DocAction.ACTION_Close);
 			assertFalse(info.isError(), info.getSummary());
@@ -942,10 +927,6 @@ public class PurchaseOrderTest extends AbstractTestCase {
 			assertEquals(0, Env.ZERO.compareTo(secondOrderLine.getQtyReserved()), "Closed second order line still reserved");
 			assertEquals(0, initialQtyOrdered.compareTo(getQtyOrdered(ctx, productId, trxName)),
 					"Closing both orders did not clear the combined storage reservation");
-		} finally {
-			DB.executeUpdateEx("UPDATE AD_SysConfig SET Value='Y' WHERE AD_Client_ID=0 AND Name=?",
-					new Object[] {MSysConfig.VALIDATE_MATCHING_TO_ORDERED_QTY}, null);
-			CacheMgt.get().reset();
 		}
 	}
 	

--- a/org.idempiere.test/src/org/idempiere/test/model/PurchaseOrderTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/PurchaseOrderTest.java
@@ -586,6 +586,368 @@ public class PurchaseOrderTest extends AbstractTestCase {
 			CacheMgt.get().reset();
 		}
 	}
+
+	/**
+	 * https://idempiere.atlassian.net/browse/IDEMPIERE-7075
+	 */
+	@Test
+	public void testOverReceiptVoidAndOrderCloseReservation() {
+		Properties ctx = Env.getCtx();
+		String trxName = getTrxName();
+		int productId = DictionaryIDs.M_Product.ROSE_BUSH.id;
+		BigDecimal qtyOrdered = new BigDecimal("300");
+		BigDecimal qtyReceived = new BigDecimal("303");
+		BigDecimal initialQtyOrdered = getQtyOrdered(ctx, productId, trxName);
+
+		DB.executeUpdateEx("UPDATE AD_SysConfig SET Value='N' WHERE AD_Client_ID=0 AND Name=?",
+				new Object[] {MSysConfig.VALIDATE_MATCHING_TO_ORDERED_QTY}, null);
+		CacheMgt.get().reset();
+
+		try {
+			MOrder order = new MOrder(ctx, 0, trxName);
+			order.setBPartner(MBPartner.get(ctx, DictionaryIDs.C_BPartner.PATIO.id));
+			order.setC_DocTypeTarget_ID(DictionaryIDs.C_DocType.PURCHASE_ORDER.id);
+			order.setIsSOTrx(false);
+			order.setSalesRep_ID(DictionaryIDs.AD_User.GARDEN_ADMIN.id);
+			order.setDocStatus(DocAction.STATUS_Drafted);
+			order.setDocAction(DocAction.ACTION_Complete);
+			Timestamp today = TimeUtil.getDay(System.currentTimeMillis());
+			order.setDateOrdered(today);
+			order.setDatePromised(today);
+			order.saveEx();
+
+			MOrderLine orderLine = new MOrderLine(order);
+			orderLine.setLine(10);
+			orderLine.setProduct(MProduct.get(ctx, productId));
+			orderLine.setQty(qtyOrdered);
+			orderLine.setDatePromised(today);
+			orderLine.saveEx();
+
+			ProcessInfo info = MWorkflow.runDocumentActionWorkflow(order, DocAction.ACTION_Complete);
+			assertFalse(info.isError(), info.getSummary());
+			order.load(trxName);
+			assertEquals(DocAction.STATUS_Completed, order.getDocStatus(), "Order not completed");
+			orderLine.load(trxName);
+			assertEquals(0, qtyOrdered.compareTo(orderLine.getQtyReserved()), "Wrong order line reserved qty after order completion");
+			assertEquals(0, initialQtyOrdered.add(qtyOrdered).compareTo(getQtyOrdered(ctx, productId, trxName)),
+					"Wrong storage reservation after order completion");
+
+			MInOut receipt = new MInOut(order, DictionaryIDs.C_DocType.MM_RECEIPT.id, order.getDateOrdered());
+			receipt.setDocStatus(DocAction.STATUS_Drafted);
+			receipt.setDocAction(DocAction.ACTION_Complete);
+			receipt.saveEx();
+
+			MInOutLine receiptLine = new MInOutLine(receipt);
+			receiptLine.setOrderLine(orderLine, 0, qtyReceived);
+			receiptLine.setQty(qtyReceived);
+			receiptLine.saveEx();
+
+			info = MWorkflow.runDocumentActionWorkflow(receipt, DocAction.ACTION_Complete);
+			assertFalse(info.isError(), info.getSummary());
+			receipt.load(trxName);
+			assertEquals(DocAction.STATUS_Completed, receipt.getDocStatus(), "Material receipt not completed");
+			orderLine.load(trxName);
+			assertEquals(0, Env.ZERO.compareTo(orderLine.getQtyReserved()), "Order line reservation not cleared by over-receipt");
+			assertEquals(0, initialQtyOrdered.compareTo(getQtyOrdered(ctx, productId, trxName)),
+					"Storage reservation not cleared by over-receipt");
+
+			info = MWorkflow.runDocumentActionWorkflow(receipt, DocAction.ACTION_Void);
+			assertFalse(info.isError(), info.getSummary());
+			receipt.load(trxName);
+			assertEquals(DocAction.STATUS_Reversed, receipt.getDocStatus(), "Material receipt not voided through reversal");
+			orderLine.load(trxName);
+			assertEquals(0, qtyOrdered.compareTo(orderLine.getQtyReserved()), "Over-receipt quantity was restored as reservation");
+			assertEquals(0, initialQtyOrdered.add(qtyOrdered).compareTo(getQtyOrdered(ctx, productId, trxName)),
+					"Wrong storage reservation after voiding over-receipt");
+
+			info = MWorkflow.runDocumentActionWorkflow(order, DocAction.ACTION_Close);
+			assertFalse(info.isError(), info.getSummary());
+			order.load(trxName);
+			assertEquals(DocAction.STATUS_Closed, order.getDocStatus(), "Order not closed");
+			orderLine.load(trxName);
+			assertEquals(0, Env.ZERO.compareTo(orderLine.getQtyOrdered()), "Wrong ordered qty on closed order line");
+			assertEquals(0, Env.ZERO.compareTo(orderLine.getQtyDelivered()), "Wrong delivered qty on closed order line");
+			assertEquals(0, qtyOrdered.compareTo(orderLine.getQtyLostSales()), "Wrong lost sales qty on closed order line");
+			assertEquals(0, Env.ZERO.compareTo(orderLine.getQtyReserved()), "Order line reservation not cleared on close");
+			assertEquals(0, initialQtyOrdered.compareTo(getQtyOrdered(ctx, productId, trxName)),
+					"Closed order left a storage reservation");
+		} finally {
+			DB.executeUpdateEx("UPDATE AD_SysConfig SET Value='Y' WHERE AD_Client_ID=0 AND Name=?",
+					new Object[] {MSysConfig.VALIDATE_MATCHING_TO_ORDERED_QTY}, null);
+			CacheMgt.get().reset();
+		}
+	}
+
+	/**
+	 * https://idempiere.atlassian.net/browse/IDEMPIERE-7075
+	 */
+	@Test
+	public void testPartialReceiptsOverReceiptVoidAndOrderCloseReservation() {
+		Properties ctx = Env.getCtx();
+		String trxName = getTrxName();
+		int productId = DictionaryIDs.M_Product.ROSE_BUSH.id;
+		BigDecimal qtyOrdered = new BigDecimal("200");
+		BigDecimal firstReceiptQty = new BigDecimal("150");
+		BigDecimal secondReceiptQty = new BigDecimal("60");
+		BigDecimal openQtyAfterFirstReceipt = new BigDecimal("50");
+		BigDecimal initialQtyOrdered = getQtyOrdered(ctx, productId, trxName);
+
+		DB.executeUpdateEx("UPDATE AD_SysConfig SET Value='N' WHERE AD_Client_ID=0 AND Name=?",
+				new Object[] {MSysConfig.VALIDATE_MATCHING_TO_ORDERED_QTY}, null);
+		CacheMgt.get().reset();
+
+		try {
+			MOrder order = new MOrder(ctx, 0, trxName);
+			order.setBPartner(MBPartner.get(ctx, DictionaryIDs.C_BPartner.PATIO.id));
+			order.setC_DocTypeTarget_ID(DictionaryIDs.C_DocType.PURCHASE_ORDER.id);
+			order.setIsSOTrx(false);
+			order.setSalesRep_ID(DictionaryIDs.AD_User.GARDEN_ADMIN.id);
+			order.setDocStatus(DocAction.STATUS_Drafted);
+			order.setDocAction(DocAction.ACTION_Complete);
+			Timestamp today = TimeUtil.getDay(System.currentTimeMillis());
+			order.setDateOrdered(today);
+			order.setDatePromised(today);
+			order.saveEx();
+
+			MOrderLine orderLine = new MOrderLine(order);
+			orderLine.setLine(10);
+			orderLine.setProduct(MProduct.get(ctx, productId));
+			orderLine.setQty(qtyOrdered);
+			orderLine.setDatePromised(today);
+			orderLine.saveEx();
+
+			ProcessInfo info = MWorkflow.runDocumentActionWorkflow(order, DocAction.ACTION_Complete);
+			assertFalse(info.isError(), info.getSummary());
+			order.load(trxName);
+			assertEquals(DocAction.STATUS_Completed, order.getDocStatus(), "Order not completed");
+			orderLine.load(trxName);
+			assertEquals(0, qtyOrdered.compareTo(orderLine.getQtyReserved()), "Wrong order line reserved qty after order completion");
+			assertEquals(0, initialQtyOrdered.add(qtyOrdered).compareTo(getQtyOrdered(ctx, productId, trxName)),
+					"Wrong storage reservation after order completion");
+
+			MInOut firstReceipt = new MInOut(order, DictionaryIDs.C_DocType.MM_RECEIPT.id, order.getDateOrdered());
+			firstReceipt.setDocStatus(DocAction.STATUS_Drafted);
+			firstReceipt.setDocAction(DocAction.ACTION_Complete);
+			firstReceipt.saveEx();
+
+			MInOutLine firstReceiptLine = new MInOutLine(firstReceipt);
+			firstReceiptLine.setOrderLine(orderLine, 0, firstReceiptQty);
+			firstReceiptLine.setQty(firstReceiptQty);
+			firstReceiptLine.saveEx();
+
+			info = MWorkflow.runDocumentActionWorkflow(firstReceipt, DocAction.ACTION_Complete);
+			assertFalse(info.isError(), info.getSummary());
+			firstReceipt.load(trxName);
+			assertEquals(DocAction.STATUS_Completed, firstReceipt.getDocStatus(), "First material receipt not completed");
+			orderLine.load(trxName);
+			assertEquals(0, firstReceiptQty.compareTo(orderLine.getQtyDelivered()), "Wrong delivered qty after first receipt");
+			assertEquals(0, openQtyAfterFirstReceipt.compareTo(orderLine.getQtyReserved()), "Wrong reserved qty after first receipt");
+			assertEquals(0, initialQtyOrdered.add(openQtyAfterFirstReceipt).compareTo(getQtyOrdered(ctx, productId, trxName)),
+					"Wrong storage reservation after first receipt");
+
+			MInOut secondReceipt = new MInOut(order, DictionaryIDs.C_DocType.MM_RECEIPT.id, order.getDateOrdered());
+			secondReceipt.setDocStatus(DocAction.STATUS_Drafted);
+			secondReceipt.setDocAction(DocAction.ACTION_Complete);
+			secondReceipt.saveEx();
+
+			MInOutLine secondReceiptLine = new MInOutLine(secondReceipt);
+			secondReceiptLine.setOrderLine(orderLine, 0, secondReceiptQty);
+			secondReceiptLine.setQty(secondReceiptQty);
+			secondReceiptLine.saveEx();
+
+			info = MWorkflow.runDocumentActionWorkflow(secondReceipt, DocAction.ACTION_Complete);
+			assertFalse(info.isError(), info.getSummary());
+			secondReceipt.load(trxName);
+			assertEquals(DocAction.STATUS_Completed, secondReceipt.getDocStatus(), "Second material receipt not completed");
+			orderLine.load(trxName);
+			assertEquals(0, firstReceiptQty.add(secondReceiptQty).compareTo(orderLine.getQtyDelivered()),
+					"Wrong delivered qty after second receipt");
+			assertEquals(0, Env.ZERO.compareTo(orderLine.getQtyReserved()), "Order line reservation not cleared by over-receipt");
+			assertEquals(0, initialQtyOrdered.compareTo(getQtyOrdered(ctx, productId, trxName)),
+					"Storage reservation not cleared by over-receipt");
+
+			info = MWorkflow.runDocumentActionWorkflow(secondReceipt, DocAction.ACTION_Void);
+			assertFalse(info.isError(), info.getSummary());
+			secondReceipt.load(trxName);
+			assertEquals(DocAction.STATUS_Reversed, secondReceipt.getDocStatus(), "Second material receipt not voided through reversal");
+			orderLine.load(trxName);
+			assertEquals(0, firstReceiptQty.compareTo(orderLine.getQtyDelivered()), "Wrong delivered qty after voiding second receipt");
+			assertEquals(0, openQtyAfterFirstReceipt.compareTo(orderLine.getQtyReserved()),
+					"Reversal restored more than the open order quantity");
+			assertEquals(0, initialQtyOrdered.add(openQtyAfterFirstReceipt).compareTo(getQtyOrdered(ctx, productId, trxName)),
+					"Wrong storage reservation after voiding second receipt");
+
+			info = MWorkflow.runDocumentActionWorkflow(order, DocAction.ACTION_Close);
+			assertFalse(info.isError(), info.getSummary());
+			order.load(trxName);
+			assertEquals(DocAction.STATUS_Closed, order.getDocStatus(), "Order not closed");
+			orderLine.load(trxName);
+			assertEquals(0, firstReceiptQty.compareTo(orderLine.getQtyOrdered()), "Wrong ordered qty on closed order line");
+			assertEquals(0, firstReceiptQty.compareTo(orderLine.getQtyDelivered()), "Wrong delivered qty on closed order line");
+			assertEquals(0, openQtyAfterFirstReceipt.compareTo(orderLine.getQtyLostSales()), "Wrong lost sales qty on closed order line");
+			assertEquals(0, Env.ZERO.compareTo(orderLine.getQtyReserved()), "Order line reservation not cleared on close");
+			assertEquals(0, initialQtyOrdered.compareTo(getQtyOrdered(ctx, productId, trxName)),
+					"Closed order left a storage reservation");
+		} finally {
+			DB.executeUpdateEx("UPDATE AD_SysConfig SET Value='Y' WHERE AD_Client_ID=0 AND Name=?",
+					new Object[] {MSysConfig.VALIDATE_MATCHING_TO_ORDERED_QTY}, null);
+			CacheMgt.get().reset();
+		}
+	}
+
+	/**
+	 * https://idempiere.atlassian.net/browse/IDEMPIERE-7075
+	 */
+	@Test
+	public void testOverReceiptReversalDoesNotAffectOtherOrderReservation() {
+		Properties ctx = Env.getCtx();
+		String trxName = getTrxName();
+		int productId = DictionaryIDs.M_Product.ROSE_BUSH.id;
+		BigDecimal firstOrderQty = new BigDecimal("200");
+		BigDecimal secondOrderQty = new BigDecimal("100");
+		BigDecimal firstReceiptQty = new BigDecimal("150");
+		BigDecimal overReceiptQty = new BigDecimal("60");
+		BigDecimal firstOrderOpenQty = new BigDecimal("50");
+		BigDecimal initialQtyOrdered = getQtyOrdered(ctx, productId, trxName);
+		Timestamp today = TimeUtil.getDay(System.currentTimeMillis());
+
+		DB.executeUpdateEx("UPDATE AD_SysConfig SET Value='N' WHERE AD_Client_ID=0 AND Name=?",
+				new Object[] {MSysConfig.VALIDATE_MATCHING_TO_ORDERED_QTY}, null);
+		CacheMgt.get().reset();
+
+		try {
+			MOrder firstOrder = new MOrder(ctx, 0, trxName);
+			firstOrder.setBPartner(MBPartner.get(ctx, DictionaryIDs.C_BPartner.PATIO.id));
+			firstOrder.setC_DocTypeTarget_ID(DictionaryIDs.C_DocType.PURCHASE_ORDER.id);
+			firstOrder.setIsSOTrx(false);
+			firstOrder.setSalesRep_ID(DictionaryIDs.AD_User.GARDEN_ADMIN.id);
+			firstOrder.setDocStatus(DocAction.STATUS_Drafted);
+			firstOrder.setDocAction(DocAction.ACTION_Complete);
+			firstOrder.setDateOrdered(today);
+			firstOrder.setDatePromised(today);
+			firstOrder.saveEx();
+
+			MOrderLine firstOrderLine = new MOrderLine(firstOrder);
+			firstOrderLine.setLine(10);
+			firstOrderLine.setProduct(MProduct.get(ctx, productId));
+			firstOrderLine.setQty(firstOrderQty);
+			firstOrderLine.setDatePromised(today);
+			firstOrderLine.saveEx();
+
+			ProcessInfo info = MWorkflow.runDocumentActionWorkflow(firstOrder, DocAction.ACTION_Complete);
+			assertFalse(info.isError(), info.getSummary());
+			firstOrder.load(trxName);
+			assertEquals(DocAction.STATUS_Completed, firstOrder.getDocStatus(), "First order not completed");
+
+			MOrder secondOrder = new MOrder(ctx, 0, trxName);
+			secondOrder.setBPartner(MBPartner.get(ctx, DictionaryIDs.C_BPartner.PATIO.id));
+			secondOrder.setC_DocTypeTarget_ID(DictionaryIDs.C_DocType.PURCHASE_ORDER.id);
+			secondOrder.setIsSOTrx(false);
+			secondOrder.setSalesRep_ID(DictionaryIDs.AD_User.GARDEN_ADMIN.id);
+			secondOrder.setDocStatus(DocAction.STATUS_Drafted);
+			secondOrder.setDocAction(DocAction.ACTION_Complete);
+			secondOrder.setDateOrdered(today);
+			secondOrder.setDatePromised(today);
+			secondOrder.saveEx();
+
+			MOrderLine secondOrderLine = new MOrderLine(secondOrder);
+			secondOrderLine.setLine(10);
+			secondOrderLine.setProduct(MProduct.get(ctx, productId));
+			secondOrderLine.setQty(secondOrderQty);
+			secondOrderLine.setDatePromised(today);
+			secondOrderLine.saveEx();
+
+			info = MWorkflow.runDocumentActionWorkflow(secondOrder, DocAction.ACTION_Complete);
+			assertFalse(info.isError(), info.getSummary());
+			secondOrder.load(trxName);
+			assertEquals(DocAction.STATUS_Completed, secondOrder.getDocStatus(), "Second order not completed");
+			firstOrderLine.load(trxName);
+			secondOrderLine.load(trxName);
+			assertEquals(0, firstOrderQty.compareTo(firstOrderLine.getQtyReserved()), "Wrong reservation on first order line");
+			assertEquals(0, secondOrderQty.compareTo(secondOrderLine.getQtyReserved()), "Wrong reservation on second order line");
+			assertEquals(0, initialQtyOrdered.add(firstOrderQty).add(secondOrderQty)
+					.compareTo(getQtyOrdered(ctx, productId, trxName)), "Wrong combined storage reservation");
+
+			MInOut firstReceipt = new MInOut(firstOrder, DictionaryIDs.C_DocType.MM_RECEIPT.id, firstOrder.getDateOrdered());
+			firstReceipt.setDocStatus(DocAction.STATUS_Drafted);
+			firstReceipt.setDocAction(DocAction.ACTION_Complete);
+			firstReceipt.saveEx();
+
+			MInOutLine firstReceiptLine = new MInOutLine(firstReceipt);
+			firstReceiptLine.setOrderLine(firstOrderLine, 0, firstReceiptQty);
+			firstReceiptLine.setQty(firstReceiptQty);
+			firstReceiptLine.saveEx();
+
+			info = MWorkflow.runDocumentActionWorkflow(firstReceipt, DocAction.ACTION_Complete);
+			assertFalse(info.isError(), info.getSummary());
+			firstOrderLine.load(trxName);
+			secondOrderLine.load(trxName);
+			assertEquals(0, firstOrderOpenQty.compareTo(firstOrderLine.getQtyReserved()), "Wrong reservation after first receipt");
+			assertEquals(0, secondOrderQty.compareTo(secondOrderLine.getQtyReserved()), "First receipt changed second order line");
+			assertEquals(0, initialQtyOrdered.add(firstOrderOpenQty).add(secondOrderQty)
+					.compareTo(getQtyOrdered(ctx, productId, trxName)), "Wrong combined reservation after first receipt");
+
+			MInOut overReceipt = new MInOut(firstOrder, DictionaryIDs.C_DocType.MM_RECEIPT.id, firstOrder.getDateOrdered());
+			overReceipt.setDocStatus(DocAction.STATUS_Drafted);
+			overReceipt.setDocAction(DocAction.ACTION_Complete);
+			overReceipt.saveEx();
+
+			MInOutLine overReceiptLine = new MInOutLine(overReceipt);
+			overReceiptLine.setOrderLine(firstOrderLine, 0, overReceiptQty);
+			overReceiptLine.setQty(overReceiptQty);
+			overReceiptLine.saveEx();
+
+			info = MWorkflow.runDocumentActionWorkflow(overReceipt, DocAction.ACTION_Complete);
+			assertFalse(info.isError(), info.getSummary());
+			firstOrderLine.load(trxName);
+			secondOrderLine.load(trxName);
+			assertEquals(0, Env.ZERO.compareTo(firstOrderLine.getQtyReserved()), "Over-received first order still reserved");
+			assertEquals(0, secondOrderQty.compareTo(secondOrderLine.getQtyReserved()), "Over-receipt changed second order line");
+			assertEquals(0, initialQtyOrdered.add(secondOrderQty).compareTo(getQtyOrdered(ctx, productId, trxName)),
+					"Over-receipt changed the other order's storage reservation");
+
+			info = MWorkflow.runDocumentActionWorkflow(overReceipt, DocAction.ACTION_Void);
+			assertFalse(info.isError(), info.getSummary());
+			overReceipt.load(trxName);
+			assertEquals(DocAction.STATUS_Reversed, overReceipt.getDocStatus(), "Over-receipt not voided through reversal");
+			firstOrderLine.load(trxName);
+			secondOrderLine.load(trxName);
+			assertEquals(0, firstOrderOpenQty.compareTo(firstOrderLine.getQtyReserved()), "Wrong first order reservation after void");
+			assertEquals(0, secondOrderQty.compareTo(secondOrderLine.getQtyReserved()), "Void changed second order line");
+			assertEquals(0, initialQtyOrdered.add(firstOrderOpenQty).add(secondOrderQty)
+					.compareTo(getQtyOrdered(ctx, productId, trxName)), "Wrong combined reservation after void");
+
+			info = MWorkflow.runDocumentActionWorkflow(firstOrder, DocAction.ACTION_Close);
+			assertFalse(info.isError(), info.getSummary());
+			firstOrder.load(trxName);
+			assertEquals(DocAction.STATUS_Closed, firstOrder.getDocStatus(), "First order not closed");
+			firstOrderLine.load(trxName);
+			secondOrderLine.load(trxName);
+			assertEquals(0, firstReceiptQty.compareTo(firstOrderLine.getQtyOrdered()), "Wrong ordered qty on closed first order line");
+			assertEquals(0, firstReceiptQty.compareTo(firstOrderLine.getQtyDelivered()), "Wrong delivered qty on closed first order line");
+			assertEquals(0, firstOrderOpenQty.compareTo(firstOrderLine.getQtyLostSales()), "Wrong lost sales on closed first order line");
+			assertEquals(0, Env.ZERO.compareTo(firstOrderLine.getQtyReserved()), "Closed first order line still reserved");
+			assertEquals(0, secondOrderQty.compareTo(secondOrderLine.getQtyReserved()), "Closing first order changed second order line");
+			assertEquals(0, initialQtyOrdered.add(secondOrderQty).compareTo(getQtyOrdered(ctx, productId, trxName)),
+					"Closing first order did not preserve second order's storage reservation");
+
+			info = MWorkflow.runDocumentActionWorkflow(secondOrder, DocAction.ACTION_Close);
+			assertFalse(info.isError(), info.getSummary());
+			secondOrder.load(trxName);
+			assertEquals(DocAction.STATUS_Closed, secondOrder.getDocStatus(), "Second order not closed");
+			secondOrderLine.load(trxName);
+			assertEquals(0, Env.ZERO.compareTo(secondOrderLine.getQtyOrdered()), "Wrong ordered qty on closed second order line");
+			assertEquals(0, Env.ZERO.compareTo(secondOrderLine.getQtyDelivered()), "Wrong delivered qty on closed second order line");
+			assertEquals(0, secondOrderQty.compareTo(secondOrderLine.getQtyLostSales()), "Wrong lost sales on closed second order line");
+			assertEquals(0, Env.ZERO.compareTo(secondOrderLine.getQtyReserved()), "Closed second order line still reserved");
+			assertEquals(0, initialQtyOrdered.compareTo(getQtyOrdered(ctx, productId, trxName)),
+					"Closing both orders did not clear the combined storage reservation");
+		} finally {
+			DB.executeUpdateEx("UPDATE AD_SysConfig SET Value='Y' WHERE AD_Client_ID=0 AND Name=?",
+					new Object[] {MSysConfig.VALIDATE_MATCHING_TO_ORDERED_QTY}, null);
+			CacheMgt.get().reset();
+		}
+	}
 	
 	@Test
 	public void testVendorRMA() {

--- a/org.idempiere.test/src/org/idempiere/test/model/SalesOrderTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/SalesOrderTest.java
@@ -270,9 +270,9 @@ public class SalesOrderTest extends AbstractTestCase {
 		order.load(getTrxName());		
 		assertEquals(DocAction.STATUS_Completed, order.getDocStatus());
 		line1.load(getTrxName());
-		assertEquals(1, line1.getQtyReserved().intValue());
+		assertEquals(0, Env.ONE.compareTo(line1.getQtyReserved()), "Wrong reserved quantity after order completion");
 		assertEquals(0, initialQtyReserved.add(Env.ONE).compareTo(MStorageReservation.getQty(line1.getM_Product_ID(),
-				line1.getM_Warehouse_ID(), 0, true, getTrxName())));
+				line1.getM_Warehouse_ID(), 0, true, getTrxName())), "Wrong storage reservation after order completion");
 		
 		MInOut shipment = new MInOut(order, DictionaryIDs.C_DocType.MM_SHIPMENT.id, order.getDateOrdered());
 		shipment.setDocStatus(DocAction.STATUS_Drafted);
@@ -291,10 +291,10 @@ public class SalesOrderTest extends AbstractTestCase {
 		assertEquals(DocAction.STATUS_Completed, shipment.getDocStatus());
 		
 		line1.load(getTrxName());
-		assertEquals(0, line1.getQtyReserved().intValue());
-		assertEquals(2, line1.getQtyDelivered().intValue());
+		assertEquals(0, Env.ZERO.compareTo(line1.getQtyReserved()), "Over-shipment left an order line reservation");
+		assertEquals(0, new BigDecimal("2").compareTo(line1.getQtyDelivered()), "Wrong delivered quantity after over-shipment");
 		assertEquals(0, initialQtyReserved.compareTo(MStorageReservation.getQty(line1.getM_Product_ID(),
-				line1.getM_Warehouse_ID(), 0, true, getTrxName())));
+				line1.getM_Warehouse_ID(), 0, true, getTrxName())), "Over-shipment left a storage reservation");
 		
 		shipment = new MInOut(order, DictionaryIDs.C_DocType.MM_SHIPMENT.id, order.getDateOrdered());
 		shipment.setDocStatus(DocAction.STATUS_Drafted);
@@ -313,10 +313,10 @@ public class SalesOrderTest extends AbstractTestCase {
 		assertEquals(DocAction.STATUS_Completed, shipment.getDocStatus());
 		
 		line1.load(getTrxName());
-		assertEquals(0, line1.getQtyReserved().intValue());
-		assertEquals(1, line1.getQtyDelivered().intValue());
+		assertEquals(0, Env.ZERO.compareTo(line1.getQtyReserved()), "First negative shipment changed the order line reservation");
+		assertEquals(0, Env.ONE.compareTo(line1.getQtyDelivered()), "Wrong delivered quantity after first negative shipment");
 		assertEquals(0, initialQtyReserved.compareTo(MStorageReservation.getQty(line1.getM_Product_ID(),
-				line1.getM_Warehouse_ID(), 0, true, getTrxName())));
+				line1.getM_Warehouse_ID(), 0, true, getTrxName())), "First negative shipment changed the storage reservation");
 
 		shipment = new MInOut(order, DictionaryIDs.C_DocType.MM_SHIPMENT.id, order.getDateOrdered());
 		shipment.setDocStatus(DocAction.STATUS_Drafted);
@@ -335,10 +335,10 @@ public class SalesOrderTest extends AbstractTestCase {
 		assertEquals(DocAction.STATUS_Completed, shipment.getDocStatus());
 
 		line1.load(getTrxName());
-		assertEquals(1, line1.getQtyReserved().intValue());
-		assertEquals(0, line1.getQtyDelivered().intValue());
+		assertEquals(0, Env.ONE.compareTo(line1.getQtyReserved()), "Second negative shipment did not restore the order line reservation");
+		assertEquals(0, Env.ZERO.compareTo(line1.getQtyDelivered()), "Second negative shipment did not clear the delivered quantity");
 		assertEquals(0, initialQtyReserved.add(Env.ONE).compareTo(MStorageReservation.getQty(line1.getM_Product_ID(),
-				line1.getM_Warehouse_ID(), 0, true, getTrxName())));
+				line1.getM_Warehouse_ID(), 0, true, getTrxName())), "Second negative shipment did not restore the storage reservation");
 	}
 
 	/**

--- a/org.idempiere.test/src/org/idempiere/test/model/SalesOrderTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/SalesOrderTest.java
@@ -85,6 +85,54 @@ public class SalesOrderTest extends AbstractTestCase {
 	}
 
 	@Test
+	public void testServiceProductReservationForShipmentAndReversal() {
+		MOrder order = new MOrder(Env.getCtx(), 0, getTrxName());
+		order.setBPartner(MBPartner.get(Env.getCtx(), DictionaryIDs.C_BPartner.JOE_BLOCK.id));
+		order.setC_DocTypeTarget_ID(MOrder.DocSubTypeSO_Standard);
+		order.setDeliveryRule(MOrder.DELIVERYRULE_CompleteOrder);
+		order.setDocStatus(DocAction.STATUS_Drafted);
+		order.setDocAction(DocAction.ACTION_Complete);
+		Timestamp today = TimeUtil.getDay(System.currentTimeMillis());
+		order.setDateOrdered(today);
+		order.setDatePromised(today);
+		order.saveEx();
+
+		MOrderLine orderLine = new MOrderLine(order);
+		orderLine.setLine(10);
+		orderLine.setProduct(MProduct.get(Env.getCtx(), DictionaryIDs.M_Product.PLANTING.id));
+		orderLine.setQty(Env.ONE);
+		orderLine.setDatePromised(today);
+		orderLine.saveEx();
+
+		ProcessInfo info = MWorkflow.runDocumentActionWorkflow(order, DocAction.ACTION_Complete);
+		assertFalse(info.isError(), info.getSummary());
+		orderLine.load(getTrxName());
+		assertEquals(0, Env.ONE.compareTo(orderLine.getQtyReserved()), "Service product was not reserved");
+
+		MInOut shipment = new MInOut(order, DictionaryIDs.C_DocType.MM_SHIPMENT.id, today);
+		shipment.setDocStatus(DocAction.STATUS_Drafted);
+		shipment.setDocAction(DocAction.ACTION_Complete);
+		shipment.saveEx();
+
+		MInOutLine shipmentLine = new MInOutLine(shipment);
+		shipmentLine.setOrderLine(orderLine, 0, Env.ONE);
+		shipmentLine.setQty(Env.ONE);
+		shipmentLine.saveEx();
+
+		info = MWorkflow.runDocumentActionWorkflow(shipment, DocAction.ACTION_Complete);
+		assertFalse(info.isError(), info.getSummary());
+		orderLine.load(getTrxName());
+		assertEquals(0, Env.ZERO.compareTo(orderLine.getQtyReserved()), "Shipment did not clear service product reservation");
+
+		info = MWorkflow.runDocumentActionWorkflow(shipment, DocAction.ACTION_Reverse_Correct);
+		assertFalse(info.isError(), info.getSummary());
+		shipment.load(getTrxName());
+		assertEquals(DocAction.STATUS_Reversed, shipment.getDocStatus(), "Shipment was not reversed");
+		orderLine.load(getTrxName());
+		assertEquals(0, Env.ONE.compareTo(orderLine.getQtyReserved()), "Reversal did not restore service product reservation");
+	}
+
+	@Test
 	/**
 	 * https://idempiere.atlassian.net/browse/IDEMPIERE-235
 	 */

--- a/org.idempiere.test/src/org/idempiere/test/model/SalesOrderTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/SalesOrderTest.java
@@ -308,6 +308,78 @@ public class SalesOrderTest extends AbstractTestCase {
 		line1.load(getTrxName());
 		assertEquals(0, line1.getQtyReserved().intValue());
 	}
+
+	/**
+	 * https://idempiere.atlassian.net/browse/IDEMPIERE-7075
+	 */
+	@Test
+	public void testQtyReservedForOverShipmentReversal() {
+		MOrder order = new MOrder(Env.getCtx(), 0, getTrxName());
+		order.setBPartner(MBPartner.get(Env.getCtx(), DictionaryIDs.C_BPartner.JOE_BLOCK.id));
+		order.setC_DocTypeTarget_ID(MOrder.DocSubTypeSO_Standard);
+		order.setDeliveryRule(MOrder.DELIVERYRULE_CompleteOrder);
+		order.setDocStatus(DocAction.STATUS_Drafted);
+		order.setDocAction(DocAction.ACTION_Complete);
+		Timestamp today = TimeUtil.getDay(System.currentTimeMillis());
+		order.setDateOrdered(today);
+		order.setDatePromised(today);
+		order.saveEx();
+
+		MOrderLine orderLine = new MOrderLine(order);
+		orderLine.setLine(10);
+		orderLine.setProduct(MProduct.get(Env.getCtx(), DictionaryIDs.M_Product.AZALEA_BUSH.id));
+		orderLine.setQty(Env.ONE);
+		orderLine.setDatePromised(today);
+		orderLine.saveEx();
+
+		BigDecimal initialQtyReserved = MStorageReservation.getQty(orderLine.getM_Product_ID(),
+				orderLine.getM_Warehouse_ID(), 0, true, getTrxName());
+		ProcessInfo info = MWorkflow.runDocumentActionWorkflow(order, DocAction.ACTION_Complete);
+		assertFalse(info.isError(), info.getSummary());
+		orderLine.load(getTrxName());
+		assertEquals(0, Env.ONE.compareTo(orderLine.getQtyOrdered()), "Wrong order line ordered quantity");
+		assertEquals(0, Env.ZERO.compareTo(orderLine.getQtyDelivered()), "Wrong order line delivered quantity");
+		assertEquals(0, Env.ONE.compareTo(orderLine.getQtyReserved()), "Wrong order line reserved quantity");
+		assertEquals(0, initialQtyReserved.add(Env.ONE).compareTo(MStorageReservation.getQty(
+				orderLine.getM_Product_ID(), orderLine.getM_Warehouse_ID(), 0, true, getTrxName())),
+				"Wrong storage reservation after order completion");
+
+		BigDecimal shipmentQty = new BigDecimal("2");
+		MInOut shipment = new MInOut(order, DictionaryIDs.C_DocType.MM_SHIPMENT.id, today);
+		shipment.setDocStatus(DocAction.STATUS_Drafted);
+		shipment.setDocAction(DocAction.ACTION_Complete);
+		shipment.saveEx();
+
+		MInOutLine shipmentLine = new MInOutLine(shipment);
+		shipmentLine.setOrderLine(orderLine, 0, shipmentQty);
+		shipmentLine.setQty(shipmentQty);
+		shipmentLine.saveEx();
+
+		info = MWorkflow.runDocumentActionWorkflow(shipment, DocAction.ACTION_Complete);
+		assertFalse(info.isError(), info.getSummary());
+		shipment.load(getTrxName());
+		assertEquals(DocAction.STATUS_Completed, shipment.getDocStatus(), "Over-shipment not completed");
+		orderLine.load(getTrxName());
+		assertEquals(0, Env.ONE.compareTo(orderLine.getQtyOrdered()), "Over-shipment changed ordered quantity");
+		assertEquals(0, shipmentQty.compareTo(orderLine.getQtyDelivered()), "Wrong delivered quantity after over-shipment");
+		assertEquals(0, Env.ZERO.compareTo(orderLine.getQtyReserved()), "Over-shipment left an order line reservation");
+		assertEquals(0, initialQtyReserved.compareTo(MStorageReservation.getQty(orderLine.getM_Product_ID(),
+				orderLine.getM_Warehouse_ID(), 0, true, getTrxName())),
+				"Over-shipment left a storage reservation");
+
+		info = MWorkflow.runDocumentActionWorkflow(shipment, DocAction.ACTION_Reverse_Correct);
+		assertFalse(info.isError(), info.getSummary());
+		shipment.load(getTrxName());
+		assertEquals(DocAction.STATUS_Reversed, shipment.getDocStatus(), "Over-shipment not reversed");
+		orderLine.load(getTrxName());
+		assertEquals(0, Env.ONE.compareTo(orderLine.getQtyOrdered()), "Reversal changed ordered quantity");
+		assertEquals(0, Env.ZERO.compareTo(orderLine.getQtyDelivered()), "Reversal did not clear delivered quantity");
+		assertEquals(0, Env.ONE.compareTo(orderLine.getQtyReserved()),
+				"Reversal restored more than the ordered quantity on the order line");
+		assertEquals(0, initialQtyReserved.add(Env.ONE).compareTo(MStorageReservation.getQty(
+				orderLine.getM_Product_ID(), orderLine.getM_Warehouse_ID(), 0, true, getTrxName())),
+				"Reversal restored more than the ordered quantity in storage reservation");
+	}
 	
 	@Test
 	public void testQtyReservedForNegativeOrderAndShipment() {

--- a/org.idempiere.test/src/org/idempiere/test/model/SalesOrderTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/SalesOrderTest.java
@@ -261,7 +261,9 @@ public class SalesOrderTest extends AbstractTestCase {
 		line1.setProduct(MProduct.get(Env.getCtx(), DictionaryIDs.M_Product.AZALEA_BUSH.id));
 		line1.setQty(new BigDecimal("1"));
 		line1.setDatePromised(today);
-		line1.saveEx();		
+		line1.saveEx();
+		BigDecimal initialQtyReserved = MStorageReservation.getQty(line1.getM_Product_ID(),
+				line1.getM_Warehouse_ID(), 0, true, getTrxName());
 		
 		ProcessInfo info = MWorkflow.runDocumentActionWorkflow(order, DocAction.ACTION_Complete);
 		assertFalse(info.isError(), info.getSummary());
@@ -269,6 +271,8 @@ public class SalesOrderTest extends AbstractTestCase {
 		assertEquals(DocAction.STATUS_Completed, order.getDocStatus());
 		line1.load(getTrxName());
 		assertEquals(1, line1.getQtyReserved().intValue());
+		assertEquals(0, initialQtyReserved.add(Env.ONE).compareTo(MStorageReservation.getQty(line1.getM_Product_ID(),
+				line1.getM_Warehouse_ID(), 0, true, getTrxName())));
 		
 		MInOut shipment = new MInOut(order, DictionaryIDs.C_DocType.MM_SHIPMENT.id, order.getDateOrdered());
 		shipment.setDocStatus(DocAction.STATUS_Drafted);
@@ -288,6 +292,9 @@ public class SalesOrderTest extends AbstractTestCase {
 		
 		line1.load(getTrxName());
 		assertEquals(0, line1.getQtyReserved().intValue());
+		assertEquals(2, line1.getQtyDelivered().intValue());
+		assertEquals(0, initialQtyReserved.compareTo(MStorageReservation.getQty(line1.getM_Product_ID(),
+				line1.getM_Warehouse_ID(), 0, true, getTrxName())));
 		
 		shipment = new MInOut(order, DictionaryIDs.C_DocType.MM_SHIPMENT.id, order.getDateOrdered());
 		shipment.setDocStatus(DocAction.STATUS_Drafted);
@@ -307,6 +314,31 @@ public class SalesOrderTest extends AbstractTestCase {
 		
 		line1.load(getTrxName());
 		assertEquals(0, line1.getQtyReserved().intValue());
+		assertEquals(1, line1.getQtyDelivered().intValue());
+		assertEquals(0, initialQtyReserved.compareTo(MStorageReservation.getQty(line1.getM_Product_ID(),
+				line1.getM_Warehouse_ID(), 0, true, getTrxName())));
+
+		shipment = new MInOut(order, DictionaryIDs.C_DocType.MM_SHIPMENT.id, order.getDateOrdered());
+		shipment.setDocStatus(DocAction.STATUS_Drafted);
+		shipment.setDocAction(DocAction.ACTION_Complete);
+		shipment.saveEx();
+
+		// Return the remaining delivered quantity and restore the order reservation
+		shipmentLine = new MInOutLine(shipment);
+		shipmentLine.setOrderLine(line1, 0, new BigDecimal("-1"));
+		shipmentLine.setQty(new BigDecimal("-1"));
+		shipmentLine.saveEx();
+
+		info = MWorkflow.runDocumentActionWorkflow(shipment, DocAction.ACTION_Complete);
+		assertFalse(info.isError(), info.getSummary());
+		shipment.load(getTrxName());
+		assertEquals(DocAction.STATUS_Completed, shipment.getDocStatus());
+
+		line1.load(getTrxName());
+		assertEquals(1, line1.getQtyReserved().intValue());
+		assertEquals(0, line1.getQtyDelivered().intValue());
+		assertEquals(0, initialQtyReserved.add(Env.ONE).compareTo(MStorageReservation.getQty(line1.getM_Product_ID(),
+				line1.getM_Warehouse_ID(), 0, true, getTrxName())));
 	}
 
 	/**


### PR DESCRIPTION
## Description

Fix two related reservation corruptions triggered by reversing an over-received material receipt and subsequently closing its order.

JIRA: https://idempiere.atlassian.net/browse/IDEMPIERE-7075

## Problem 1: large negative storage reservation

For an over-receipt reversal, the previous code could change `storageReservationToUpdate` from the negative reversal movement quantity to a positive capped quantity. The value was negated again when passed to `MStorageReservation.add()`.

Instead of restoring the reservation, this deducted it a second time and could create a large negative Ordered Qty in `M_StorageReservation` (for example `-1041.55`). These invalid values affected inventory and reservation reports.

## Problem 2: incorrect order-line reservation

Correcting only the sign exposed a second issue. Reversing an over-receipt could restore the complete receipt quantity to `C_OrderLine.QtyReserved`, even when it exceeded the remaining open order quantity.

For example:

- Purchase order quantity: 300
- Over-receipt quantity: 303
- Reservation after receipt: 0
- Incorrect reservation after reversal: 303 instead of 300

For purchase receipts, the `M_MatchPO` reversal updates `QtyDelivered` before the relevant `MInOut.completeIt()` logic runs. The previous safeguard therefore saw `QtyDelivered = 0` and did not detect the over-reservation. When the order was closed, `MOrder.reserveStock()` cleared 303 from a storage reservation containing only 300, leaving `M_StorageReservation` at `-3`.

The order line was therefore already incorrect before closing the order, and closing propagated that inconsistency into storage.

## Root cause

The order-line and storage reservations were calculated through separate sign and capping logic. The calculation did not consistently limit the restored quantity to the actual open order quantity, and it did not account for the different `QtyDelivered` update timing of purchase receipts and sales shipments.

## Changes

- Calculate a single `reservationDelta` for both `C_OrderLine.QtyReserved` and `M_StorageReservation`.
- Calculate the target reservation from the current reservation plus that delta.
- Bound the target reservation to the range from zero to the actual open quantity: `max(0, QtyOrdered - anticipated QtyDelivered)`.
- Account for purchase receipt matching updating `QtyDelivered` before this code, while sales shipment processing updates it later.
- Use the same bounded delta for the order line and storage so both remain consistent.

## Test coverage

### Complete over-receipt reversal

- Complete a purchase order for 300.
- Receive 303.
- Void the receipt.
- Close the order.
- Verify the closed order line has `QtyOrdered = 0`, `QtyDelivered = 0`, `QtyLostSales = 300`, and `QtyReserved = 0`.
- Verify the storage reservation is 0.

### Partial receipts and partial reversal

- Complete a purchase order for 200.
- Receive 150.
- Receive another 60, producing a total receipt of 210.
- Void the receipt for 60.
- Verify `QtyDelivered = 150` and `QtyReserved = 50`, rather than incorrectly restoring 60.
- Close the order.
- Verify the closed order line has `QtyOrdered = 150`, `QtyDelivered = 150`, `QtyLostSales = 50`, and `QtyReserved = 0`.
- Verify the storage reservation is 0.

### Reservation isolation between two orders

- Complete two orders for the same product and warehouse.
- Over-receive, reverse, and close only the first order.
- Verify the second order line remains reserved for its complete quantity.
- Verify the shared `M_StorageReservation` retains exactly the second order's reservation.
- Close the second order and verify the combined storage reservation returns to its initial value.

## Impact

Receipt reversals no longer create large negative storage reservations or inflate the related order-line reservation. Closing an affected order clears only its valid remaining reservation and does not corrupt reservations belonging to another order for the same product and warehouse.

## Validation

- Full Maven reactor: `BUILD SUCCESS`
- `org.idempiere.test`: `SUCCESS`
- `git diff --check upstream/master...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reservation handling when purchase receipts exceed ordered quantities.
  * Corrected reservation restoration when over-receipts or over-shipments are reversed or orders are closed.
  * Prevented reservation changes from affecting unrelated orders.
  * Improved reservation tracking for service products during shipment completion and reversal.

* **Tests**
  * Added coverage for over-receipts, reversals, closures, partial receipts, service products, and over-shipments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->