### PR TITLE
[WIP] IDEMPIERE-2022 Add scheduled workflow wait action

### DIFF
--- a/migration/iD14/oracle/202608211700_IDEMPIERE-2022.sql
+++ b/migration/iD14/oracle/202608211700_IDEMPIERE-2022.sql
@@ -1,0 +1,25 @@
+-- IDEMPIERE-2022 Workflow - Wait (Schedule) Action for scheduled workflow activities
+SELECT register_migration_script('202608211700_IDEMPIERE-2022.sql') FROM dual;
+
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Aug 21, 2026, 5:00:00 PM CEST
+INSERT INTO AD_Ref_List (AD_Ref_List_ID,Name,Description,AD_Reference_ID,Value,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,AD_Ref_List_UU) VALUES (200778,'Wait (Schedule)','Wait until a dynamically calculated date and time',302,'S',0,0,'Y',TO_TIMESTAMP('2026-08-21 17:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-21 17:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','5c67d246-70f0-4538-9075-a1d70cb51330')
+;
+
+-- Aug 21, 2026, 5:00:01 PM CEST
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,ColumnName,Name,Description,Help,PrintName,EntityType,AD_Element_UU) VALUES (204121,0,0,'Y',TO_TIMESTAMP('2026-08-21 17:00:01','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-21 17:00:01','YYYY-MM-DD HH24:MI:SS'),100,'ScheduleExpression','Schedule Expression','SQL expression that determines when a scheduled workflow activity resumes','The expression must start with @SQL= and return one timestamp. It is evaluated when the activity is created and again on every workflow processor run. Context variables are resolved from the workflow record.','Schedule Expression','D','b84d9acf-93fd-4ee6-88bc-20cff9f44a42')
+;
+
+-- Aug 21, 2026, 5:00:02 PM CEST
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,IsHtml,IsPartitionKey) VALUES (217655,0,'Schedule Expression','SQL expression that determines when a scheduled workflow activity resumes','The expression must start with @SQL= and return one timestamp. It is evaluated when the activity is created and again on every workflow processor run. Context variables are resolved from the workflow record.',129,'ScheduleExpression',2000,'N','N','N','N','N',0,'N',14,0,0,'Y',TO_TIMESTAMP('2026-08-21 17:00:02','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-21 17:00:02','YYYY-MM-DD HH24:MI:SS'),100,204121,'Y','N','D','N','N','N','Y','3f09efa7-a7fb-4ae4-90f9-e71850a7eaf8','Y',0,'N','N','N','N')
+;
+
+-- Aug 21, 2026, 5:00:03 PM CEST
+ALTER TABLE AD_WF_Node ADD ScheduleExpression NVARCHAR2(2000) DEFAULT NULL
+;
+
+-- Aug 21, 2026, 5:00:04 PM CEST
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLogic,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,XPosition,ColumnSpan,NumLines) VALUES (209240,'Schedule Expression','SQL expression that determines when a scheduled workflow activity resumes','The expression must start with @SQL= and return one timestamp. It is evaluated when the activity is created and again on every workflow processor run. Context variables are resolved from the workflow record.',(SELECT AD_Tab_ID FROM AD_Field WHERE AD_Field_ID=10088),217655,'Y','@Action@=S',60,225,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2026-08-21 17:00:04','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-21 17:00:04','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','e91cd828-31d2-46f5-9cf9-a4763e614d4f','N',1,5,3)
+;

--- a/migration/iD14/postgresql/202608211700_IDEMPIERE-2022.sql
+++ b/migration/iD14/postgresql/202608211700_IDEMPIERE-2022.sql
@@ -1,0 +1,22 @@
+-- IDEMPIERE-2022 Workflow - Wait (Schedule) Action for scheduled workflow activities
+SELECT register_migration_script('202608211700_IDEMPIERE-2022.sql') FROM dual;
+
+-- Aug 21, 2026, 5:00:00 PM CEST
+INSERT INTO AD_Ref_List (AD_Ref_List_ID,Name,Description,AD_Reference_ID,Value,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,AD_Ref_List_UU) VALUES (200778,'Wait (Schedule)','Wait until a dynamically calculated date and time',302,'S',0,0,'Y',TO_TIMESTAMP('2026-08-21 17:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-21 17:00:00','YYYY-MM-DD HH24:MI:SS'),100,'D','5c67d246-70f0-4538-9075-a1d70cb51330')
+;
+
+-- Aug 21, 2026, 5:00:01 PM CEST
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,ColumnName,Name,Description,Help,PrintName,EntityType,AD_Element_UU) VALUES (204121,0,0,'Y',TO_TIMESTAMP('2026-08-21 17:00:01','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-21 17:00:01','YYYY-MM-DD HH24:MI:SS'),100,'ScheduleExpression','Schedule Expression','SQL expression that determines when a scheduled workflow activity resumes','The expression must start with @SQL= and return one timestamp. It is evaluated when the activity is created and again on every workflow processor run. Context variables are resolved from the workflow record.','Schedule Expression','D','b84d9acf-93fd-4ee6-88bc-20cff9f44a42')
+;
+
+-- Aug 21, 2026, 5:00:02 PM CEST
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,IsHtml,IsPartitionKey) VALUES (217655,0,'Schedule Expression','SQL expression that determines when a scheduled workflow activity resumes','The expression must start with @SQL= and return one timestamp. It is evaluated when the activity is created and again on every workflow processor run. Context variables are resolved from the workflow record.',129,'ScheduleExpression',2000,'N','N','N','N','N',0,'N',14,0,0,'Y',TO_TIMESTAMP('2026-08-21 17:00:02','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-21 17:00:02','YYYY-MM-DD HH24:MI:SS'),100,204121,'Y','N','D','N','N','N','Y','3f09efa7-a7fb-4ae4-90f9-e71850a7eaf8','Y',0,'N','N','N','N')
+;
+
+-- Aug 21, 2026, 5:00:03 PM CEST
+ALTER TABLE AD_WF_Node ADD COLUMN ScheduleExpression VARCHAR(2000) DEFAULT NULL
+;
+
+-- Aug 21, 2026, 5:00:04 PM CEST
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLogic,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,XPosition,ColumnSpan,NumLines) VALUES (209240,'Schedule Expression','SQL expression that determines when a scheduled workflow activity resumes','The expression must start with @SQL= and return one timestamp. It is evaluated when the activity is created and again on every workflow processor run. Context variables are resolved from the workflow record.',(SELECT AD_Tab_ID FROM AD_Field WHERE AD_Field_ID=10088),217655,'Y','@Action@=S',60,225,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2026-08-21 17:00:04','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-21 17:00:04','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','e91cd828-31d2-46f5-9cf9-a4763e614d4f','N',1,5,3)
+;

--- a/org.adempiere.base/src/org/compiere/model/I_AD_WF_Node.java
+++ b/org.adempiere.base/src/org/compiere/model/I_AD_WF_Node.java
@@ -632,6 +632,19 @@ public interface I_AD_WF_Node
 	@Deprecated(since="13") // use better methods with cache
 	public org.compiere.model.I_R_MailText getR_MailText() throws RuntimeException;
 
+    /** Column name ScheduleExpression */
+    public static final String COLUMNNAME_ScheduleExpression = "ScheduleExpression";
+
+	/** Set Schedule Expression.
+	  * SQL expression that determines when a scheduled workflow activity resumes
+	  */
+	public void setScheduleExpression (String ScheduleExpression);
+
+	/** Get Schedule Expression.
+	  * SQL expression that determines when a scheduled workflow activity resumes
+	  */
+	public String getScheduleExpression();
+
     /** Column name S_Resource_ID */
     public static final String COLUMNNAME_S_Resource_ID = "S_Resource_ID";
 

--- a/org.adempiere.base/src/org/compiere/model/X_AD_WF_Node.java
+++ b/org.adempiere.base/src/org/compiere/model/X_AD_WF_Node.java
@@ -561,6 +561,8 @@ public class X_AD_WF_Node extends PO implements I_AD_WF_Node, I_Persistent
 	public static final String ACTION_AppsProcess = "P";
 	/** Apps Report = R */
 	public static final String ACTION_AppsReport = "R";
+	/** Wait (Schedule) = S */
+	public static final String ACTION_WaitSchedule = "S";
 	/** Apps Task = T */
 	public static final String ACTION_AppsTask = "T";
 	/** Set Variable = V */
@@ -1151,6 +1153,22 @@ public class X_AD_WF_Node extends PO implements I_AD_WF_Node, I_Persistent
 		if (ii == null)
 			 return 0;
 		return ii.intValue();
+	}
+
+	/** Set Schedule Expression.
+		@param ScheduleExpression SQL expression that determines when a scheduled workflow activity resumes
+	*/
+	public void setScheduleExpression (String ScheduleExpression)
+	{
+		set_Value (COLUMNNAME_ScheduleExpression, ScheduleExpression);
+	}
+
+	/** Get Schedule Expression.
+		@return SQL expression that determines when a scheduled workflow activity resumes
+	  */
+	public String getScheduleExpression()
+	{
+		return (String)get_Value(COLUMNNAME_ScheduleExpression);
 	}
 
 	@Deprecated(since="13") // use better methods with cache

