### PR TITLE
IDEMPIERE-3763 Respect one asset per UOM for matched invoices

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MAssetAddition.java
+++ b/org.adempiere.base/src/org/compiere/model/MAssetAddition.java
@@ -23,8 +23,10 @@ package org.compiere.model;
 
 import java.io.File;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.logging.Level;
@@ -145,23 +147,120 @@ public class MAssetAddition extends X_A_Asset_Addition
 	 */
 	public static MAssetAddition createAsset(MMatchInv match)
 	{
-		MAssetAddition assetAdd = new MAssetAddition(match);
+		return createAssets(match).get(0);
+	}
+
+	/**
+	 * Create assets and asset additions from a match invoice.
+	 * When the effective asset group is configured for one asset per UOM,
+	 * one asset and addition is created for every matched unit.
+	 * @param match match invoice
+	 * @return created asset additions, or existing additions for the match
+	 */
+	public static List<MAssetAddition> createAssets(MMatchInv match)
+	{
+		List<MAssetAddition> existingAdditions = new Query(match.getCtx(), Table_Name,
+				COLUMNNAME_M_MatchInv_ID + "=?", match.get_TrxName())
+				.setParameters(match.getM_MatchInv_ID())
+				.setOrderBy(COLUMNNAME_A_Asset_Addition_ID)
+				.list();
+		if (!existingAdditions.isEmpty())
+			return existingAdditions;
+
+		MInvoiceLine invLine = new MInvoiceLine(match.getCtx(), match.getC_InvoiceLine_ID(), match.get_TrxName());
+		int assetGroupId = invLine.getA_Asset_Group_ID();
+		if (assetGroupId <= 0)
+			assetGroupId = MProduct.get(match.getCtx(), match.getM_Product_ID()).getA_Asset_Group_ID();
+		MAssetGroup assetGroup = MAssetGroup.get(match.getCtx(), assetGroupId);
+		boolean oneAssetPerUOM = assetGroup != null && assetGroup.isOneAssetPerUOM();
+
+		int additionCount = 1;
+		if (oneAssetPerUOM)
+		{
+			BigDecimal qty = match.getQty();
+			try
+			{
+				if (qty == null || qty.signum() <= 0)
+					throw new ArithmeticException();
+				additionCount = qty.toBigIntegerExact().intValueExact();
+			}
+			catch (ArithmeticException e)
+			{
+				throw new AssetException("@Invalid@ @Qty@=" + qty
+						+ " (@IsOneAssetPerUOM@)", e);
+			}
+		}
+
+		BigDecimal matchNetAmt = DB.getSQLValueBD(match.get_TrxName(),
+				"SELECT MatchNetAmt FROM mb_matchinv WHERE M_MatchInv_ID=?", match.getM_MatchInv_ID());
+		if (matchNetAmt == null)
+			throw new AssetException("@NotFound@ MatchNetAmt, @M_MatchInv_ID@=" + match.getM_MatchInv_ID());
+
+		int precision = new MCurrency(match.getCtx(), invLine.getParent().getC_Currency_ID(),
+				match.get_TrxName()).getStdPrecision();
+		BigDecimal additionAmt = matchNetAmt.divide(BigDecimal.valueOf(additionCount), precision, RoundingMode.HALF_UP);
+		BigDecimal allocatedAmt = Env.ZERO;
+		List<MAssetAddition> additions = new ArrayList<>(additionCount);
+		for (int i = 1; i <= additionCount; i++)
+		{
+			BigDecimal amount = i == additionCount ? matchNetAmt.subtract(allocatedAmt) : additionAmt;
+			MAssetAddition assetAdd = new MAssetAddition(match);
+			assetAdd.setSourceAmt(amount);
+			if (oneAssetPerUOM)
+				assetAdd.setA_QTY_Current(Env.ONE);
+			createAsset(assetAdd, invLine, oneAssetPerUOM ? i : 0);
+			additions.add(assetAdd);
+			allocatedAmt = allocatedAmt.add(amount);
+		}
+		return additions;
+	}
+
+	/**
+	 * Create and save the asset for an addition when applicable.
+	 * @param assetAdd asset addition
+	 * @param invLine invoice line
+	 * @param sequence sequence number, or zero when no suffix is needed
+	 */
+	private static void createAsset(MAssetAddition assetAdd, MInvoiceLine invLine, int sequence)
+	{
 		assetAdd.dump();
 		//@win add condition to prevent asset creation when expense addition or second addition
-		MInvoiceLine invLine = new MInvoiceLine(match.getCtx(), match.getC_InvoiceLine_ID(), match.get_TrxName());
-		if (MAssetAddition.A_CAPVSEXP_Capital.equals(assetAdd.getA_CapvsExp())
-				&& invLine.getA_Asset_ID() == 0 && assetAdd.isA_CreateAsset()) { 
+		if (A_CAPVSEXP_Capital.equals(assetAdd.getA_CapvsExp())
+				&& invLine.getA_Asset_ID() == 0 && assetAdd.isA_CreateAsset())
+		{
 			//end @win add condition to prevent asset creation when expense addition or second addition
 			MAsset asset = assetAdd.createAsset();
+			if (sequence > 0)
+			{
+				asset.setName(addSequenceSuffix(asset, MAsset.COLUMNNAME_Name, asset.getName(), sequence));
+				asset.setValue(addSequenceSuffix(asset, MAsset.COLUMNNAME_Value, asset.getValue(), sequence));
+				asset.saveEx();
+			}
 			asset.dump();
-			//@win add
-
-		} else {
+		}
+		else
+		{
 			assetAdd.setA_Asset_ID(invLine.getA_Asset_ID());
 			assetAdd.setA_CreateAsset(false);
 		}
 		assetAdd.saveEx();
-		return assetAdd;
+	}
+
+	/**
+	 * Add a sequence suffix while respecting the dictionary field length.
+	 * @param asset asset model
+	 * @param columnName column name
+	 * @param value current value
+	 * @param sequence sequence number
+	 * @return value with sequence suffix
+	 */
+	private static String addSequenceSuffix(MAsset asset, String columnName, String value, int sequence)
+	{
+		String suffix = "-" + sequence;
+		int fieldLength = POInfo.getPOInfo(asset.getCtx(), MAsset.Table_ID).getFieldLength(columnName);
+		if (fieldLength > 0 && value.length() + suffix.length() > fieldLength)
+			value = value.substring(0, fieldLength - suffix.length());
+		return value + suffix;
 	}
 	
 	/**
@@ -397,8 +496,10 @@ public class MAssetAddition extends X_A_Asset_Addition
 		setLine(invLine.getLine());
 		setM_Locator_ID(mi.getM_InOutLine().getM_Locator_ID());
 		setA_CapvsExp(invLine.getA_CapvsExp());
-		setAssetAmtEntered(invLine.getLineNetAmt());
-		setAssetSourceAmt(invLine.getLineNetAmt());
+		BigDecimal matchNetAmt = DB.getSQLValueBD(get_TrxName(),
+				"SELECT MatchNetAmt FROM mb_matchinv WHERE M_MatchInv_ID=?", mi.getM_MatchInv_ID());
+		setAssetAmtEntered(matchNetAmt);
+		setAssetSourceAmt(matchNetAmt);
 		setC_Currency_ID(invLine.getParent().getC_Currency_ID());
 		setC_ConversionType_ID(invLine.getParent().getC_ConversionType_ID());
 		setDateDoc(mi.getM_InOutLine().getParent().getMovementDate());
@@ -1047,7 +1148,26 @@ public class MAssetAddition extends X_A_Asset_Addition
 				throw new AdempiereException("No Invoice Line");
 			MInvoiceLine invoiceLine = new MInvoiceLine(getCtx(), C_InvoiceLine_ID, get_TrxName());
 			invoiceLine.setA_Processed(!isReversal);
-			invoiceLine.setA_Asset_ID(isReversal ? 0 : getA_Asset_ID());
+			if (isReversal)
+			{
+				if (invoiceLine.getA_Asset_ID() == getA_Asset_ID())
+					invoiceLine.setA_Asset_ID(0);
+			}
+			else if (invoiceLine.getA_Asset_ID() == 0)
+			{
+				int assetId = getA_Asset_ID();
+				if (getM_MatchInv_ID() > 0)
+				{
+					MAssetAddition firstAddition = new Query(getCtx(), Table_Name,
+							COLUMNNAME_M_MatchInv_ID + "=? AND " + COLUMNNAME_A_Asset_ID + ">0", get_TrxName())
+							.setParameters(getM_MatchInv_ID())
+							.setOrderBy(COLUMNNAME_A_Asset_Addition_ID)
+							.first();
+					if (firstAddition != null)
+						assetId = firstAddition.getA_Asset_ID();
+				}
+				invoiceLine.setA_Asset_ID(assetId);
+			}
 			invoiceLine.saveEx();
 		}
 		//

--- a/org.adempiere.base/src/org/compiere/model/MAssetAddition.java
+++ b/org.adempiere.base/src/org/compiere/model/MAssetAddition.java
@@ -147,18 +147,30 @@ public class MAssetAddition extends X_A_Asset_Addition
 	 */
 	public static MAssetAddition createAsset(MMatchInv match)
 	{
-		return createAssets(match).get(0);
+		return createAssetAdditions(match).get(0);
 	}
 
 	/**
-	 * Create assets and asset additions from a match invoice.
+	 * Create asset additions and assets from a match invoice.
 	 * When the effective asset group is configured for one asset per UOM,
 	 * one asset and addition is created for every matched unit.
 	 * @param match match invoice
 	 * @return created asset additions, or existing additions for the match
 	 */
-	public static List<MAssetAddition> createAssets(MMatchInv match)
+	public static List<MAssetAddition> createAssetAdditions(MMatchInv match)
 	{
+		if (match.isReversal())
+			throw new AssetException("@Invalid@ @M_MatchInv_ID@=" + match.getM_MatchInv_ID()
+					+ " (@Reversal_ID@)");
+
+		// Serialize creation for the same match. The existence check alone does not
+		// protect against a process and the model event running concurrently.
+		new Query(match.getCtx(), MMatchInv.Table_Name,
+				MMatchInv.COLUMNNAME_M_MatchInv_ID + "=?", match.get_TrxName())
+				.setParameters(match.getM_MatchInv_ID())
+				.setForUpdate(true)
+				.first();
+
 		List<MAssetAddition> existingAdditions = new Query(match.getCtx(), Table_Name,
 				COLUMNNAME_M_MatchInv_ID + "=?", match.get_TrxName())
 				.setParameters(match.getM_MatchInv_ID())
@@ -171,7 +183,9 @@ public class MAssetAddition extends X_A_Asset_Addition
 		int assetGroupId = invLine.getA_Asset_Group_ID();
 		if (assetGroupId <= 0)
 			assetGroupId = MProduct.get(match.getCtx(), match.getM_Product_ID()).getA_Asset_Group_ID();
-		MAssetGroup assetGroup = MAssetGroup.get(match.getCtx(), assetGroupId);
+		MAssetGroup assetGroup = assetGroupId > 0
+				? new MAssetGroup(match.getCtx(), assetGroupId, match.get_TrxName())
+				: null;
 		boolean oneAssetPerUOM = assetGroup != null && assetGroup.isOneAssetPerUOM();
 
 		int additionCount = 1;
@@ -191,10 +205,7 @@ public class MAssetAddition extends X_A_Asset_Addition
 			}
 		}
 
