### PR TITLE
IDEMPIERE-7080 Restrict shipment and receipt order selection

### DIFF
--- a/migration/iD14/oracle/202608150743_IDEMPIERE-7080.sql
+++ b/migration/iD14/oracle/202608150743_IDEMPIERE-7080.sql
@@ -1,4 +1,4 @@
--- IDEMPIERE-7080 Material Receipt Create Lines From: show only completed purchase orders without checking delivered quantities
+-- IDEMPIERE-7080 Shipment/Receipt Create Lines From: show only completed orders and allow purchase order over-receipts
 SELECT register_migration_script('202608150743_IDEMPIERE-7080.sql') FROM dual;
 
 SET SQLBLANKLINES ON
@@ -9,7 +9,7 @@ UPDATE AD_Val_Rule SET Code='C_BPartner_ID=@C_BPartner_ID@ AND IsSOTrx=''@IsSOTr
 (
  (IsSOTrx=''N'' AND DocStatus=''CO'')
  OR
- (IsSOTrx=''Y'' AND DocStatus IN (''CL'',''CO'') AND C_Order_ID IN (SELECT C_Order_ID FROM C_OrderLine WHERE QtyOrdered-QtyDelivered!=0))
+ (IsSOTrx=''Y'' AND DocStatus=''CO'' AND C_Order_ID IN (SELECT C_Order_ID FROM C_OrderLine WHERE QtyOrdered-QtyDelivered!=0))
 )
 AND M_Warehouse_ID = (CASE WHEN @M_Warehouse_ID@>0 THEN @M_Warehouse_ID@ ELSE M_Warehouse_ID END)',Updated=TO_TIMESTAMP('2026-08-15 07:43:46','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Val_Rule_ID=200164
 ;

--- a/migration/iD14/oracle/202608150743_IDEMPIERE-7080.sql
+++ b/migration/iD14/oracle/202608150743_IDEMPIERE-7080.sql
@@ -1,0 +1,15 @@
+-- IDEMPIERE-7080 Material Receipt Create Lines From: show only completed purchase orders without checking delivered quantities
+SELECT register_migration_script('202608150743_IDEMPIERE-7080.sql') FROM dual;
+
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Aug 15, 2026, 7:43:46 AM CEST
+UPDATE AD_Val_Rule SET Code='C_BPartner_ID=@C_BPartner_ID@ AND IsSOTrx=''@IsSOTrx@'' AND
+(
+ (IsSOTrx=''N'' AND DocStatus=''CO'')
+ OR
+ (IsSOTrx=''Y'' AND DocStatus IN (''CL'',''CO'') AND C_Order_ID IN (SELECT C_Order_ID FROM C_OrderLine WHERE QtyOrdered-QtyDelivered!=0))
+)
+AND M_Warehouse_ID = (CASE WHEN @M_Warehouse_ID@>0 THEN @M_Warehouse_ID@ ELSE M_Warehouse_ID END)',Updated=TO_TIMESTAMP('2026-08-15 07:43:46','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Val_Rule_ID=200164
+;

--- a/migration/iD14/postgresql/202608150743_IDEMPIERE-7080.sql
+++ b/migration/iD14/postgresql/202608150743_IDEMPIERE-7080.sql
@@ -1,4 +1,4 @@
--- IDEMPIERE-7080 Material Receipt Create Lines From: show only completed purchase orders without checking delivered quantities
+-- IDEMPIERE-7080 Shipment/Receipt Create Lines From: show only completed orders and allow purchase order over-receipts
 SELECT register_migration_script('202608150743_IDEMPIERE-7080.sql') FROM dual;
 
 -- Aug 15, 2026, 7:43:46 AM CEST
