### PR TITLE
IDEMPIERE-7084 Use node-local connector for WebSocket AU requests

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/EndpointConfigurator.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/EndpointConfigurator.java
@@ -40,6 +40,13 @@ import org.apache.hc.client5.http.impl.cookie.BasicClientCookie;
 
 public class EndpointConfigurator extends ServerEndpointConfig.Configurator {
 
+	/**
+	 * Resolve the node-local HTTP base URI used to forward WebSocket events.
+	 *
+	 * @param httpSession HTTP session containing the per-desktop connector URI
+	 * @param request WebSocket handshake request
+	 * @return node-local base URI, or a localhost compatibility URI
+	 */
 	static URI getInternalBaseUri(HttpSession httpSession, HandshakeRequest request) {
 		URI requestUri = request.getRequestURI();
 		if (httpSession != null && requestUri != null) {
@@ -72,6 +79,7 @@ public class EndpointConfigurator extends ServerEndpointConfig.Configurator {
 		}
 	}
 
+	/** {@inheritDoc} */
 	@Override
     public void modifyHandshake(ServerEndpointConfig sec, HandshakeRequest request, HandshakeResponse response) {
         // Store the ServletContext, HttpSession and remote address in user properties for the ServerPushEndPoint to access

--- a/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/EndpointConfigurator.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/EndpointConfigurator.java
@@ -58,8 +58,9 @@ public class EndpointConfigurator extends ServerEndpointConfig.Configurator {
 				if (value instanceof String localBaseUrl) {
 					try {
 						URI uri = URI.create(localBaseUrl);
+						int port = uri.getPort();
 						if (("http".equals(uri.getScheme()) || "https".equals(uri.getScheme()))
-								&& uri.getHost() != null && uri.getPort() > 0)
+								&& uri.getHost() != null && (port == -1 || port > 0))
 							return uri;
 					} catch (IllegalArgumentException e) {
 						// Ignore invalid session data and use the compatibility fallback below.

--- a/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/EndpointConfigurator.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/EndpointConfigurator.java
@@ -24,6 +24,8 @@
  **********************************************************************/
 package org.idempiere.ui.zk.websocket;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 
@@ -37,6 +39,38 @@ import org.apache.hc.client5.http.cookie.BasicCookieStore;
 import org.apache.hc.client5.http.impl.cookie.BasicClientCookie;
 
 public class EndpointConfigurator extends ServerEndpointConfig.Configurator {
+
+	static URI getInternalBaseUri(HttpSession httpSession, HandshakeRequest request) {
+		URI requestUri = request.getRequestURI();
+		if (httpSession != null && requestUri != null) {
+			String path = requestUri.getPath();
+			int separator = path != null ? path.lastIndexOf('/') : -1;
+			if (separator >= 0 && separator + 1 < path.length()) {
+				String desktopId = path.substring(separator + 1);
+				Object value = httpSession.getAttribute(WebSocketServerPush.getLocalBaseUrlAttribute(desktopId));
+				if (value instanceof String localBaseUrl) {
+					try {
+						URI uri = URI.create(localBaseUrl);
+						if (("http".equals(uri.getScheme()) || "https".equals(uri.getScheme()))
+								&& uri.getHost() != null && uri.getPort() > 0)
+							return uri;
+					} catch (IllegalArgumentException e) {
+						// Ignore invalid session data and use the compatibility fallback below.
+					}
+				}
+			}
+		}
+
+		// Compatibility fallback for desktops created before this code was deployed.
+		String scheme = requestUri != null && ("wss".equalsIgnoreCase(requestUri.getScheme())
+				|| "https".equalsIgnoreCase(requestUri.getScheme())) ? "https" : "http";
+		int port = requestUri != null ? requestUri.getPort() : -1;
+		try {
+			return new URI(scheme, null, "localhost", port, null, null, null);
+		} catch (URISyntaxException e) {
+			throw new IllegalArgumentException("Unable to build the internal server push URL", e);
+		}
+	}
 
 	@Override
     public void modifyHandshake(ServerEndpointConfig sec, HandshakeRequest request, HandshakeResponse response) {
@@ -52,6 +86,8 @@ public class EndpointConfigurator extends ServerEndpointConfig.Configurator {
             sec.getUserProperties().put(HttpSession.class.getName(), httpSession);
             sec.getUserProperties().put(ServletContext.class.getName(), httpSession.getServletContext());
             sec.getUserProperties().put(HandshakeRequest.class.getName(), request);
+			URI internalBaseUri = getInternalBaseUri(httpSession, request);
+			sec.getUserProperties().put(WebSocketServerPush.WS_LOCAL_BASE_URL, internalBaseUri);
 
             //create BasicCookieStore from request
             Map<String, List<String>> headers = request.getHeaders();
@@ -60,6 +96,7 @@ public class EndpointConfigurator extends ServerEndpointConfig.Configurator {
             	cookieHeaders = headers.get("cookie");
             if (cookieHeaders != null && !cookieHeaders.isEmpty()) {
             	BasicCookieStore cookieStore = new BasicCookieStore();
+	            String requestHost = internalBaseUri.getHost();
             	for(String cookieHeader : cookieHeaders) {
             		String[] cookies = cookieHeader.split(";");
                     for (String cookie : cookies) {
@@ -68,8 +105,7 @@ public class EndpointConfigurator extends ServerEndpointConfig.Configurator {
                         	String name = pair[0].trim();
                         	String value = pair[1].trim();
                         	BasicClientCookie c = new BasicClientCookie(name, value);
-                            // localhost domain for internal request cookies
-                            c.setDomain("localhost");
+	                        c.setDomain(requestHost);
                         	cookieStore.addCookie(c);
                         }
                     }

--- a/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/ServerPushEndPoint.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/ServerPushEndPoint.java
@@ -104,6 +104,14 @@ public class ServerPushEndPoint {
 		}
 	}
 
+	/**
+	 * Initialize the endpoint with the node-local connector URI captured for the desktop.
+	 *
+	 * @param sess WebSocket session
+	 * @param config endpoint configuration populated during the handshake
+	 * @param dtid ZK desktop identifier
+	 * @throws IOException if endpoint initialization fails
+	 */
 	@OnOpen
 	public void onOpen(Session sess, EndpointConfig config, @PathParam("dtid") String dtid) throws IOException {
 		if (!Util.isEmpty(dtid, true) && WebSocketServerPush.isValidDesktopId(dtid)) {			

--- a/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/ServerPushEndPoint.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/ServerPushEndPoint.java
@@ -96,6 +96,12 @@ public class ServerPushEndPoint {
 	public ServerPushEndPoint() {
 	}
 	
+	/**
+	 * Unregister this endpoint when its WebSocket session closes.
+	 *
+	 * @param sess WebSocket session
+	 * @throws IOException if closing the endpoint fails
+	 */
 	@OnClose
 	public void onClose(Session sess) throws IOException {
 		if (this.session != null) {
@@ -147,6 +153,12 @@ public class ServerPushEndPoint {
 		}
 	}
 
+	/**
+	 * Log an error raised by the WebSocket container.
+	 *
+	 * @param sess WebSocket session
+	 * @param throwable reported error
+	 */
 	@OnError
 	public void onError(Session sess, Throwable throwable) {
 		CLogger.getCLogger(getClass()).log(Level.WARNING, throwable.getMessage(), throwable);	
@@ -370,6 +382,11 @@ public class ServerPushEndPoint {
 				.build();
 	}
 	
+	/**
+	 * Create the HTTP client used to forward AU requests to the local connector.
+	 *
+	 * @return configured HTTP client
+	 */
 	private CloseableHttpClient createHttpClient() {
 		try {
 			//use basic instead of pooling connection manager to avoid connection leak, as http client instance is created per each au request

--- a/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/ServerPushEndPoint.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/ServerPushEndPoint.java
@@ -84,6 +84,7 @@ public class ServerPushEndPoint {
 	private String dtid;
 	private HttpSession httpSession;
 	private String baseUrl;
+	private String requestHost;
 	private Map<String, List<String>> requestHeaders;
 	private BasicCookieStore cookieStore;
 
@@ -117,22 +118,13 @@ public class ServerPushEndPoint {
 			
 			HandshakeRequest handshakeRequest = (HandshakeRequest) config.getUserProperties().get(HandshakeRequest.class.getName());
 
-			// Build the Base URL dynamically
+			// Use the actual connector address captured on this node when server push started.
 	        if (handshakeRequest != null) {
-	            URI requestUri = handshakeRequest.getRequestURI();
-
-	            // Map ws -> http and wss -> https
-	            String scheme = "wss".equalsIgnoreCase(requestUri.getScheme()) || "https".equalsIgnoreCase(requestUri.getScheme()) ? "https" : "http";
-	            String host = "localhost";
-	            int port = requestUri.getPort();
-
-	            // Construct the base URL, handling default ports
-	            StringBuilder urlBuilder = new StringBuilder();
-	            urlBuilder.append(scheme).append("://").append(host);
-	            if (port != -1 && !((scheme.equals("http") && port == 80) || (scheme.equals("https") && port == 443))) {
-	                urlBuilder.append(":").append(port);
-	            }
-	            this.baseUrl = urlBuilder.toString();
+				URI internalBaseUri = (URI) config.getUserProperties().get(WebSocketServerPush.WS_LOCAL_BASE_URL);
+				if (internalBaseUri == null)
+					internalBaseUri = EndpointConfigurator.getInternalBaseUri(httpSession, handshakeRequest);
+	            this.baseUrl = internalBaseUri.toASCIIString();
+	            this.requestHost = internalBaseUri.getHost();
 	            this.requestHeaders = handshakeRequest.getHeaders();
 	            if (!this.requestHeaders.containsKey("X-Forwarded-For")) {
 	            	Object ipAttr = config.getUserProperties().get(WebSocketServerPush.WS_CLIENT_IP);
@@ -215,11 +207,11 @@ public class ServerPushEndPoint {
 				        httpPost.setHeader("ZK-SID", sid);
 				        httpPost.setHeader("Pragma", "no-cache");
 				        httpPost.setHeader("Cache-Control", "no-cache");
-				        if (cookieStore != null) {
-				        	BasicClientCookie cookie = new BasicClientCookie("JSESSIONID", sessionId);
-							cookie.setDomain("localhost");
-				        	cookieStore.addCookie(cookie);
-				        }
+						if (cookieStore != null) {
+							BasicClientCookie cookie = new BasicClientCookie("JSESSIONID", sessionId);
+							cookie.setDomain(requestHost);
+							cookieStore.addCookie(cookie);
+						}
 				        requestHeaders.forEach((key, values) -> {
 				        	// Forward selected headers
 				        	if ("User-Agent".equalsIgnoreCase(key) || "Accept-Language".equalsIgnoreCase(key) 
@@ -254,9 +246,9 @@ public class ServerPushEndPoint {
 											String[] cookieElements = value.split(";");
 											String[] pair = cookieElements[0].split("=", 2);
 											if (pair.length == 2) {
-												//localhost for internal request, no domain for browser cookie
+												// Internal request cookie uses the node-local host; browser cookie has no domain.
 												BasicClientCookie cookie = new BasicClientCookie(pair[0].trim(), pair[1].trim());
-												cookie.setDomain("localhost");
+												cookie.setDomain(requestHost);
 												
 												if (responseCookieStore == null) {
 													responseCookieStore = new BasicCookieStore();

--- a/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/WebSocketServerPush.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/WebSocketServerPush.java
@@ -403,6 +403,11 @@ public class WebSocketServerPush implements ServerPush {
 		return WS_LOCAL_BASE_URL + "." + desktopId;
 	}
 
+	/**
+	 * Notify the browser to open the WebSocket server-push connection.
+	 *
+	 * @param desktop ZK desktop to connect
+	 */
 	private void startServerPushAtClient(Desktop desktop) {
 		Clients.response("org.idempiere.websocket.serverpush.start", new AuScript(null, "org.idempiere.websocket.startServerPush('" + desktop.getId() + "');"));
 	}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/WebSocketServerPush.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/WebSocketServerPush.java
@@ -24,6 +24,8 @@
  **********************************************************************/
 package org.idempiere.ui.zk.websocket;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -87,6 +89,10 @@ public class WebSocketServerPush implements ServerPush {
     private AbstractComponent dummyTarget;
     
     protected static final String WS_CLIENT_IP = "ws-client-ip";
+
+    protected static final String WS_LOCAL_BASE_URL = "ws-local-base-url";
+
+    private static final String SSL_CIPHER_SUITE_ATTRIBUTE = "javax.servlet.request.cipher_suite";
 
     private static class OnScheduleEvent extends Event {
 		private static final long serialVersionUID = 1L;
@@ -319,16 +325,20 @@ public class WebSocketServerPush implements ServerPush {
         	log.debug("Starting server push for " + desktop);
         registerEndPoint(desktop.getId(), STUB);
 
-        // Store client IP address in session attribute for later use in EndpointConfigurator
+        // Store connection details in session attributes for later use in EndpointConfigurator
         var execution = Executions.getCurrent();
         if (execution != null) {
         	var request = execution.getNativeRequest();
         	if (request instanceof HttpServletRequest httpRequest) {
-				var clientIp = httpRequest.getRemoteAddr();
-				if (clientIp != null) {
-					var session = desktop.getSession();
-					if (session != null) {
+				var session = desktop.getSession();
+				if (session != null) {
+					var clientIp = httpRequest.getRemoteAddr();
+					if (clientIp != null)
 						session.setAttribute(WS_CLIENT_IP, clientIp);
+
+					String localBaseUrl = getLocalBaseUrl(httpRequest);
+					if (localBaseUrl != null) {
+						session.setAttribute(getLocalBaseUrlAttribute(desktop.getId()), localBaseUrl);
 					}
 				}
 			}
@@ -359,6 +369,27 @@ public class WebSocketServerPush implements ServerPush {
 		desktop.addListener(cookieHandler);
     }
 
+	private String getLocalBaseUrl(HttpServletRequest request) {
+		String localAddress = request.getLocalAddr();
+		int localPort = request.getLocalPort();
+		if (localAddress == null || localAddress.isBlank() || localPort <= 0)
+			return null;
+
+		// Do not use request.getScheme(): a reverse proxy can replace it with the
+		// browser-facing scheme. The standard TLS attribute reflects the local connector.
+		String scheme = request.getAttribute(SSL_CIPHER_SUITE_ATTRIBUTE) != null ? "https" : "http";
+		try {
+			return new URI(scheme, null, localAddress, localPort, null, null, null).toASCIIString();
+		} catch (URISyntaxException e) {
+			log.warn("Unable to build the node-local server push URL", e);
+			return null;
+		}
+	}
+
+	protected static String getLocalBaseUrlAttribute(String desktopId) {
+		return WS_LOCAL_BASE_URL + "." + desktopId;
+	}
+
 	private void startServerPushAtClient(Desktop desktop) {
 		Clients.response("org.idempiere.websocket.serverpush.start", new AuScript(null, "org.idempiere.websocket.startServerPush('" + desktop.getId() + "');"));
 	}
@@ -373,6 +404,9 @@ public class WebSocketServerPush implements ServerPush {
 
         if (log.isDebugEnabled())
         	log.debug("Stopping server push for " + desktop);
+		var session = desktop.getSession();
+		if (session != null)
+			session.removeAttribute(getLocalBaseUrlAttribute(desktop.getId()));
         Clients.response("org.idempiere.websocket.serverpush.stop", new AuScript(null, "org.idempiere.websocket.stopServerPush('" + desktop.getId() + "');"));
     }
 

--- a/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/WebSocketServerPush.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/WebSocketServerPush.java
@@ -313,6 +313,7 @@ public class WebSocketServerPush implements ServerPush {
     	}
     }
     
+	/** {@inheritDoc} */
     @Override
     public void start(Desktop desktop) {
         Desktop oldDesktop = this.desktop.getAndSet(desktop);
@@ -369,6 +370,12 @@ public class WebSocketServerPush implements ServerPush {
 		desktop.addListener(cookieHandler);
     }
 
+	/**
+	 * Build the base URL of the local servlet connector that accepted the request.
+	 *
+	 * @param request current servlet request
+	 * @return node-local base URL, or {@code null} when connector data is unavailable
+	 */
 	private String getLocalBaseUrl(HttpServletRequest request) {
 		String localAddress = request.getLocalAddr();
 		int localPort = request.getLocalPort();
@@ -386,6 +393,12 @@ public class WebSocketServerPush implements ServerPush {
 		}
 	}
 
+	/**
+	 * Build the session attribute name for a desktop's node-local connector URL.
+	 *
+	 * @param desktopId ZK desktop identifier
+	 * @return session attribute name
+	 */
 	protected static String getLocalBaseUrlAttribute(String desktopId) {
 		return WS_LOCAL_BASE_URL + "." + desktopId;
 	}
@@ -394,6 +407,7 @@ public class WebSocketServerPush implements ServerPush {
 		Clients.response("org.idempiere.websocket.serverpush.start", new AuScript(null, "org.idempiere.websocket.startServerPush('" + desktop.getId() + "');"));
 	}
 
+	/** {@inheritDoc} */
     @Override
     public void stop() {
         Desktop desktop = this.desktop.getAndSet(null);


### PR DESCRIPTION
## Description

The WebSocket server-push endpoint forwards ZK AU requests to `/zkau` through an internal HTTP client. That client used `localhost`, which fails when the application server connector is bound only to a non-loopback address. The initial login echo request then never completes and the login fields remain disabled. Switching server push to Atmosphere hides the problem because that implementation does not use this WebSocket forwarding path.

JIRA: https://idempiere.atlassian.net/browse/IDEMPIERE-7084

## Root cause

`ServerPushEndPoint` derived its internal AU URL from the WebSocket request but replaced the host with `localhost`. This assumes that the servlet connector always listens on the loopback interface.

## Changes

- Capture the actual local servlet connector address, port, and transport when WebSocket server push starts.
- Store the node-local base URL per desktop in the HTTP session.
- Use that URL for internal `/zkau` requests and cookie handling.
- Keep a `localhost` compatibility fallback for desktops created before deployment or when connector metadata is unavailable.
- Remove the per-desktop session value when server push stops.
- Build the URL through `URI` so IPv4 and IPv6 addresses are handled correctly.

## Cluster and reverse-proxy behavior

Internal AU requests remain on the node that owns the ZK desktop and do not pass through a load balancer, public hostname, or cluster VIP. The connector transport is determined independently of proxy-rewritten browser-facing request metadata.

## Validation

- Full Maven build including tests passed locally.
- WebSocket login was tested successfully on a connector bound to a non-loopback address.
- `git diff --check upstream/master...HEAD` passes.
- The PR contains only the three WebSocket server-push files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket server-push connectivity across local and remote deployments.
  * Correctly detects the active server host, port, and secure connection settings.
  * Fixed session and response cookie domains to use the active server host instead of `localhost`.
  * Added compatibility handling for invalid or unavailable connection details.
  * Improved connection handling when applications run behind different network configurations or server nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->