-		BigDecimal matchNetAmt = DB.getSQLValueBD(match.get_TrxName(),
-				"SELECT MatchNetAmt FROM mb_matchinv WHERE M_MatchInv_ID=?", match.getM_MatchInv_ID());
-		if (matchNetAmt == null)
-			throw new AssetException("@NotFound@ MatchNetAmt, @M_MatchInv_ID@=" + match.getM_MatchInv_ID());
+		BigDecimal matchNetAmt = getMatchNetAmt(match);
 
 		int precision = new MCurrency(match.getCtx(), invLine.getParent().getC_Currency_ID(),
 				match.get_TrxName()).getStdPrecision();
@@ -204,10 +215,13 @@ public class MAssetAddition extends X_A_Asset_Addition
 		for (int i = 1; i <= additionCount; i++)
 		{
 			BigDecimal amount = i == additionCount ? matchNetAmt.subtract(allocatedAmt) : additionAmt;
-			MAssetAddition assetAdd = new MAssetAddition(match);
+			MAssetAddition assetAdd = new MAssetAddition(match, matchNetAmt);
 			assetAdd.setSourceAmt(amount);
 			if (oneAssetPerUOM)
+			{
+				assetAdd.setA_CreateAsset(true);
 				assetAdd.setA_QTY_Current(Env.ONE);
+			}
 			createAsset(assetAdd, invLine, oneAssetPerUOM ? i : 0);
 			additions.add(assetAdd);
 			allocatedAmt = allocatedAmt.add(amount);
@@ -226,7 +240,7 @@ public class MAssetAddition extends X_A_Asset_Addition
 		assetAdd.dump();
 		//@win add condition to prevent asset creation when expense addition or second addition
 		if (A_CAPVSEXP_Capital.equals(assetAdd.getA_CapvsExp())
-				&& invLine.getA_Asset_ID() == 0 && assetAdd.isA_CreateAsset())
+				&& (sequence > 0 || invLine.getA_Asset_ID() == 0) && assetAdd.isA_CreateAsset())
 		{
 			//end @win add condition to prevent asset creation when expense addition or second addition
 			MAsset asset = assetAdd.createAsset();
@@ -258,9 +272,30 @@ public class MAssetAddition extends X_A_Asset_Addition
 	{
 		String suffix = "-" + sequence;
 		int fieldLength = POInfo.getPOInfo(asset.getCtx(), MAsset.Table_ID).getFieldLength(columnName);
+		if (value == null)
+			value = "";
 		if (fieldLength > 0 && value.length() + suffix.length() > fieldLength)
-			value = value.substring(0, fieldLength - suffix.length());
+			value = value.substring(0, Math.max(0, fieldLength - suffix.length()));
 		return value + suffix;
+	}
+
+	/**
+	 * Get the amount represented by a match invoice.
+	 * @param match match invoice
+	 * @return match net amount
+	 */
+	private static BigDecimal getMatchNetAmt(MMatchInv match)
+	{
+		MInvoiceLine invoiceLine = new MInvoiceLine(match.getCtx(), match.getC_InvoiceLine_ID(),
+				match.get_TrxName());
+		BigDecimal qtyInvoiced = invoiceLine.getQtyInvoiced();
+		if (qtyInvoiced == null || qtyInvoiced.signum() == 0)
+			throw new AssetException("@Invalid@ @QtyInvoiced@=" + qtyInvoiced
+					+ ", @C_InvoiceLine_ID@=" + invoiceLine.getC_InvoiceLine_ID());
+
+		int precision = invoiceLine.getParent().getC_Currency().getStdPrecision();
+		return invoiceLine.getLineNetAmt().multiply(match.getQty())
+				.divide(qtyInvoiced, precision, RoundingMode.HALF_UP);
 	}
 	
 	/**
@@ -360,8 +395,18 @@ public class MAssetAddition extends X_A_Asset_Addition
 	 */
 	private MAssetAddition (MMatchInv match)
 	{
+		this(match, getMatchNetAmt(match));
+	}
+
+	/**
+	 * Construct an addition from a match invoice with its already resolved amount.
+	 * @param match match invoice
+	 * @param matchNetAmt amount represented by the match
+	 */
+	private MAssetAddition (MMatchInv match, BigDecimal matchNetAmt)
+	{
 		this(match.getCtx(), 0, match.get_TrxName());
-		setM_MatchInv(match);
+		setM_MatchInv(match, matchNetAmt);
 		setC_DocType_ID();
 	}
 	
@@ -473,7 +518,7 @@ public class MAssetAddition extends X_A_Asset_Addition
 	/**
 	 * @param mi
 	 */
-	private void setM_MatchInv(MMatchInv mi)
+	private void setM_MatchInv(MMatchInv mi, BigDecimal matchNetAmt)
 	{
 		mi.load(get_TrxName());
 		setAD_Org_ID(mi.getAD_Org_ID());
@@ -496,10 +541,7 @@ public class MAssetAddition extends X_A_Asset_Addition
 		setLine(invLine.getLine());
 		setM_Locator_ID(mi.getM_InOutLine().getM_Locator_ID());
 		setA_CapvsExp(invLine.getA_CapvsExp());
-		BigDecimal matchNetAmt = DB.getSQLValueBD(get_TrxName(),
-				"SELECT MatchNetAmt FROM mb_matchinv WHERE M_MatchInv_ID=?", mi.getM_MatchInv_ID());
-		setAssetAmtEntered(matchNetAmt);
-		setAssetSourceAmt(matchNetAmt);
+		setSourceAmt(matchNetAmt);
 		setC_Currency_ID(invLine.getParent().getC_Currency_ID());
 		setC_ConversionType_ID(invLine.getParent().getC_ConversionType_ID());
 		setDateDoc(mi.getM_InOutLine().getParent().getMovementDate());
@@ -1140,35 +1182,13 @@ public class MAssetAddition extends X_A_Asset_Addition
 		}
 		final String sourceType = getA_SourceType();
 		//
-		// Invoice: mark C_InvoiceLine.A_Processed='Y' and set C_InvoiceLine.A_Asset_ID
-		if (A_SOURCETYPE_Invoice.equals(sourceType) && isProcessed())
+		// Invoice: reconcile the line against all of its active asset additions.
+		if (A_SOURCETYPE_Invoice.equals(sourceType))
 		{
 			int C_InvoiceLine_ID = getC_InvoiceLine_ID();
 			if (C_InvoiceLine_ID == 0)
 				throw new AdempiereException("No Invoice Line");
-			MInvoiceLine invoiceLine = new MInvoiceLine(getCtx(), C_InvoiceLine_ID, get_TrxName());
-			invoiceLine.setA_Processed(!isReversal);
-			if (isReversal)
-			{
-				if (invoiceLine.getA_Asset_ID() == getA_Asset_ID())
-					invoiceLine.setA_Asset_ID(0);
-			}
-			else if (invoiceLine.getA_Asset_ID() == 0)
-			{
-				int assetId = getA_Asset_ID();
-				if (getM_MatchInv_ID() > 0)
-				{
-					MAssetAddition firstAddition = new Query(getCtx(), Table_Name,
-							COLUMNNAME_M_MatchInv_ID + "=? AND " + COLUMNNAME_A_Asset_ID + ">0", get_TrxName())
-							.setParameters(getM_MatchInv_ID())
-							.setOrderBy(COLUMNNAME_A_Asset_Addition_ID)
-							.first();
-					if (firstAddition != null)
-						assetId = firstAddition.getA_Asset_ID();
-				}
-				invoiceLine.setA_Asset_ID(assetId);
-			}
-			invoiceLine.saveEx();
+			reconcileInvoiceLine(C_InvoiceLine_ID, isReversal ? getA_Asset_Addition_ID() : 0);
 		}
 		//
 		// Project
@@ -1219,6 +1239,47 @@ public class MAssetAddition extends X_A_Asset_Addition
 			if (log.isLoggable(Level.FINE))
 				log.fine("Nothing to do");
 		}