--- a/org.adempiere.base/src/org/compiere/wf/MWFActivity.java
+++ b/org.adempiere.base/src/org/compiere/wf/MWFActivity.java
@@ -422,6 +422,35 @@ public class MWFActivity extends X_AD_WF_Activity implements Runnable
 	}	//	getPO
 
 	/**
+	 * Evaluate the schedule expression of the current workflow node.
+	 * Context variables are resolved against the workflow record and passed as
+	 * prepared statement parameters.
+	 *
+	 * @param trx transaction, may be {@code null}
+	 * @return calculated end wait time, or {@code null} if the expression returns null
+	 */
+	public Timestamp evaluateScheduleEndWaitTime(Trx trx)
+	{
+		String expression = getNode().getScheduleExpression();
+		if (Util.isEmpty(expression, true) || !expression.trim().startsWith(MColumn.VIRTUAL_UI_COLUMN_PREFIX))
+			throw new AdempiereException("Invalid ScheduleExpression - expected @SQL=SELECT ...");
+
+		String sql = expression.trim().substring(MColumn.VIRTUAL_UI_COLUMN_PREFIX.length()).trim();
+		if (!sql.regionMatches(true, 0, "SELECT", 0, 6))
+			throw new AdempiereException("Invalid ScheduleExpression - expected @SQL=SELECT ...");
+
+		PO po = getPO(trx);
+		if (po == null)
+			throw new AdempiereException("Persistent Object not found - AD_Table_ID="
+					+ getAD_Table_ID() + ", Record_ID=" + getRecord_ID());
+
+		String trxName = trx != null ? trx.getTrxName() : null;
+		List<Object> parameters = new ArrayList<>();
+		sql = Env.parseVariableForSql(sql, po, trxName, false, parameters);
+		return DB.getSQLValueTSEx(trxName, sql, parameters);
+	}	//	evaluateScheduleEndWaitTime
+
+	/**
 	 * 	Get PO AD_Client_ID
 	 *	@return client of PO
 	 */
