### PR TITLE
IDEMPIERE-1479 Separate change log visibility from preference level

### DIFF
--- a/migration/iD14/oracle/202608211337_IDEMPIERE-1479.sql
+++ b/migration/iD14/oracle/202608211337_IDEMPIERE-1479.sql
@@ -1,4 +1,4 @@
--- IDEMPIERE-1479 Add the default-deny AD_Role.IsShowChangeLog flag and preserve visibility for roles with PreferenceType='C'
+-- IDEMPIERE-1479 Add the default-deny Show Change Log checkbox to Role and preserve visibility for roles with PreferenceType='C'
 SELECT register_migration_script('202608211337_IDEMPIERE-1479.sql') FROM dual;
 
 SET SQLBLANKLINES ON

--- a/migration/iD14/oracle/202608211337_IDEMPIERE-1479.sql
+++ b/migration/iD14/oracle/202608211337_IDEMPIERE-1479.sql
@@ -1,0 +1,137 @@
+-- IDEMPIERE-1479 Implement AD_Role.IsShowChangeLog
+SELECT register_migration_script('202608211337_IDEMPIERE-1479.sql') FROM dual;
+
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Aug 21, 2026, 1:37:44 PM CEST
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,ColumnName,Name,Description,PrintName,EntityType,AD_Element_UU) VALUES (204120,0,0,'Y',TO_TIMESTAMP('2026-08-21 13:37:43','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-21 13:37:43','YYYY-MM-DD HH24:MI:SS'),100,'IsShowChangeLog','Show Change Log','Allow users with this role to view change log information','Show Change Log','D','01a0241c-d4fe-77c4-a831-06d5f85b8496')
+;
+
+-- Aug 21, 2026, 1:41:59 PM CEST
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,IsHtml,IsPartitionKey) VALUES (217654,0,'Show Change Log','Allow users with this role to view change log information',156,'IsShowChangeLog','N',1,'N','N','Y','N','N',0,'N',20,0,0,'Y',TO_TIMESTAMP('2026-08-21 13:41:59','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-21 13:41:59','YYYY-MM-DD HH24:MI:SS'),100,204120,'Y','N','D','N','N','N','Y','01a02420-b927-708e-89fd-23787c4774d3','Y',0,'N','N','N','N')
+;
+
+-- Aug 21, 2026, 1:42:26 PM CEST
+ALTER TABLE AD_Role ADD IsShowChangeLog CHAR(1) DEFAULT 'N' CHECK (IsShowChangeLog IN ('Y','N')) NOT NULL
+;
+
+-- Preserve the existing change log visibility for client preference roles
+UPDATE AD_Role SET IsShowChangeLog='Y' WHERE PreferenceType='C'
+;
+
+-- Aug 21, 2026, 1:43:37 PM CEST
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan) VALUES (209239,'Show Change Log','Allow users with this role to view change log information',119,217654,'Y',1,450,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2026-08-21 13:43:37','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-21 13:43:37','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','01a02422-3754-7ba3-a254-7e7764bb81a1','Y',470,2,2)
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=80,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=200071
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=90,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=11002
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=100,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=930
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=110,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=931
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=120,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=59591
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=130,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=59592
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=140,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=10126
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=150,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=205947
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=160,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=11003
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=170,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=5227
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=180,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=202366
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=190,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=10813
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=200,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=11257
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=210,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=8312
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=220,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=8310
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=230,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=8313
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=240,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=8314
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=250,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206904
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=260,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=8311
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=270,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=11006
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=280, XPosition=2, ColumnSpan=1,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=209239
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=0,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=200411
+;
+
+-- Aug 21, 2026, 1:49:32 PM CEST
+UPDATE AD_Element SET Help='Preferences allow you to define default values.  If set to None, you cannot set any preference nor value preference.',Updated=TO_TIMESTAMP('2026-08-21 13:49:32','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=2656
+;
+
+-- Aug 21, 2026, 1:49:32 PM CEST
+UPDATE AD_Column SET ColumnName='PreferenceType', Name='Preference Level', Description='Determines what preferences the user can set', Help='Preferences allow you to define default values.  If set to None, you cannot set any preference nor value preference.', Placeholder=NULL WHERE AD_Element_ID=2656
+;
+
+-- Aug 21, 2026, 1:49:32 PM CEST
+UPDATE AD_Process_Para SET ColumnName='PreferenceType', Name='Preference Level', Description='Determines what preferences the user can set', Help='Preferences allow you to define default values.  If set to None, you cannot set any preference nor value preference.', AD_Element_ID=2656 WHERE UPPER(ColumnName)='PREFERENCETYPE' AND IsCentrallyMaintained='Y' AND AD_Element_ID IS NULL
+;
+
+-- Aug 21, 2026, 1:49:32 PM CEST
+UPDATE AD_Process_Para SET ColumnName='PreferenceType', Name='Preference Level', Description='Determines what preferences the user can set', Help='Preferences allow you to define default values.  If set to None, you cannot set any preference nor value preference.', Placeholder=NULL WHERE AD_Element_ID=2656 AND IsCentrallyMaintained='Y'
+;
+
+-- Aug 21, 2026, 1:49:32 PM CEST
+UPDATE AD_InfoColumn SET ColumnName='PreferenceType', Name='Preference Level', Description='Determines what preferences the user can set', Help='Preferences allow you to define default values.  If set to None, you cannot set any preference nor value preference.', Placeholder=NULL WHERE AD_Element_ID=2656 AND IsCentrallyMaintained='Y'
+;
+
+-- Aug 21, 2026, 1:49:32 PM CEST
+UPDATE AD_Field SET Name='Preference Level', Description='Determines what preferences the user can set', Help='Preferences allow you to define default values.  If set to None, you cannot set any preference nor value preference.', Placeholder=NULL WHERE AD_Column_ID IN (SELECT AD_Column_ID FROM AD_Column WHERE AD_Element_ID=2656) AND IsCentrallyMaintained='Y'
+;

--- a/migration/iD14/oracle/202608211337_IDEMPIERE-1479.sql
+++ b/migration/iD14/oracle/202608211337_IDEMPIERE-1479.sql
@@ -1,4 +1,4 @@
--- IDEMPIERE-1479 Implement AD_Role.IsShowChangeLog
+-- IDEMPIERE-1479 Add the default-deny AD_Role.IsShowChangeLog flag and preserve visibility for roles with PreferenceType='C'
 SELECT register_migration_script('202608211337_IDEMPIERE-1479.sql') FROM dual;
 
 SET SQLBLANKLINES ON

--- a/migration/iD14/postgresql/202608211337_IDEMPIERE-1479.sql
+++ b/migration/iD14/postgresql/202608211337_IDEMPIERE-1479.sql
@@ -1,4 +1,4 @@
--- IDEMPIERE-1479 Implement AD_Role.IsShowChangeLog
+-- IDEMPIERE-1479 Add the default-deny AD_Role.IsShowChangeLog flag and preserve visibility for roles with PreferenceType='C'
 SELECT register_migration_script('202608211337_IDEMPIERE-1479.sql') FROM dual;
 
 -- Aug 21, 2026, 1:37:44 PM CEST

--- a/migration/iD14/postgresql/202608211337_IDEMPIERE-1479.sql
+++ b/migration/iD14/postgresql/202608211337_IDEMPIERE-1479.sql
@@ -1,0 +1,134 @@
+-- IDEMPIERE-1479 Implement AD_Role.IsShowChangeLog
+SELECT register_migration_script('202608211337_IDEMPIERE-1479.sql') FROM dual;
+
+-- Aug 21, 2026, 1:37:44 PM CEST
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,ColumnName,Name,Description,PrintName,EntityType,AD_Element_UU) VALUES (204120,0,0,'Y',TO_TIMESTAMP('2026-08-21 13:37:43','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-21 13:37:43','YYYY-MM-DD HH24:MI:SS'),100,'IsShowChangeLog','Show Change Log','Allow users with this role to view change log information','Show Change Log','D','01a0241c-d4fe-77c4-a831-06d5f85b8496')
+;
+
+-- Aug 21, 2026, 1:41:59 PM CEST
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,IsHtml,IsPartitionKey) VALUES (217654,0,'Show Change Log','Allow users with this role to view change log information',156,'IsShowChangeLog','N',1,'N','N','Y','N','N',0,'N',20,0,0,'Y',TO_TIMESTAMP('2026-08-21 13:41:59','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-21 13:41:59','YYYY-MM-DD HH24:MI:SS'),100,204120,'Y','N','D','N','N','N','Y','01a02420-b927-708e-89fd-23787c4774d3','Y',0,'N','N','N','N')
+;
+
+-- Aug 21, 2026, 1:42:26 PM CEST
+ALTER TABLE AD_Role ADD COLUMN IsShowChangeLog CHAR(1) DEFAULT 'N' CHECK (IsShowChangeLog IN ('Y','N')) NOT NULL
+;
+
+-- Preserve the existing change log visibility for client preference roles
+UPDATE AD_Role SET IsShowChangeLog='Y' WHERE PreferenceType='C'
+;
+
+-- Aug 21, 2026, 1:43:37 PM CEST
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan) VALUES (209239,'Show Change Log','Allow users with this role to view change log information',119,217654,'Y',1,450,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2026-08-21 13:43:37','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-21 13:43:37','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','01a02422-3754-7ba3-a254-7e7764bb81a1','Y',470,2,2)
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=80,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=200071
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=90,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=11002
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=100,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=930
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=110,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=931
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=120,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=59591
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=130,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=59592
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=140,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=10126
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=150,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=205947
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=160,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=11003
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=170,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=5227
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=180,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=202366
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=190,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=10813
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=200,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=11257
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=210,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=8312
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=220,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=8310
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=230,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=8313
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=240,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=8314
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=250,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=206904
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=260,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=8311
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=270,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=11006
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=280, XPosition=2, ColumnSpan=1,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=209239
+;
+
+-- Aug 21, 2026, 1:47:54 PM CEST
+UPDATE AD_Field SET SeqNo=0,Updated=TO_TIMESTAMP('2026-08-21 13:47:54','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=200411
+;
+
+-- Aug 21, 2026, 1:49:32 PM CEST
+UPDATE AD_Element SET Help='Preferences allow you to define default values.  If set to None, you cannot set any preference nor value preference.',Updated=TO_TIMESTAMP('2026-08-21 13:49:32','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Element_ID=2656
+;
+
+-- Aug 21, 2026, 1:49:32 PM CEST
+UPDATE AD_Column SET ColumnName='PreferenceType', Name='Preference Level', Description='Determines what preferences the user can set', Help='Preferences allow you to define default values.  If set to None, you cannot set any preference nor value preference.', Placeholder=NULL WHERE AD_Element_ID=2656
+;
+
+-- Aug 21, 2026, 1:49:32 PM CEST
+UPDATE AD_Process_Para SET ColumnName='PreferenceType', Name='Preference Level', Description='Determines what preferences the user can set', Help='Preferences allow you to define default values.  If set to None, you cannot set any preference nor value preference.', AD_Element_ID=2656 WHERE UPPER(ColumnName)='PREFERENCETYPE' AND IsCentrallyMaintained='Y' AND AD_Element_ID IS NULL
+;
+
+-- Aug 21, 2026, 1:49:32 PM CEST
+UPDATE AD_Process_Para SET ColumnName='PreferenceType', Name='Preference Level', Description='Determines what preferences the user can set', Help='Preferences allow you to define default values.  If set to None, you cannot set any preference nor value preference.', Placeholder=NULL WHERE AD_Element_ID=2656 AND IsCentrallyMaintained='Y'
+;
+
+-- Aug 21, 2026, 1:49:32 PM CEST
+UPDATE AD_InfoColumn SET ColumnName='PreferenceType', Name='Preference Level', Description='Determines what preferences the user can set', Help='Preferences allow you to define default values.  If set to None, you cannot set any preference nor value preference.', Placeholder=NULL WHERE AD_Element_ID=2656 AND IsCentrallyMaintained='Y'
+;
+
+-- Aug 21, 2026, 1:49:32 PM CEST
+UPDATE AD_Field SET Name='Preference Level', Description='Determines what preferences the user can set', Help='Preferences allow you to define default values.  If set to None, you cannot set any preference nor value preference.', Placeholder=NULL WHERE AD_Column_ID IN (SELECT AD_Column_ID FROM AD_Column WHERE AD_Element_ID=2656) AND IsCentrallyMaintained='Y'
+;

--- a/migration/iD14/postgresql/202608211337_IDEMPIERE-1479.sql
+++ b/migration/iD14/postgresql/202608211337_IDEMPIERE-1479.sql
@@ -1,4 +1,4 @@
--- IDEMPIERE-1479 Add the default-deny AD_Role.IsShowChangeLog flag and preserve visibility for roles with PreferenceType='C'
+-- IDEMPIERE-1479 Add the default-deny Show Change Log checkbox to Role and preserve visibility for roles with PreferenceType='C'
 SELECT register_migration_script('202608211337_IDEMPIERE-1479.sql') FROM dual;
 
 -- Aug 21, 2026, 1:37:44 PM CEST

--- a/org.adempiere.base/src/org/compiere/model/I_AD_Role.java
+++ b/org.adempiere.base/src/org/compiere/model/I_AD_Role.java
@@ -22,7 +22,7 @@ import org.compiere.util.KeyNamePair;
 
 /** Generated Interface for AD_Role
  *  @author iDempiere (generated) 
- *  @version Release 13
+ *  @version Release 14
  */
 public interface I_AD_Role 
 {
@@ -498,6 +498,19 @@ public interface I_AD_Role
 	  * Users with this role can see accounting information
 	  */
 	public boolean isShowAcct();
+
+    /** Column name IsShowChangeLog */
+    public static final String COLUMNNAME_IsShowChangeLog = "IsShowChangeLog";
+
+	/** Set Show Change Log.
+	  * Allow users with this role to view change log information
+	  */
+	public void setIsShowChangeLog (boolean IsShowChangeLog);
+
+	/** Get Show Change Log.
+	  * Allow users with this role to view change log information
+	  */
+	public boolean isShowChangeLog();
 
     /** Column name IsUseUserOrgAccess */
     public static final String COLUMNNAME_IsUseUserOrgAccess = "IsUseUserOrgAccess";

--- a/org.adempiere.base/src/org/compiere/model/MRole.java
+++ b/org.adempiere.base/src/org/compiere/model/MRole.java
@@ -336,6 +336,7 @@ public final class MRole extends X_AD_Role implements ImmutablePOSupport
 		setIsPersonalAccess (false);
 		setIsPersonalLock (false);
 		setIsShowAcct (false);
+		setIsShowChangeLog(false);
 		setIsAccessAllOrgs(false);
 		setUserLevel (USERLEVEL_Organization);
 		setPreferenceType(PREFERENCETYPE_Organization);

--- a/org.adempiere.base/src/org/compiere/model/MSetup.java
+++ b/org.adempiere.base/src/org/compiere/model/MSetup.java
@@ -253,6 +253,7 @@ public final class MSetup
 		admin.setName(name);
 		admin.setUserLevel(MRole.USERLEVEL_ClientPlusOrganization);
 		admin.setPreferenceType(MRole.PREFERENCETYPE_Client);
+		admin.setIsShowChangeLog(true);
 		admin.setIsShowAcct(true);
 		admin.setIsAccessAdvanced(true);
 		admin.setIsClientAdministrator(true);

--- a/org.adempiere.base/src/org/compiere/model/X_AD_Role.java
+++ b/org.adempiere.base/src/org/compiere/model/X_AD_Role.java
@@ -25,7 +25,7 @@ import org.compiere.util.KeyNamePair;
 
 /** Generated Model for AD_Role
  *  @author iDempiere (generated)
- *  @version Release 13 - $Id$ */
+ *  @version Release 14 - $Id$ */
 @org.adempiere.base.Model(table="AD_Role")
 public class X_AD_Role extends PO implements I_AD_Role, I_Persistent
 {
@@ -33,7 +33,7 @@ public class X_AD_Role extends PO implements I_AD_Role, I_Persistent
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20260309L;
+	private static final long serialVersionUID = 20260821L;
 
     /** Standard Constructor */
     public X_AD_Role (Properties ctx, int AD_Role_ID, String trxName)
@@ -88,6 +88,8 @@ public class X_AD_Role extends PO implements I_AD_Role, I_Persistent
 			setIsPersonalLock (false);
 // N
 			setIsShowAcct (false);
+// N
+			setIsShowChangeLog (false);
 // N
 			setIsUseUserOrgAccess (false);
 // N
@@ -155,6 +157,8 @@ public class X_AD_Role extends PO implements I_AD_Role, I_Persistent
 // N
 			setIsShowAcct (false);
 // N
+			setIsShowChangeLog (false);
+// N
 			setIsUseUserOrgAccess (false);
 // N
 			setMaxQueryRecords (0);
@@ -221,6 +225,8 @@ public class X_AD_Role extends PO implements I_AD_Role, I_Persistent
 // N
 			setIsShowAcct (false);
 // N
+			setIsShowChangeLog (false);
+// N
 			setIsUseUserOrgAccess (false);
 // N
 			setMaxQueryRecords (0);
@@ -286,6 +292,8 @@ public class X_AD_Role extends PO implements I_AD_Role, I_Persistent
 			setIsPersonalLock (false);
 // N
 			setIsShowAcct (false);
+// N
+			setIsShowChangeLog (false);
 // N
 			setIsUseUserOrgAccess (false);
 // N
@@ -1096,6 +1104,29 @@ public class X_AD_Role extends PO implements I_AD_Role, I_Persistent
 	public boolean isShowAcct()
 	{
 		Object oo = get_Value(COLUMNNAME_IsShowAcct);
+		if (oo != null)
+		{
+			 if (oo instanceof Boolean)
+				 return ((Boolean)oo).booleanValue();
+			return "Y".equals(oo);
+		}
+		return false;
+	}
+
+	/** Set Show Change Log.
+		@param IsShowChangeLog Allow users with this role to view change log information
+	*/
+	public void setIsShowChangeLog (boolean IsShowChangeLog)
+	{
+		set_Value (COLUMNNAME_IsShowChangeLog, Boolean.valueOf(IsShowChangeLog));
+	}
+
+	/** Get Show Change Log.
+		@return Allow users with this role to view change log information
+	  */
+	public boolean isShowChangeLog()
+	{
+		Object oo = get_Value(COLUMNNAME_IsShowChangeLog);
 		if (oo != null)
 		{
 			 if (oo instanceof Boolean)

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WFieldRecordInfo.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WFieldRecordInfo.java
@@ -217,8 +217,7 @@ public class WFieldRecordInfo extends Window implements EventListener<Event>
 			setTitle(title + " - " + table1.getName());
 		}
 
-		//	Only Client Preference can view Change Log
-		if (!MRole.PREFERENCETYPE_Client.equals(MRole.getDefault().getPreferenceType()))
+		if (!MRole.getDefault().isShowChangeLog())
 			return false;
 		
 		if (Record_ID == 0 && Util.isEmpty(Record_UU))

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WFieldRecordInfo.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WFieldRecordInfo.java
@@ -429,6 +429,9 @@ public class WFieldRecordInfo extends Window implements EventListener<Event>
 	 * @param popupMenu
 	 */
 	public static void addMenu(WEditorPopupMenu popupMenu) {
+		if (MRole.getDefault() == null || !MRole.getDefault().isShowChangeLog())
+			return;
+
 		Menuitem changeLogItem = new Menuitem();
         changeLogItem.setLabel(Msg.getElement(Env.getCtx(), "AD_ChangeLog_ID"));
         if (ThemeManager.isUseFontIconForImage())

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WRecordInfo.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WRecordInfo.java
@@ -400,11 +400,6 @@ public class WRecordInfo extends Window implements EventListener<Event>
 				m_copySelect.setVisible(true);
 			}
 		}
-		if (gridTab != null)
-		{
-			timeLinePanel.render(gridTab);
-		}
-		
 		//	Title
 		if (tabName == null && dse.AD_Table_ID != 0)
 		{
@@ -412,9 +407,13 @@ public class WRecordInfo extends Window implements EventListener<Event>
 		}
 		setTitle(title + " - " + tabName);
 
-		//	Only Client Preference can view Change Log
-		if (!MRole.PREFERENCETYPE_Client.equals(MRole.getDefault().getPreferenceType()))
+		if (!MRole.getDefault().isShowChangeLog())
 			return false;
+
+		if (gridTab != null)
+		{
+			timeLinePanel.render(gridTab);
+		}
 		
 		if (Record_ID <= 0 && Util.isEmpty(Record_UU))
 			return false;

--- a/org.idempiere.test/src/org/idempiere/test/model/MRoleTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/MRoleTest.java
@@ -1462,6 +1462,21 @@ public class MRoleTest extends AbstractTestCase {
         role.setPreferenceType(MRole.PREFERENCETYPE_Organization);
         assertTrue(role.isShowPreference(), "PreferenceType=Organization should return true");
     }
+
+    /**
+     * Test that change log visibility is independent of the preference type.
+     */
+    @Test
+    public void testIsShowChangeLog() {
+        MRole role = new MRole(Env.getCtx(), 0, getTrxName());
+
+        role.setPreferenceType(MRole.PREFERENCETYPE_Client);
+        assertFalse(role.isShowChangeLog(), "Client preference must not grant change log access");
+
+        role.setIsShowChangeLog(true);
+        role.setPreferenceType(MRole.PREFERENCETYPE_None);
+        assertTrue(role.isShowChangeLog(), "Change log access must not depend on preference type");
+    }
     
     /**
      * Test cases for MRole.isTableAccessExcluded(int)


### PR DESCRIPTION
## Description

Adds `AD_Role.IsShowChangeLog` to control access to record and field change history independently from `PreferenceType`.

JIRA: https://idempiere.atlassian.net/browse/IDEMPIERE-1479

## Changes

- Add the mandatory **Show Change Log** role flag, defaulting to disabled.
- Preserve existing behavior during migration by enabling it for roles with `PreferenceType='C'`.
- Enable it for client administrator roles created by `MSetup`.
- Guard record, field, and timeline change-log queries with the new role flag.
- Hide the field change-log context-menu item when the role lacks the permission.
- Update the Preference Level help text.
- Regenerate `I_AD_Role` and `X_AD_Role`.
- Add a test proving independence from `PreferenceType`.

## Security

The role permission is checked before `RecordTimeLinePanel.render()`, so unauthorized roles do not query `AD_ChangeLog` through the timeline. The field change-log context-menu item is not created for unauthorized roles, while the dialog retains its permission check as a second layer.

## Validation

- `mvn integration-test -DskipTests=false`
- Production and test bundles compiled in the root Maven reactor.
- CRLF-aware `git diff --check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a role-level setting to control change-log visibility.
  - Change-log access is now determined by the configured role setting.
  - New administrator roles display change logs by default; other roles remain disabled unless enabled.

- **Bug Fixes**
  - Prevented change-log menus and timelines from appearing when access is disabled or no default role is available.
  - Improved role and preference metadata displayed in the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->