+	}
+
+	/**
+	 * Recalculate the fixed asset processing state of an invoice line from all
+	 * active additions. The optional excluded addition is used while a reversal
+	 * is in progress and its new document status has not been saved yet.
+	 * @param C_InvoiceLine_ID invoice line
+	 * @param excludedAdditionId addition currently being reversed, or zero
+	 */
+	private void reconcileInvoiceLine(int C_InvoiceLine_ID, int excludedAdditionId)
+	{
+		StringBuilder whereClause = new StringBuilder(COLUMNNAME_C_InvoiceLine_ID)
+				.append("=? AND IsActive='Y' AND DocStatus NOT IN ('")
+				.append(DOCSTATUS_Reversed).append("','").append(DOCSTATUS_Voided).append("')");
+		if (excludedAdditionId > 0)
+			whereClause.append(" AND ").append(COLUMNNAME_A_Asset_Addition_ID).append("<>?");
+
+		Query query = new Query(getCtx(), Table_Name, whereClause.toString(), get_TrxName())
+				.setOrderBy(COLUMNNAME_A_Asset_Addition_ID);
+		if (excludedAdditionId > 0)
+			query.setParameters(C_InvoiceLine_ID, excludedAdditionId);
+		else
+			query.setParameters(C_InvoiceLine_ID);
+
+		List<MAssetAddition> additions = query.list();
+		boolean allProcessed = !additions.isEmpty();
+		int firstProcessedAssetId = 0;
+		for (MAssetAddition addition : additions)
+		{
+			boolean completed = addition.isProcessed()
+					&& (DOCSTATUS_Completed.equals(addition.getDocStatus())
+							|| DOCSTATUS_Closed.equals(addition.getDocStatus()));
+			allProcessed &= completed;
+			if (completed && firstProcessedAssetId == 0)
+				firstProcessedAssetId = addition.getA_Asset_ID();
+		}
+
+		MInvoiceLine invoiceLine = new MInvoiceLine(getCtx(), C_InvoiceLine_ID, get_TrxName());
+		invoiceLine.setA_Processed(allProcessed);
+		invoiceLine.setA_Asset_ID(firstProcessedAssetId);
+		invoiceLine.saveEx();
 	}
 	
 	/**

--- a/org.adempiere.base/src/org/idempiere/fa/model/ModelValidator.java
+++ b/org.adempiere.base/src/org/idempiere/fa/model/ModelValidator.java
@@ -85,14 +85,12 @@ implements org.compiere.model.ModelValidator
 						|| (TYPE_AFTER_CHANGE == type && po.is_ValueChanged(MMatchInv.COLUMNNAME_Processed))))
 		{
 			MMatchInv mi = (MMatchInv)po;
-			if (mi.isProcessed())
+			if (mi.isProcessed() && !mi.isReversal())
 			{
 				MInvoiceLine invoiceLine = new MInvoiceLine(mi.getCtx(), mi.getC_InvoiceLine_ID(), mi.get_TrxName());
-				if (invoiceLine.isA_CreateAsset()
-						&& !invoiceLine.isA_Processed()
-					)
+				if (invoiceLine.isA_CreateAsset())
 				{
-					MAssetAddition.createAsset(mi);
+					MAssetAddition.createAssetAdditions(mi);
 				}
 			}
 		}

--- a/org.adempiere.base/src/org/idempiere/fa/process/A_Asset_CreateFromMatchInv.java
+++ b/org.adempiere.base/src/org/idempiere/fa/process/A_Asset_CreateFromMatchInv.java
@@ -21,6 +21,8 @@
  **********************************************************************/
 package org.idempiere.fa.process;
 