@@ -1089,6 +1118,15 @@ public class MWFActivity extends X_AD_WF_Activity implements Runnable
 			if (m_node.getWaitTime() == -1)
 				prepareCommitEvent();
 			return false;		//	not done
+		}
+
+		/******	Wait until calculated schedule	******/
+		else if (MWFNode.ACTION_WaitSchedule.equals(action))
+		{
+			Timestamp endWaitTime = evaluateScheduleEndWaitTime(trx);
+			setEndWaitTime(endWaitTime);
+			if (log.isLoggable(Level.FINE)) log.fine("Schedule:EndWaitTime=" + endWaitTime);
+			return endWaitTime != null && !endWaitTime.after(new Timestamp(System.currentTimeMillis()));
 		}
 
 		/******	Document Action				******/

--- a/org.adempiere.base/src/org/compiere/wf/MWFNode.java
+++ b/org.adempiere.base/src/org/compiere/wf/MWFNode.java
@@ -443,6 +443,8 @@ public class MWFNode extends X_AD_WF_Node implements ImmutablePOSupport
 			return "Window:AD_InfoWindow_ID=" + getAD_InfoWindow_ID();
 		else if (ACTION_WaitSleep.equals(action))
 			return "Sleep:WaitTime=" + getWaitTime();
+		else if (ACTION_WaitSchedule.equals(action))
+			return "Schedule:ScheduleExpression=" + getScheduleExpression();
 		return "??";
 	}	//	getActionInfo
 		