@@ -6,7 +6,7 @@ UPDATE AD_Val_Rule SET Code='C_BPartner_ID=@C_BPartner_ID@ AND IsSOTrx=''@IsSOTr
 (
  (IsSOTrx=''N'' AND DocStatus=''CO'')
  OR
- (IsSOTrx=''Y'' AND DocStatus IN (''CL'',''CO'') AND C_Order_ID IN (SELECT C_Order_ID FROM C_OrderLine WHERE QtyOrdered-QtyDelivered!=0))
+ (IsSOTrx=''Y'' AND DocStatus=''CO'' AND C_Order_ID IN (SELECT C_Order_ID FROM C_OrderLine WHERE QtyOrdered-QtyDelivered!=0))
 )
 AND M_Warehouse_ID = (CASE WHEN @M_Warehouse_ID@>0 THEN @M_Warehouse_ID@ ELSE M_Warehouse_ID END)',Updated=TO_TIMESTAMP('2026-08-15 07:43:46','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Val_Rule_ID=200164
 ;

--- a/migration/iD14/postgresql/202608150743_IDEMPIERE-7080.sql
+++ b/migration/iD14/postgresql/202608150743_IDEMPIERE-7080.sql
@@ -1,0 +1,12 @@
+-- IDEMPIERE-7080 Material Receipt Create Lines From: show only completed purchase orders without checking delivered quantities
+SELECT register_migration_script('202608150743_IDEMPIERE-7080.sql') FROM dual;
+
+-- Aug 15, 2026, 7:43:46 AM CEST
+UPDATE AD_Val_Rule SET Code='C_BPartner_ID=@C_BPartner_ID@ AND IsSOTrx=''@IsSOTrx@'' AND
+(
+ (IsSOTrx=''N'' AND DocStatus=''CO'')
+ OR
+ (IsSOTrx=''Y'' AND DocStatus IN (''CL'',''CO'') AND C_Order_ID IN (SELECT C_Order_ID FROM C_OrderLine WHERE QtyOrdered-QtyDelivered!=0))
+)
+AND M_Warehouse_ID = (CASE WHEN @M_Warehouse_ID@>0 THEN @M_Warehouse_ID@ ELSE M_Warehouse_ID END)',Updated=TO_TIMESTAMP('2026-08-15 07:43:46','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Val_Rule_ID=200164
+;

--- a/org.adempiere.ui/src/org/compiere/grid/CreateFrom.java
+++ b/org.adempiere.ui/src/org/compiere/grid/CreateFrom.java
@@ -155,10 +155,15 @@ public abstract class CreateFrom implements ICreateFrom
 			.append(" FROM C_Order o WHERE ")
 			.append(colBP)
 			.append("=? AND o.IsSOTrx=? ");