+import java.util.List;
+
 import org.compiere.model.MAssetAddition;
 import org.compiere.model.MMatchInv;
 import org.compiere.model.MProcessPara;
@@ -62,8 +64,11 @@ public class A_Asset_CreateFromMatchInv extends SvrProcess {
 		if (match == null || match.get_ID() <= 0) {
 			throw new AssetException("@NotFound@ @M_MatchInv_ID@=" + match + "(ID="+p_M_MatchInv_ID+")");
 		}
-		MAssetAddition assetAdd = MAssetAddition.createAsset(match);
+		if (match.isReversal())
+			throw new AssetException("@Invalid@ @M_MatchInv_ID@=" + match.getM_MatchInv_ID()
+					+ " (@Reversal_ID@)");
+		List<MAssetAddition> assetAdditions = MAssetAddition.createAssetAdditions(match);
 		
-		return "@A_Asset_Addition_ID@ - " + assetAdd;
+		return "@A_Asset_Addition_ID@ - " + assetAdditions;
 	}
 }

--- a/org.idempiere.test/src/org/idempiere/test/model/FixedAssetsTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/FixedAssetsTest.java
@@ -30,15 +30,33 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Properties;
 
 import org.compiere.model.MAsset;
 import org.compiere.model.MAssetAddition;
