### PR TITLE
IDEMPIERE-7081 Stop SSO callback processing after redirect

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/sso/filter/SSOWebUIFilter.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/sso/filter/SSOWebUIFilter.java
@@ -228,6 +228,7 @@ public class SSOWebUIFilter implements Filter
 							}
 							httpResponse.sendRedirect(currentUri);
 						}
+						return;
 					}
 					else if (!m_SSOPrincipal.isAuthenticated(httpRequest, httpResponse))
 					{


### PR DESCRIPTION
## Description

Stop processing an SSO authentication callback after its response has been redirected or committed.

JIRA: https://idempiere.atlassian.net/browse/IDEMPIERE-7081

## Root cause

`SSOWebUIFilter` continued to `chain.doFilter(...)` after handling an authentication code. ZK could then try to render the callback request through a response that had already been redirected, causing Jetty to log `EofException: Closed`.

The same continuation occurred when `getAuthenticationToken()` committed a redirect itself, such as for an invalid OIDC state.

## Changes

- Return unconditionally after the authentication-code branch completes.
- Preserve the existing authentication and redirect behavior.

## Impact

SSO callback requests are handled only once. ZK no longer attempts to write a second response after the callback redirect.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SSO authentication redirects to prevent unintended additional processing after the redirect.
  * Improved reliability of the sign-in flow by stopping request handling at the correct point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->