@@ -649,6 +651,22 @@ public class MWFNode extends X_AD_WF_Node implements ImmutablePOSupport
 		String action = getAction();
 		if (action.equals(ACTION_WaitSleep))
 			;
+		else if (action.equals(ACTION_WaitSchedule))
+		{
+			String expression = getScheduleExpression();
+			if (Util.isEmpty(expression, true))
+			{
+				log.saveError("FillMandatory", Msg.getElement(getCtx(), COLUMNNAME_ScheduleExpression));
+				return false;
+			}
+			String sql = expression.trim();
+			if (!sql.startsWith(MColumn.VIRTUAL_UI_COLUMN_PREFIX)
+					|| !sql.substring(MColumn.VIRTUAL_UI_COLUMN_PREFIX.length()).trim().regionMatches(true, 0, "SELECT", 0, 6))
+			{
+				log.saveError("Invalid", Msg.getElement(getCtx(), COLUMNNAME_ScheduleExpression) + " (@SQL=SELECT ...)");
+				return false;
+			}
+		}
 		else if (action.equals(ACTION_AppsProcess) || action.equals(ACTION_AppsReport)) 
 		{
 			if (getAD_Process_ID() == 0)

--- a/org.adempiere.server/src/main/server/org/compiere/server/WorkflowProcessor.java
+++ b/org.adempiere.server/src/main/server/org/compiere/server/WorkflowProcessor.java
@@ -74,6 +74,7 @@ public class WorkflowProcessor extends AdempiereServer
 	{
 		m_summary = new StringBuffer();
 		//
+		recalculateScheduledActivities();
 		wakeup();
 		dynamicPriority();
 		sendAlerts();
@@ -88,6 +89,74 @@ public class WorkflowProcessor extends AdempiereServer
 	}	//	doWork
 
 	/**
+	 * Recalculate the end wait time for suspended schedule activities. This makes
+	 * changes to the source record effective without restarting the workflow.
+	 */
+	protected void recalculateScheduledActivities()
+	{
+		String sql = "SELECT * "
+			+ "FROM AD_WF_Activity a "
+			+ "WHERE Processed='N' AND WFState='OS'"
+			+ " AND AD_Client_ID=?"
+			+ " AND EXISTS (SELECT * FROM AD_Workflow wf "
+				+ " INNER JOIN AD_WF_Node wfn ON (wf.AD_Workflow_ID=wfn.AD_Workflow_ID) "
+				+ "WHERE a.AD_WF_Node_ID=wfn.AD_WF_Node_ID"
+				+ " AND wfn.Action=?"
+				+ " AND (wf.AD_WorkflowProcessor_ID IS NULL OR wf.AD_WorkflowProcessor_ID=?))";
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		int count = 0;
+		int errors = 0;
+		try
+		{
+			pstmt = DB.prepareStatement(sql, null);
+			pstmt.setInt(1, m_model.getAD_Client_ID());
+			pstmt.setString(2, MWFNode.ACTION_WaitSchedule);
+			pstmt.setInt(3, m_model.getAD_WorkflowProcessor_ID());
+			rs = pstmt.executeQuery();
+			while (rs.next())
+			{
+				MWFActivity activity = new MWFActivity(getCtx(), rs, null);
+				try
+				{
+					Timestamp oldEndWaitTime = activity.getEndWaitTime();
+					Timestamp newEndWaitTime = activity.evaluateScheduleEndWaitTime(null);
+					if (oldEndWaitTime == null ? newEndWaitTime != null : !oldEndWaitTime.equals(newEndWaitTime))
+					{
+						activity.setEndWaitTime(newEndWaitTime);
+						activity.saveEx();
+					}
+					count++;
+				}
+				catch (Exception e)
+				{
+					errors++;
+					// Never wake an activity using a stale date after recalculation failed.
+					if (activity.getEndWaitTime() != null)
+					{
+						activity.setEndWaitTime(null);
+						activity.saveEx();
+					}
+					log.log(Level.WARNING, "recalculateScheduledActivities - AD_WF_Activity_ID="
+							+ activity.getAD_WF_Activity_ID(), e);
+				}
+			}
+		}
+		catch (Exception e)
+		{
+			log.log(Level.SEVERE, "recalculateScheduledActivities", e);
+		}
+		finally
+		{
+			DB.close(rs, pstmt);
+		}
+		m_summary.append("Schedule #").append(count);
+		if (errors > 0)
+			m_summary.append(" (Errors=").append(errors).append(")");
+		m_summary.append(" - ");
+	}	//	recalculateScheduledActivities
+
+	/**
 	 * 	Continue Workflow After Sleep
 	 */
 	protected void wakeup()
@@ -100,7 +169,7 @@ public class WorkflowProcessor extends AdempiereServer
 			+ " AND EXISTS (SELECT * FROM AD_Workflow wf "
 				+ " INNER JOIN AD_WF_Node wfn ON (wf.AD_Workflow_ID=wfn.AD_Workflow_ID) "
 				+ "WHERE a.AD_WF_Node_ID=wfn.AD_WF_Node_ID"
-				+ " AND wfn.Action='Z'"		//	sleeping
+				+ " AND wfn.Action IN (?,?)"		//	sleeping or scheduled
 				+ " AND (wf.AD_WorkflowProcessor_ID IS NULL OR wf.AD_WorkflowProcessor_ID=?))";
 		PreparedStatement pstmt = null;
 		ResultSet rs = null;
@@ -109,7 +178,9 @@ public class WorkflowProcessor extends AdempiereServer
 		{
 			pstmt = DB.prepareStatement (sql, null);
 			pstmt.setInt (1, m_model.getAD_Client_ID());
-			pstmt.setInt (2, m_model.getAD_WorkflowProcessor_ID());
+			pstmt.setString(2, MWFNode.ACTION_WaitSleep);
+			pstmt.setString(3, MWFNode.ACTION_WaitSchedule);
+			pstmt.setInt (4, m_model.getAD_WorkflowProcessor_ID());
 			rs = pstmt.executeQuery ();
 			while (rs.next ())
 			{

--- a/org.idempiere.test/src/org/idempiere/test/workflow/WFMaterialReceiptTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/workflow/WFMaterialReceiptTest.java
@@ -26,6 +26,9 @@ package org.idempiere.test.workflow;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
@@ -42,6 +45,7 @@ import org.compiere.process.ProcessInfo;
 import org.compiere.util.CacheMgt;
 import org.compiere.util.Env;
 import org.compiere.util.TimeUtil;
+import org.compiere.util.Trx;
 import org.compiere.wf.MWFActivity;
 import org.compiere.wf.MWFNextCondition;
 import org.compiere.wf.MWFNode;
@@ -65,6 +69,51 @@ public class WFMaterialReceiptTest extends AbstractTestCase {
 	private static final int WF_PROCESS_SHIPMENT_NODE_COMPLETE = 190;
 	private static final int PROCESS_SYNC_DOC_TRL = 321;
 	private static final int COLUMN_M_INOUT_ISSOTRX = 3790;
+
+	/**
+	 * https://idempiere.atlassian.net/browse/IDEMPIERE-2022
+	 */
+	@Test
+	public void testScheduledWaitRecalculation() throws Exception {
+		try {
+			Properties ctx = Env.getCtx();
+			String trxName = getTrxName();
+			MWorkflow wf = new MWorkflow(ctx, WF_PROCESS_SHIPMENT, trxName);
+
+			MWFNode scheduleNode = new MWFNode(wf, "WaitSchedule", "Wait until DateOrdered");
+			scheduleNode.setClientOrg(Env.getAD_Client_ID(ctx), 0);
+			scheduleNode.setAction(MWFNode.ACTION_WaitSchedule);
+			scheduleNode.setScheduleExpression("@SQL=SELECT DateOrdered FROM M_InOut WHERE M_InOut_ID=@M_InOut_ID@");
+			scheduleNode.saveEx();
+
+			MInOut shipment = new MInOut(ctx, 0, trxName);
+			shipment.setBPartner(MBPartner.get(ctx, DictionaryIDs.C_BPartner.PATIO.id));
+			shipment.setC_BPartner_Location_ID(LOCATION_FROM_PATIO);
+			shipment.setM_Warehouse_ID(DictionaryIDs.M_Warehouse.HQ.id);
+			shipment.setC_DocType_ID(DictionaryIDs.C_DocType.MM_RECEIPT.id);
+			shipment.setIsSOTrx(false);
+			shipment.setMovementType(MInOut.MOVEMENTTYPE_VendorReceipts);
+			Timestamp initialSchedule = TimeUtil.addDays(TimeUtil.getDay(System.currentTimeMillis()), 1);
+			shipment.setDateOrdered(initialSchedule);
+			shipment.saveEx();
+
+			Trx trx = Trx.get(trxName, false);
+			MWFActivity activity = mock(MWFActivity.class);
+			doReturn(scheduleNode).when(activity).getNode();
+			doReturn(shipment).when(activity).getPO(trx);
+			doCallRealMethod().when(activity).evaluateScheduleEndWaitTime(trx);
+
+			assertEquals(initialSchedule, activity.evaluateScheduleEndWaitTime(trx));
+
+			Timestamp changedSchedule = TimeUtil.addDays(initialSchedule, 1);
+			shipment.setDateOrdered(changedSchedule);
+			shipment.saveEx();
+			assertEquals(changedSchedule, activity.evaluateScheduleEndWaitTime(trx));
+		} finally {
+			rollback();
+			CacheMgt.get().reset();
+		}
+	}
 
 	/**
 	 * https://idempiere.atlassian.net/browse/IDEMPIERE-4186


### PR DESCRIPTION
## Work in Progress

This pull request is a work in progress. Comments and early feedback are explicitly welcome, especially regarding the schedule expression contract and recalculation by Workflow Processor.

JIRA: https://idempiere.atlassian.net/browse/IDEMPIERE-2022

## Proposal

Add a new Wait (Schedule) workflow node action for activities whose resume time is calculated dynamically from the workflow record.

## Current behavior

- A new Schedule Expression field accepts an @SQL=SELECT expression returning one timestamp.
- Context variables are resolved from the workflow record and bound as prepared-statement parameters.
- The expression is evaluated when the activity first reaches the node.
- Suspended schedule activities are recalculated on every Workflow Processor run before due activities are resumed.
- A null result keeps the activity suspended for reevaluation on the next run.
- A due or past result completes the wait immediately.
- The existing Wait (Sleep) action remains unchanged.

## Dictionary changes

- Add the Wait (Schedule) action list entry.
- Add AD_WF_Node.ScheduleExpression and its workflow-node field.
- Use centrally reserved dictionary IDs.
- Include PostgreSQL and Oracle migration scripts.

## Validation

- mvn integration-test -DskipTests=false completed successfully.
- WFMaterialReceiptTest: 2 tests, 0 failures, 0 errors.
- git diff --check passes.

## Feedback requested

Please comment on the proposed @SQL contract, the null-result behavior, and whether recalculation on every Workflow Processor run is the preferred integration point.