-		if (!forInvoice && !isSOTrx)
+		if (!forInvoice)
 		{
-			// Completed purchase orders are eligible for additional material receipts, including over-receipts
+			// Shipments/receipts can only reference completed orders; purchase receipts can exceed ordered quantity
 			sql.append("AND o.DocStatus='CO' ");
+			if (isSOTrx)
+			{
+				// Customer shipments require an open delivery quantity
+				sql.append("AND o.C_Order_ID IN (SELECT ol.C_Order_ID FROM C_OrderLine ol WHERE ol.QtyOrdered-ol.QtyDelivered!=0) ");
+			}
 		}
 		else
 		{

--- a/org.adempiere.ui/src/org/compiere/grid/CreateFrom.java
+++ b/org.adempiere.ui/src/org/compiere/grid/CreateFrom.java
@@ -154,11 +154,20 @@ public abstract class CreateFrom implements ICreateFrom
 			.append(display)
 			.append(" FROM C_Order o WHERE ")
 			.append(colBP)
-			.append("=? AND o.IsSOTrx=? AND o.DocStatus IN ('CL','CO') AND o.C_Order_ID IN (SELECT ol.C_Order_ID FROM C_OrderLine ol WHERE ");
-		if (forCreditMemo)
-			sql.append(column).append(">0 AND (CASE WHEN ol.QtyDelivered>=ol.QtyOrdered THEN ol.QtyDelivered-ol.QtyInvoiced!=0 ELSE 1=1 END)) ");
+			.append("=? AND o.IsSOTrx=? ");
+		if (!forInvoice && !isSOTrx)
+		{
+			// Completed purchase orders are eligible for additional material receipts, including over-receipts
+			sql.append("AND o.DocStatus='CO' ");
+		}
 		else
-			sql.append("ol.QtyOrdered-").append(column).append("!=0) ");
+		{
+			sql.append("AND o.DocStatus IN ('CL','CO') AND o.C_Order_ID IN (SELECT ol.C_Order_ID FROM C_OrderLine ol WHERE ");
+			if (forCreditMemo)
+				sql.append(column).append(">0 AND (CASE WHEN ol.QtyDelivered>=ol.QtyOrdered THEN ol.QtyDelivered-ol.QtyInvoiced!=0 ELSE 1=1 END)) ");
+			else
+				sql.append("ol.QtyOrdered-").append(column).append("!=0) ");
+		}
 					
 		if(sameWarehouseOnly)
 		{

--- a/org.idempiere.test/src/org/idempiere/test/form/CreateFromShipmentFormTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/form/CreateFromShipmentFormTest.java
@@ -50,17 +50,19 @@ import org.compiere.model.MProduct;
 import org.compiere.model.MQuery;
 import org.compiere.model.MRMA;
 import org.compiere.model.MRMALine;
+import org.compiere.model.MSysConfig;
 import org.compiere.model.MWarehouse;
 import org.compiere.model.SystemIDs;
 import org.compiere.process.DocAction;
 import org.compiere.process.ProcessInfo;
 import org.compiere.util.Env;
 import org.compiere.util.KeyNamePair;
-import org.compiere.util.TimeUtil;
 import org.compiere.wf.MWorkflow;
 import org.idempiere.test.AbstractTestCase;
 import org.idempiere.test.DictionaryIDs;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 /**
  * @author hengsin
@@ -83,7 +85,7 @@ public class CreateFromShipmentFormTest extends AbstractTestCase {
 		order.setSalesRep_ID(DictionaryIDs.AD_User.GARDEN_ADMIN.id);
 		order.setDocStatus(DocAction.STATUS_Drafted);
 		order.setDocAction(DocAction.ACTION_Complete);
-		Timestamp today = TimeUtil.getDay(System.currentTimeMillis());
+		Timestamp today = getLoginDate();
 		order.setDateOrdered(today);
 		order.setDatePromised(today);
 		order.saveEx();
@@ -163,7 +165,7 @@ public class CreateFromShipmentFormTest extends AbstractTestCase {
 		order.setSalesRep_ID(DictionaryIDs.AD_User.GARDEN_ADMIN.id);
 		order.setDocStatus(DocAction.STATUS_Drafted);
 		order.setDocAction(DocAction.ACTION_Complete);
-		Timestamp today = TimeUtil.getDay(System.currentTimeMillis());
+		Timestamp today = getLoginDate();
 		order.setDateOrdered(today);
 		order.setDatePromised(today);
 		order.saveEx();
@@ -180,28 +182,73 @@ public class CreateFromShipmentFormTest extends AbstractTestCase {
 		order.load(getTrxName());
 		assertEquals(DocAction.STATUS_Completed, order.getDocStatus());
 
-		completeReceipt(order, orderLine, BigDecimal.ONE);
-		orderLine.load(getTrxName());
-		assertEquals(0, orderLine.getQtyDelivered().compareTo(orderLine.getQtyOrdered()), "Order must be fully delivered");
+		try (MockedStatic<MSysConfig> mocked = Mockito.mockStatic(MSysConfig.class, Mockito.CALLS_REAL_METHODS)) {
+			mocked.when(() -> MSysConfig.getBooleanValue(MSysConfig.VALIDATE_MATCHING_TO_ORDERED_QTY, true,
+					Env.getAD_Client_ID(Env.getCtx()))).thenReturn(false);
 
-		MInOut selectionReceipt = new MInOut(order, DictionaryIDs.C_DocType.MM_RECEIPT.id, today);
-		selectionReceipt.saveEx();
-		CreateFromShipmentImpl form = createFromShipmentForm(selectionReceipt);
-		assertOrderListed(form.getOrders(order.getC_BPartner_ID()), order.get_ID(), true,
-				"Completed and fully delivered purchase order must be listed");
+			completeReceipt(order, orderLine, BigDecimal.ONE);
+			orderLine.load(getTrxName());
+			assertEquals(0, orderLine.getQtyDelivered().compareTo(orderLine.getQtyOrdered()), "Order must be fully delivered");
 
-		completeReceipt(order, orderLine, BigDecimal.ONE);
+			MInOut selectionReceipt = new MInOut(order, DictionaryIDs.C_DocType.MM_RECEIPT.id, today);
+			selectionReceipt.saveEx();
+			CreateFromShipmentImpl form = createFromShipmentForm(selectionReceipt);
+			assertOrderListed(form.getOrders(order.getC_BPartner_ID()), order.get_ID(), true,
+					"Completed and fully delivered purchase order must be listed");
+
+			completeReceipt(order, orderLine, BigDecimal.ONE);
+			orderLine.load(getTrxName());
+			assertTrue(orderLine.getQtyDelivered().compareTo(orderLine.getQtyOrdered()) > 0, "Order must be over-received");
+			assertOrderListed(form.getOrders(order.getC_BPartner_ID()), order.get_ID(), true,
+					"Completed and over-received purchase order must be listed");
+
+			info = MWorkflow.runDocumentActionWorkflow(order, DocAction.ACTION_Close);
+			assertFalse(info.isError(), info.getSummary());
+			order.load(getTrxName());
+			assertEquals(DocAction.STATUS_Closed, order.getDocStatus());
+			assertOrderListed(form.getOrders(order.getC_BPartner_ID()), order.get_ID(), false,
+					"Closed purchase order must not be listed");
+		}
+	}
+
+	@Test
+	public void testSalesOrderSelectionExcludesClosedOrders() {
+		Timestamp today = getLoginDate();
+		MOrder order = new MOrder(Env.getCtx(), 0, getTrxName());
+		order.setBPartner(MBPartner.get(Env.getCtx(), DictionaryIDs.C_BPartner.JOE_BLOCK.id));
+		order.setC_DocTypeTarget_ID(DictionaryIDs.C_DocType.STANDARD_ORDER.id);
+		order.setDeliveryRule(MOrder.DELIVERYRULE_CompleteOrder);
+		order.setSalesRep_ID(getAD_User_ID());
+		order.setDateOrdered(today);
+		order.setDatePromised(today);
+		order.saveEx();
+
+		MOrderLine orderLine = new MOrderLine(order);
+		orderLine.setLine(10);
+		orderLine.setProduct(MProduct.get(Env.getCtx(), DictionaryIDs.M_Product.AZALEA_BUSH.id));
+		orderLine.setQty(BigDecimal.ONE);
+		orderLine.setDatePromised(today);
+		orderLine.saveEx();
+
+		ProcessInfo info = MWorkflow.runDocumentActionWorkflow(order, DocAction.ACTION_Complete);
+		assertFalse(info.isError(), info.getSummary());
+		order.load(getTrxName());
+		assertEquals(DocAction.STATUS_Completed, order.getDocStatus());
 		orderLine.load(getTrxName());
-		assertTrue(orderLine.getQtyDelivered().compareTo(orderLine.getQtyOrdered()) > 0, "Order must be over-received");
+		assertEquals(0, Env.ZERO.compareTo(orderLine.getQtyDelivered()), "Sales order must have an open delivery quantity");
+
+		MInOut selectionShipment = new MInOut(order, DictionaryIDs.C_DocType.MM_SHIPMENT.id, today);
+		selectionShipment.saveEx();
+		CreateFromShipmentImpl form = createFromShipmentForm(selectionShipment, SystemIDs.WINDOW_SHIPMENT_CUSTOMER);
 		assertOrderListed(form.getOrders(order.getC_BPartner_ID()), order.get_ID(), true,
-				"Completed and over-received purchase order must be listed");
+				"Completed sales order with an open delivery quantity must be listed");
 
 		info = MWorkflow.runDocumentActionWorkflow(order, DocAction.ACTION_Close);
 		assertFalse(info.isError(), info.getSummary());
 		order.load(getTrxName());
 		assertEquals(DocAction.STATUS_Closed, order.getDocStatus());
 		assertOrderListed(form.getOrders(order.getC_BPartner_ID()), order.get_ID(), false,
-				"Closed purchase order must not be listed");
+				"Closed sales order must not be listed");
 	}
 	
 	@Test
@@ -213,7 +260,7 @@ public class CreateFromShipmentFormTest extends AbstractTestCase {
 		order.setSalesRep_ID(DictionaryIDs.AD_User.GARDEN_ADMIN.id);
 		order.setDocStatus(DocAction.STATUS_Drafted);
 		order.setDocAction(DocAction.ACTION_Complete);
-		Timestamp today = TimeUtil.getDay(System.currentTimeMillis());
+		Timestamp today = getLoginDate();
 		order.setDateOrdered(today);
 		order.setDatePromised(today);
 		order.saveEx();
@@ -305,7 +352,7 @@ public class CreateFromShipmentFormTest extends AbstractTestCase {
 		order.setDeliveryRule(MOrder.DELIVERYRULE_CompleteOrder);
 		order.setDocStatus(DocAction.STATUS_Drafted);
 		order.setDocAction(DocAction.ACTION_Complete);
-		Timestamp today = TimeUtil.getDay(System.currentTimeMillis());
+		Timestamp today = getLoginDate();
 		order.setDateOrdered(today);
 		order.setDatePromised(today);
 		order.setSalesRep_ID(getAD_User_ID());
@@ -435,12 +482,16 @@ public class CreateFromShipmentFormTest extends AbstractTestCase {
 	}
 
 	private CreateFromShipmentImpl createFromShipmentForm(MInOut receipt) {
-		GridWindow gridWindow = GridWindow.get(Env.getCtx(), 1, SystemIDs.WINDOW_MATERIAL_RECEIPT);
-		assertNotNull(gridWindow, "Failed to load grid window of Material Receipt");
+		return createFromShipmentForm(receipt, SystemIDs.WINDOW_MATERIAL_RECEIPT);
+	}
+
+	private CreateFromShipmentImpl createFromShipmentForm(MInOut inOut, int windowId) {
+		GridWindow gridWindow = GridWindow.get(Env.getCtx(), 1, windowId);
+		assertNotNull(gridWindow, "Failed to load shipment/receipt grid window");
 		gridWindow.initTab(0);
 		GridTab gridTab = gridWindow.getTab(0);
 		MQuery query = new MQuery(MInOut.Table_Name);
-		query.addRestriction(MInOut.COLUMNNAME_M_InOut_ID, "=", receipt.get_ID());
+		query.addRestriction(MInOut.COLUMNNAME_M_InOut_ID, "=", inOut.get_ID());
 		gridTab.setQuery(query);
 		gridTab.getTableModel().setImportingMode(false, getTrxName());
 		gridTab.query(false);

--- a/org.idempiere.test/src/org/idempiere/test/form/CreateFromShipmentFormTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/form/CreateFromShipmentFormTest.java
@@ -153,6 +153,56 @@ public class CreateFromShipmentFormTest extends AbstractTestCase {
 		assertEquals(1, receiptLines.length, "Unexpected number of Material Receipt Line records");
 		assertEquals(orderLine.get_ID(), receiptLines[0].getC_OrderLine_ID(), "Order line not match to material receipt line");
 	}
+
+	@Test
+	public void testPurchaseOrderSelectionIgnoresDeliveredQuantity() {
+		MOrder order = new MOrder(Env.getCtx(), 0, getTrxName());
+		order.setBPartner(MBPartner.get(Env.getCtx(), DictionaryIDs.C_BPartner.PATIO.id));
+		order.setC_DocTypeTarget_ID(DictionaryIDs.C_DocType.PURCHASE_ORDER.id);
+		order.setIsSOTrx(false);
+		order.setSalesRep_ID(DictionaryIDs.AD_User.GARDEN_ADMIN.id);
+		order.setDocStatus(DocAction.STATUS_Drafted);
+		order.setDocAction(DocAction.ACTION_Complete);
+		Timestamp today = TimeUtil.getDay(System.currentTimeMillis());
+		order.setDateOrdered(today);
+		order.setDatePromised(today);
+		order.saveEx();
+
+		MOrderLine orderLine = new MOrderLine(order);
+		orderLine.setLine(10);
+		orderLine.setProduct(MProduct.get(Env.getCtx(), DictionaryIDs.M_Product.HOLLY_BUSH.id));
+		orderLine.setQty(BigDecimal.ONE);
+		orderLine.setDatePromised(today);
+		orderLine.saveEx();
+
+		ProcessInfo info = MWorkflow.runDocumentActionWorkflow(order, DocAction.ACTION_Complete);
+		assertFalse(info.isError(), info.getSummary());
+		order.load(getTrxName());
+		assertEquals(DocAction.STATUS_Completed, order.getDocStatus());
+
+		completeReceipt(order, orderLine, BigDecimal.ONE);
+		orderLine.load(getTrxName());
+		assertEquals(0, orderLine.getQtyDelivered().compareTo(orderLine.getQtyOrdered()), "Order must be fully delivered");
+
+		MInOut selectionReceipt = new MInOut(order, DictionaryIDs.C_DocType.MM_RECEIPT.id, today);
+		selectionReceipt.saveEx();
+		CreateFromShipmentImpl form = createFromShipmentForm(selectionReceipt);
+		assertOrderListed(form.getOrders(order.getC_BPartner_ID()), order.get_ID(), true,
+				"Completed and fully delivered purchase order must be listed");
+
+		completeReceipt(order, orderLine, BigDecimal.ONE);
+		orderLine.load(getTrxName());
+		assertTrue(orderLine.getQtyDelivered().compareTo(orderLine.getQtyOrdered()) > 0, "Order must be over-received");
+		assertOrderListed(form.getOrders(order.getC_BPartner_ID()), order.get_ID(), true,
+				"Completed and over-received purchase order must be listed");
+
+		info = MWorkflow.runDocumentActionWorkflow(order, DocAction.ACTION_Close);
+		assertFalse(info.isError(), info.getSummary());
+		order.load(getTrxName());
+		assertEquals(DocAction.STATUS_Closed, order.getDocStatus());
+		assertOrderListed(form.getOrders(order.getC_BPartner_ID()), order.get_ID(), false,
+				"Closed purchase order must not be listed");
+	}
 	
 	@Test
 	public void testCreateFromInvoiceLine() {
@@ -368,6 +418,44 @@ public class CreateFromShipmentFormTest extends AbstractTestCase {
 		assertEquals(rmaLine.get_ID(), receiptLines[0].getM_RMALine_ID(), "RMA line not match to material receipt line");
 	}
 	
+	private void completeReceipt(MOrder order, MOrderLine orderLine, BigDecimal quantity) {
+		MInOut receipt = new MInOut(order, DictionaryIDs.C_DocType.MM_RECEIPT.id, order.getDateOrdered());
+		receipt.saveEx();
+
+		MInOutLine receiptLine = new MInOutLine(receipt);
+		int locatorId = MLocator.getDefault(MWarehouse.get(order.getM_Warehouse_ID())).getM_Locator_ID();
+		receiptLine.setOrderLine(orderLine, locatorId, quantity);
+		receiptLine.setQty(quantity);
+		receiptLine.saveEx();
+
+		ProcessInfo info = MWorkflow.runDocumentActionWorkflow(receipt, DocAction.ACTION_Complete);
+		assertFalse(info.isError(), info.getSummary());
+		receipt.load(getTrxName());
+		assertEquals(DocAction.STATUS_Completed, receipt.getDocStatus());
+	}
+
+	private CreateFromShipmentImpl createFromShipmentForm(MInOut receipt) {
+		GridWindow gridWindow = GridWindow.get(Env.getCtx(), 1, SystemIDs.WINDOW_MATERIAL_RECEIPT);
+		assertNotNull(gridWindow, "Failed to load grid window of Material Receipt");
+		gridWindow.initTab(0);
+		GridTab gridTab = gridWindow.getTab(0);
+		MQuery query = new MQuery(MInOut.Table_Name);
+		query.addRestriction(MInOut.COLUMNNAME_M_InOut_ID, "=", receipt.get_ID());
+		gridTab.setQuery(query);
+		gridTab.getTableModel().setImportingMode(false, getTrxName());
+		gridTab.query(false);
+		assertEquals(1, gridTab.getRowCount(), "Unexpected number of rows retrieved from DB");
+
+		CreateFromShipmentImpl form = new CreateFromShipmentImpl(gridTab);
+		form.setTrxName(getTrxName());
+		return form;
+	}
+
+	private void assertOrderListed(ArrayList<KeyNamePair> orders, int orderId, boolean expected, String message) {
+		boolean listed = orders.stream().anyMatch(order -> order.getKey() == orderId);
+		assertEquals(expected, listed, message);
+	}
+
 	private static class CreateFromShipmentImpl extends CreateFromShipment {
 
 		private MiniTableImpl minitable = null;


### PR DESCRIPTION
## Description

Shipment/Receipt → Create Lines From now lists only completed orders. Completed purchase orders remain eligible for additional material receipts regardless of delivered quantity, while customer shipments continue to require an open delivery quantity.

JIRA: https://idempiere.atlassian.net/browse/IDEMPIERE-7080

## Root cause

The shared Create From order lookup accepted both completed and closed orders. It also required at least one order line where `QtyOrdered - QtyDelivered != 0`.

For purchase orders, an over-received closed order therefore remained selectable because its quantity difference was negative instead of zero. For sales orders, a closed order with an open delivery quantity was offered even though `MInOut.prepareIt()` rejects shipments that reference closed orders.

## Changes

- Restrict order selection for shipments and material receipts to `DocStatus='CO'`.
- Remove the delivered-quantity condition from the purchase-order lookup so supported over-receipts remain possible.
- Retain the open delivery quantity condition for sales orders.
- Update dynamic validation rule `200164` for PostgreSQL and Oracle.
- Preserve the existing Business Partner, warehouse, transaction, tenant, organization and access filters.
- Preserve the existing Vendor Invoice selection behavior.
- Add regression coverage for fully delivered, over-received and closed purchase orders.
- Add regression coverage showing that a completed sales order with an open delivery quantity is selectable and a closed sales order is not.
- Isolate the over-receipt test with a scoped Mockito mock instead of changing global `AD_SysConfig` data.
- Use the configured login date throughout the test class instead of the wall clock.

## Impact

Completed purchase orders remain available for additional material receipts, including supported over-receipts. Closed purchase orders are no longer offered. Completed sales orders remain available while they have an open delivery quantity; closed sales orders are no longer offered. Invoice selection behavior is unchanged.

## Validation

- `mvn -DskipTests=false -Dtest=org.idempiere.test.form.CreateFromShipmentFormTest verify`
- `CreateFromShipmentFormTest`: 5 tests, 0 failures, 0 errors and 0 skipped tests.
- Full 61-module Maven/Tycho reactor: `BUILD SUCCESS`.
- Staged diff whitespace check passes with CRLF recognized as end-of-line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order selection when creating shipments.
  * Excludes closed sales orders and requires remaining quantities for delivery.
  * Allows completed purchase orders to remain selectable, including orders eligible for over-receipt.
  * Preserves business partner, transaction type, and warehouse filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->