+import org.compiere.model.MAssetGroup;
 import org.compiere.model.MAssetGroupAcct;
+import org.compiere.model.MBPartner;
+import org.compiere.model.MInOut;
+import org.compiere.model.MInOutLine;
+import org.compiere.model.MInvoice;
+import org.compiere.model.MInvoiceLine;
+import org.compiere.model.MMatchInv;
+import org.compiere.model.MOrder;
+import org.compiere.model.MOrderLine;
+import org.compiere.model.MPriceList;
+import org.compiere.model.MPriceListVersion;
+import org.compiere.model.MProduct;
+import org.compiere.model.MProductPrice;
+import org.compiere.model.MWarehouse;
+import org.compiere.model.Query;
 import org.compiere.process.DocAction;
 import org.compiere.process.ProcessInfo;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
+import org.compiere.util.TimeUtil;
 import org.compiere.wf.MWorkflow;
 import org.idempiere.test.AbstractTestCase;
 import org.idempiere.test.DictionaryIDs;
@@ -47,6 +65,100 @@ import org.junit.jupiter.api.Test;
 public class FixedAssetsTest extends AbstractTestCase {
 
 	public FixedAssetsTest() {
+	}
+
+	/**
+	 * IDEMPIERE-3763 - create one fixed asset per matched UOM.
+	 */
+	@Test
+	public void testCreateOneAssetPerMatchedUOM() {
+		Properties ctx = Env.getCtx();
+		String trxName = getTrxName();
+		BigDecimal qty = new BigDecimal("3");
+		BigDecimal unitPrice = new BigDecimal("100");
+		Timestamp today = TimeUtil.getDay(System.currentTimeMillis());
+
+		MProduct product = MProduct.get(ctx, DictionaryIDs.M_Product.ASSET_VEHICLE.id);
+		MAssetGroup assetGroup = new MAssetGroup(ctx, product.getA_Asset_Group_ID(), trxName);
+		assetGroup.setIsOneAssetPerUOM(true);
+		assetGroup.saveEx();
+
+		MPriceListVersion priceListVersion = MPriceList.get(DictionaryIDs.M_PriceList.PURCHASE.id)
+				.getPriceListVersion(today);
+		MProductPrice productPrice = new MProductPrice(ctx, 0, trxName);
+		productPrice.setM_PriceList_Version_ID(priceListVersion.get_ID());
+		productPrice.setM_Product_ID(product.get_ID());
+		productPrice.setPrices(unitPrice, unitPrice, unitPrice);
+		productPrice.saveEx();
+
+		MOrder order = new MOrder(ctx, 0, trxName);
+		order.setBPartner(MBPartner.get(ctx, DictionaryIDs.C_BPartner.PATIO.id));
+		order.setC_DocTypeTarget_ID(DictionaryIDs.C_DocType.PURCHASE_ORDER.id);
+		order.setIsSOTrx(false);
+		order.setSalesRep_ID(DictionaryIDs.AD_User.GARDEN_ADMIN.id);
+		order.setDateOrdered(today);
+		order.setDatePromised(today);
+		order.setDocStatus(DocAction.STATUS_Drafted);
+		order.setDocAction(DocAction.ACTION_Complete);
+		order.saveEx();
+
+		MOrderLine orderLine = new MOrderLine(order);
+		orderLine.setLine(10);
+		orderLine.setProduct(product);
+		orderLine.setQty(qty);
+		orderLine.setPrice(unitPrice);
+		orderLine.setDatePromised(today);
+		orderLine.saveEx();
+
+		MInOut receipt = new MInOut(order, DictionaryIDs.C_DocType.MM_RECEIPT.id, today);
+		receipt.setDocStatus(DocAction.STATUS_Drafted);
+		receipt.setDocAction(DocAction.ACTION_Complete);
+		receipt.saveEx();
+
+		MInOutLine receiptLine = new MInOutLine(receipt);
+		receiptLine.setOrderLine(orderLine, 0, qty);
+		receiptLine.setQty(qty);
+		receiptLine.setM_Locator_ID(MWarehouse.get(ctx, receipt.getM_Warehouse_ID()).getDefaultLocator().get_ID());
+		receiptLine.saveEx();
+
+		MInvoice invoice = new MInvoice(receipt, today);
+		invoice.setC_DocTypeTarget_ID(DictionaryIDs.C_DocType.AP_INVOICE.id);
+		invoice.setC_ConversionType_ID(DictionaryIDs.C_ConversionType.SPOT.id);
+		invoice.setDocStatus(DocAction.STATUS_Drafted);
+		invoice.setDocAction(DocAction.ACTION_Complete);
+		invoice.saveEx();
+
+		MInvoiceLine invoiceLine = new MInvoiceLine(invoice);
+		invoiceLine.setM_InOutLine_ID(receiptLine.get_ID());
+		invoiceLine.setLine(10);
+		invoiceLine.setProduct(product);
+		invoiceLine.setQty(qty);
+		invoiceLine.setPrice(unitPrice);
+		invoiceLine.setA_CapvsExp(MAssetAddition.A_CAPVSEXP_Capital);
+		invoiceLine.setA_CreateAsset(true);
+		invoiceLine.saveEx();
+
+		MMatchInv match = new MMatchInv(invoiceLine, today, qty);
+		match.saveEx();
+
+		MMatchInv[] matches = MMatchInv.getInvoiceLine(ctx, invoiceLine.get_ID(), trxName);
+		assertEquals(1, matches.length);
+		List<MAssetAddition> additions = MAssetAddition.createAssetAdditions(matches[0]);
+		assertEquals(3, additions.size());
+		assertEquals(3, new HashSet<>(additions.stream().map(MAssetAddition::getA_Asset_ID).toList()).size());
+		assertTrue(additions.stream().allMatch(addition -> Env.ONE.compareTo(addition.getA_QTY_Current()) == 0));
+		assertEquals(0, invoiceLine.getLineNetAmt().compareTo(
+				additions.stream().map(MAssetAddition::getAssetSourceAmt).reduce(Env.ZERO, BigDecimal::add)));
+
+		List<MAssetAddition> repeated = MAssetAddition.createAssetAdditions(matches[0]);
+		assertEquals(additions.stream().map(MAssetAddition::get_ID).toList(),
+				repeated.stream().map(MAssetAddition::get_ID).toList());
+
+		List<MAssetAddition> persisted = new Query(ctx, MAssetAddition.Table_Name,
+				MAssetAddition.COLUMNNAME_M_MatchInv_ID + "=?", trxName)
+				.setParameters(matches[0].get_ID())
+				.list();
+		assertEquals(3, persisted.size());
 	}
 
 	/**


### PR DESCRIPTION
## Description

Asset creation from vendor invoice matches now respects IsOneAssetPerUOM from the effective asset group without restricting purchase order line quantities to one.

JIRA: https://idempiere.atlassian.net/browse/IDEMPIERE-3763

## Changes

- Use the invoice-line asset group, falling back to the product asset group.
- Create one asset addition and one asset for every matched unit when IsOneAssetPerUOM is enabled.
- Keep the existing single-asset behavior when the option is disabled.
- Support partial invoice matches by deriving the matched net amount from standard invoice and match models.
- Split matched amounts using currency precision and assign rounding differences to the last addition.
- Reject fractional and non-positive matched quantities for one-asset-per-UOM groups.
- Add sequence suffixes to generated asset names and values.
- Serialize processing of the same M_MatchInv row and return existing additions on repeated execution.
- Ignore reversal matches and reconcile C_InvoiceLine.A_Processed and A_Asset_ID from all active additions.
- Preserve compatibility through createAsset(MMatchInv), delegating to the plural creation method.

## Validation

- Added FixedAssetsTest.testCreateOneAssetPerMatchedUOM with purchase order quantity three.
- Verified creation of three distinct assets and additions, unit quantities, total source amount, and idempotent reprocessing.
- FixedAssetsTest: 2 tests, 0 failures, 0 errors.
- Full Maven reactor: 61 modules, BUILD SUCCESS.
- Git whitespace validation passes with CRLF-aware settings.
