### PR TITLE
IDEMPIERE-7086 Restrict purchases to approved vendors

### DIFF
--- a/migration/iD14/oracle/202608271411_IDEMPIERE-7086.sql
+++ b/migration/iD14/oracle/202608271411_IDEMPIERE-7086.sql
@@ -1,0 +1,265 @@
+-- IDEMPIERE-7086 Restrict Purchase of Selected Products to Approved Vendors
+SELECT register_migration_script('202608271411_IDEMPIERE-7086.sql') FROM dual;
+
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- Aug 27, 2026, 2:11:45 PM CEST
+INSERT INTO AD_Reference (AD_Reference_ID,Name,Description,Help,ValidationType,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,IsOrderByValue,AD_Reference_UU,ShowInactive) VALUES (200289,'Approved Vendor Requirement','Determines whether purchasing this product requires an approved vendor.','Use Product Category applies the approved-vendor requirement defined by the product category. Required allows the product to be purchased only from vendors explicitly approved for it. Not Required permits purchasing from any vendor, regardless of the product-category setting.','L',0,0,'Y',TO_TIMESTAMP('2026-08-27 14:11:45','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:11:45','YYYY-MM-DD HH24:MI:SS'),100,'D','N','01a04322-2332-79e1-a48b-d6cf1084c1dc','N')
+;
+
+-- Aug 27, 2026, 2:12:32 PM CEST
+INSERT INTO AD_Ref_List (AD_Ref_List_ID,Name,Description,AD_Reference_ID,Value,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,AD_Ref_List_UU) VALUES (200779,'Use Product Category','Apply the approved-vendor requirement defined by the product category.',200289,'C',0,0,'Y',TO_TIMESTAMP('2026-08-27 14:12:32','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:12:32','YYYY-MM-DD HH24:MI:SS'),100,'D','01a04322-d92b-7e1b-9bff-c8cf4835854c')
+;
+
+-- Aug 27, 2026, 2:13:18 PM CEST
+INSERT INTO AD_Ref_List (AD_Ref_List_ID,Name,Description,AD_Reference_ID,Value,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,AD_Ref_List_UU) VALUES (200780,'Required','The product may only be purchased from an approved vendor.',200289,'Y',0,0,'Y',TO_TIMESTAMP('2026-08-27 14:13:17','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:13:17','YYYY-MM-DD HH24:MI:SS'),100,'D','01a04323-8b50-753d-9bfa-3df870346f17')
+;
+
+-- Aug 27, 2026, 2:14:39 PM CEST
+INSERT INTO AD_Ref_List (AD_Ref_List_ID,Name,Description,AD_Reference_ID,Value,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,AD_Ref_List_UU) VALUES (200781,'Not Required','The product may be purchased without an approved-vendor restriction.',200289,'N',0,0,'Y',TO_TIMESTAMP('2026-08-27 14:14:39','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:14:39','YYYY-MM-DD HH24:MI:SS'),100,'D','01a04324-ca42-74e1-b3db-c63197123e05')
+;
+
+-- Aug 27, 2026, 2:18:09 PM CEST
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,ColumnName,Name,Description,Help,PrintName,EntityType,AD_Element_UU) VALUES (204122,0,0,'Y',TO_TIMESTAMP('2026-08-27 14:18:09','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:18:09','YYYY-MM-DD HH24:MI:SS'),100,'IsApprovedVendorRequired','Approved Vendor Required','Products in this category must normally be purchased from an approved vendor.','When selected, products in this category may only be purchased from vendors explicitly approved for the respective product. Individual products can override this setting.','Approved Vendor Required','D','01a04327-fd8b-7112-82f3-445c7bdafc39')
+;
+
+-- Aug 27, 2026, 2:20:49 PM CEST
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,ColumnName,Name,Description,Help,PrintName,EntityType,AD_Element_UU) VALUES (204123,0,0,'Y',TO_TIMESTAMP('2026-08-27 14:20:49','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:20:49','YYYY-MM-DD HH24:MI:SS'),100,'ApprovedVendorRequirement','Approved Vendor Requirement','Defines whether an approved vendor is required for purchasing this product.','Determines whether this product may only be purchased from an approved vendor. Use Product Category applies the setting from the product category. Required enforces vendor approval, while Not Required permits purchasing from any vendor.','Approved Vendor Requirement','D','01a0432a-6fbc-7f2c-b1e3-8b05bdefb2d0')
+;
+
+-- Aug 27, 2026, 2:22:46 PM CEST
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,ColumnName,Name,Description,Help,PrintName,EntityType,AD_Element_UU) VALUES (204124,0,0,'Y',TO_TIMESTAMP('2026-08-27 14:22:45','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:22:45','YYYY-MM-DD HH24:MI:SS'),100,'IsApprovedVendor','Approved Vendor','Indicates that this vendor is approved to supply this product when approved vendor purchasing is required.','Select this option to approve the vendor for supplying this product. This setting is independent of Current Vendor. It is evaluated only when the product requires an approved vendor. Inactive or discontinued purchasing records are not considered approved.','Approved Vendor','D','01a0432c-361f-762c-a072-49cab7b24326')
+;
+
+-- Aug 27, 2026, 2:24:59 PM CEST
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,IsHtml,IsPartitionKey) VALUES (217656,0,'Approved Vendor Required','Products in this category must normally be purchased from an approved vendor.','When selected, products in this category may only be purchased from vendors explicitly approved for the respective product. Individual products can override this setting.',209,'IsApprovedVendorRequired','N',1,'N','N','Y','N','N',0,'N',20,0,0,'Y',TO_TIMESTAMP('2026-08-27 14:24:59','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:24:59','YYYY-MM-DD HH24:MI:SS'),100,204122,'Y','N','D','N','N','N','Y','01a0432e-4044-72ec-beee-8d61649b76c0','Y',0,'N','N','N','N')
+;
+
+-- Aug 27, 2026, 2:25:39 PM CEST
+ALTER TABLE M_Product_Category ADD IsApprovedVendorRequired CHAR(1) DEFAULT 'N' CHECK (IsApprovedVendorRequired IN ('Y','N')) NOT NULL
+;
+
+-- Aug 27, 2026, 2:28:39 PM CEST
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Reference_Value_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,IsHtml,IsPartitionKey) VALUES (217657,0,'Approved Vendor Requirement','Defines whether an approved vendor is required for purchasing this product.','Determines whether this product may only be purchased from an approved vendor. Use Product Category applies the setting from the product category. Required enforces vendor approval, while Not Required permits purchasing from any vendor.',208,'ApprovedVendorRequirement','C',1,'N','N','Y','N','N',0,'N',17,200289,0,0,'Y',TO_TIMESTAMP('2026-08-27 14:28:38','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:28:38','YYYY-MM-DD HH24:MI:SS'),100,204123,'Y','N','D','N','N','N','Y','01a04331-9926-78b5-b6f9-26f070f67d8d','Y',0,'N','N','N','N')
+;
+
+-- Aug 27, 2026, 2:29:39 PM CEST
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,IsHtml,IsPartitionKey) VALUES (217658,0,'Approved Vendor','Indicates that this vendor is approved to supply this product when approved vendor purchasing is required.','Select this option to approve the vendor for supplying this product. This setting is independent of Current Vendor. It is evaluated only when the product requires an approved vendor. Inactive or discontinued purchasing records are not considered approved.',210,'IsApprovedVendor','N',1,'N','N','Y','N','N',0,'N',20,0,0,'Y',TO_TIMESTAMP('2026-08-27 14:29:39','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:29:39','YYYY-MM-DD HH24:MI:SS'),100,204124,'Y','N','D','N','N','N','Y','01a04332-86fc-701b-9424-05ab4a8f1a21','Y',0,'N','N','N','N')
+;
+
+-- Aug 27, 2026, 2:29:43 PM CEST
+ALTER TABLE M_Product_PO ADD IsApprovedVendor CHAR(1) DEFAULT 'N' CHECK (IsApprovedVendor IN ('Y','N')) NOT NULL
+;
+
+-- Aug 27, 2026, 2:30:15 PM CEST
+ALTER TABLE M_Product ADD ApprovedVendorRequirement CHAR(1) DEFAULT 'C' NOT NULL
+;
+
+-- Aug 27, 2026, 2:31:14 PM CEST
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan) VALUES (209241,'Approved Vendor Required','Products in this category must normally be purchased from an approved vendor.','When selected, products in this category may only be purchased from vendors explicitly approved for the respective product. Individual products can override this setting.',189,217656,'Y',1,130,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2026-08-27 14:31:13','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:31:13','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','01a04333-f68d-76d4-b52c-d84cb9e534bd','Y',130,2,2)
+;
+
+-- Aug 27, 2026, 2:32:49 PM CEST
+UPDATE AD_Field SET SeqNo=70,Updated=TO_TIMESTAMP('2026-08-27 14:32:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=50181
+;
+
+-- Aug 27, 2026, 2:32:49 PM CEST
+UPDATE AD_Field SET SeqNo=80,Updated=TO_TIMESTAMP('2026-08-27 14:32:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=11203
+;
+
+-- Aug 27, 2026, 2:32:49 PM CEST
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=90, XPosition=5,Updated=TO_TIMESTAMP('2026-08-27 14:32:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=209241
+;
+
+-- Aug 27, 2026, 2:32:49 PM CEST
+UPDATE AD_Field SET SeqNo=100,Updated=TO_TIMESTAMP('2026-08-27 14:32:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=3748
+;
+
+-- Aug 27, 2026, 2:32:49 PM CEST
+UPDATE AD_Field SET SeqNo=110,Updated=TO_TIMESTAMP('2026-08-27 14:32:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=8614
+;
+
+-- Aug 27, 2026, 2:32:49 PM CEST
+UPDATE AD_Field SET SeqNo=120,Updated=TO_TIMESTAMP('2026-08-27 14:32:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=4459
+;
+
+-- Aug 27, 2026, 2:32:49 PM CEST
+UPDATE AD_Field SET SeqNo=130,Updated=TO_TIMESTAMP('2026-08-27 14:32:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=6134
+;
+
+-- Aug 27, 2026, 2:32:49 PM CEST
+UPDATE AD_Field SET SeqNo=140,Updated=TO_TIMESTAMP('2026-08-27 14:32:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=10261
+;
+
+-- Aug 27, 2026, 2:32:49 PM CEST
+UPDATE AD_Field SET SeqNo=0,Updated=TO_TIMESTAMP('2026-08-27 14:32:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=204948
+;
+
+-- Aug 27, 2026, 2:33:43 PM CEST
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (209242,'Approved Vendor Requirement','Defines whether an approved vendor is required for purchasing this product.','Determines whether this product may only be purchased from an approved vendor. Use Product Category applies the setting from the product category. Required enforces vendor approval, while Not Required permits purchasing from any vendor.',180,217657,'Y',1,630,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2026-08-27 14:33:42','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:33:42','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','01a04336-3d75-70f8-b329-10db22e6f64f','Y',630,2)
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=470, XPosition=1,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=209242
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=480,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=1568
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=490,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=1569
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=500,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=5381
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=510,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=5383
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=520,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=12418
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=530,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=5910
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=540,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=5911
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=550,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=6130
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=560,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=8307
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=570,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=6343
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=580,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=6344
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=590,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=58973
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=600,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=8608
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=610,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=8613
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=620,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=52015
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=630,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=52016
+;
+
+-- Aug 27, 2026, 2:38:19 PM CEST
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan) VALUES (209243,'Approved Vendor','Indicates that this vendor is approved to supply this product when approved vendor purchasing is required.','Select this option to approve the vendor for supplying this product. This setting is independent of Current Vendor. It is evaluated only when the product requires an approved vendor. Inactive or discontinued purchasing records are not considered approved.',239,217658,'Y',1,270,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2026-08-27 14:38:18','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:38:18','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','01a0433a-7363-7cdd-a20c-450844c2de5d','Y',270,2,2)
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=80, XPosition=5,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=209243
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=90,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=3818
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=100,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2898
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=110,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2322
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=120,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2899
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=130,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2900
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=140,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=5912
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=150,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2321
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=160,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=5333
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=170,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2310
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=180,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2319
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=190,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2320
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=200,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=3291
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=210,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=3290
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=220,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=3289
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=230,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2314
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=240,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2313
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=250,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=5913
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=260,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2311
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=270,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2312
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=0,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=202930
+;
+
+-- Aug 27, 2026, 2:41:18 PM CEST
+INSERT INTO AD_Message (MsgType,MsgText,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Message_ID,Value,EntityType,AD_Message_UU) VALUES ('I','Product "{0}" must be purchased from an approved vendor. Vendor "{1}" is not approved for this product.',0,0,'Y',TO_TIMESTAMP('2026-08-27 14:41:18','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:41:18','YYYY-MM-DD HH24:MI:SS'),100,201054,'ProductNotApprovedForVendor','D','01a0433d-2f29-7f59-a266-70986668c002')
+;
+
+-- Aug 27, 2026, 2:44:00 PM CEST
+UPDATE AD_Field SET DisplayLogic='@IsPurchased@=''Y''',Updated=TO_TIMESTAMP('2026-08-27 14:44:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=209242
+;

--- a/migration/iD14/postgresql/202608271411_IDEMPIERE-7086.sql
+++ b/migration/iD14/postgresql/202608271411_IDEMPIERE-7086.sql
@@ -1,0 +1,262 @@
+-- IDEMPIERE-7086 Restrict Purchase of Selected Products to Approved Vendors
+SELECT register_migration_script('202608271411_IDEMPIERE-7086.sql') FROM dual;
+
+-- Aug 27, 2026, 2:11:45 PM CEST
+INSERT INTO AD_Reference (AD_Reference_ID,Name,Description,Help,ValidationType,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,IsOrderByValue,AD_Reference_UU,ShowInactive) VALUES (200289,'Approved Vendor Requirement','Determines whether purchasing this product requires an approved vendor.','Use Product Category applies the approved-vendor requirement defined by the product category. Required allows the product to be purchased only from vendors explicitly approved for it. Not Required permits purchasing from any vendor, regardless of the product-category setting.','L',0,0,'Y',TO_TIMESTAMP('2026-08-27 14:11:45','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:11:45','YYYY-MM-DD HH24:MI:SS'),100,'D','N','01a04322-2332-79e1-a48b-d6cf1084c1dc','N')
+;
+
+-- Aug 27, 2026, 2:12:32 PM CEST
+INSERT INTO AD_Ref_List (AD_Ref_List_ID,Name,Description,AD_Reference_ID,Value,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,AD_Ref_List_UU) VALUES (200779,'Use Product Category','Apply the approved-vendor requirement defined by the product category.',200289,'C',0,0,'Y',TO_TIMESTAMP('2026-08-27 14:12:32','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:12:32','YYYY-MM-DD HH24:MI:SS'),100,'D','01a04322-d92b-7e1b-9bff-c8cf4835854c')
+;
+
+-- Aug 27, 2026, 2:13:18 PM CEST
+INSERT INTO AD_Ref_List (AD_Ref_List_ID,Name,Description,AD_Reference_ID,Value,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,AD_Ref_List_UU) VALUES (200780,'Required','The product may only be purchased from an approved vendor.',200289,'Y',0,0,'Y',TO_TIMESTAMP('2026-08-27 14:13:17','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:13:17','YYYY-MM-DD HH24:MI:SS'),100,'D','01a04323-8b50-753d-9bfa-3df870346f17')
+;
+
+-- Aug 27, 2026, 2:14:39 PM CEST
+INSERT INTO AD_Ref_List (AD_Ref_List_ID,Name,Description,AD_Reference_ID,Value,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,EntityType,AD_Ref_List_UU) VALUES (200781,'Not Required','The product may be purchased without an approved-vendor restriction.',200289,'N',0,0,'Y',TO_TIMESTAMP('2026-08-27 14:14:39','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:14:39','YYYY-MM-DD HH24:MI:SS'),100,'D','01a04324-ca42-74e1-b3db-c63197123e05')
+;
+
+-- Aug 27, 2026, 2:18:09 PM CEST
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,ColumnName,Name,Description,Help,PrintName,EntityType,AD_Element_UU) VALUES (204122,0,0,'Y',TO_TIMESTAMP('2026-08-27 14:18:09','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:18:09','YYYY-MM-DD HH24:MI:SS'),100,'IsApprovedVendorRequired','Approved Vendor Required','Products in this category must normally be purchased from an approved vendor.','When selected, products in this category may only be purchased from vendors explicitly approved for the respective product. Individual products can override this setting.','Approved Vendor Required','D','01a04327-fd8b-7112-82f3-445c7bdafc39')
+;
+
+-- Aug 27, 2026, 2:20:49 PM CEST
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,ColumnName,Name,Description,Help,PrintName,EntityType,AD_Element_UU) VALUES (204123,0,0,'Y',TO_TIMESTAMP('2026-08-27 14:20:49','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:20:49','YYYY-MM-DD HH24:MI:SS'),100,'ApprovedVendorRequirement','Approved Vendor Requirement','Defines whether an approved vendor is required for purchasing this product.','Determines whether this product may only be purchased from an approved vendor. Use Product Category applies the setting from the product category. Required enforces vendor approval, while Not Required permits purchasing from any vendor.','Approved Vendor Requirement','D','01a0432a-6fbc-7f2c-b1e3-8b05bdefb2d0')
+;
+
+-- Aug 27, 2026, 2:22:46 PM CEST
+INSERT INTO AD_Element (AD_Element_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,ColumnName,Name,Description,Help,PrintName,EntityType,AD_Element_UU) VALUES (204124,0,0,'Y',TO_TIMESTAMP('2026-08-27 14:22:45','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:22:45','YYYY-MM-DD HH24:MI:SS'),100,'IsApprovedVendor','Approved Vendor','Indicates that this vendor is approved to supply this product when approved vendor purchasing is required.','Select this option to approve the vendor for supplying this product. This setting is independent of Current Vendor. It is evaluated only when the product requires an approved vendor. Inactive or discontinued purchasing records are not considered approved.','Approved Vendor','D','01a0432c-361f-762c-a072-49cab7b24326')
+;
+
+-- Aug 27, 2026, 2:24:59 PM CEST
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,IsHtml,IsPartitionKey) VALUES (217656,0,'Approved Vendor Required','Products in this category must normally be purchased from an approved vendor.','When selected, products in this category may only be purchased from vendors explicitly approved for the respective product. Individual products can override this setting.',209,'IsApprovedVendorRequired','N',1,'N','N','Y','N','N',0,'N',20,0,0,'Y',TO_TIMESTAMP('2026-08-27 14:24:59','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:24:59','YYYY-MM-DD HH24:MI:SS'),100,204122,'Y','N','D','N','N','N','Y','01a0432e-4044-72ec-beee-8d61649b76c0','Y',0,'N','N','N','N')
+;
+
+-- Aug 27, 2026, 2:25:39 PM CEST
+ALTER TABLE M_Product_Category ADD COLUMN IsApprovedVendorRequired CHAR(1) DEFAULT 'N' CHECK (IsApprovedVendorRequired IN ('Y','N')) NOT NULL
+;
+
+-- Aug 27, 2026, 2:28:39 PM CEST
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Reference_Value_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,IsHtml,IsPartitionKey) VALUES (217657,0,'Approved Vendor Requirement','Defines whether an approved vendor is required for purchasing this product.','Determines whether this product may only be purchased from an approved vendor. Use Product Category applies the setting from the product category. Required enforces vendor approval, while Not Required permits purchasing from any vendor.',208,'ApprovedVendorRequirement','C',1,'N','N','Y','N','N',0,'N',17,200289,0,0,'Y',TO_TIMESTAMP('2026-08-27 14:28:38','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:28:38','YYYY-MM-DD HH24:MI:SS'),100,204123,'Y','N','D','N','N','N','Y','01a04331-9926-78b5-b6f9-26f070f67d8d','Y',0,'N','N','N','N')
+;
+
+-- Aug 27, 2026, 2:29:39 PM CEST
+INSERT INTO AD_Column (AD_Column_ID,Version,Name,Description,Help,AD_Table_ID,ColumnName,DefaultValue,FieldLength,IsKey,IsParent,IsMandatory,IsTranslated,IsIdentifier,SeqNo,IsEncrypted,AD_Reference_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Element_ID,IsUpdateable,IsSelectionColumn,EntityType,IsSyncDatabase,IsAlwaysUpdateable,IsAutocomplete,IsAllowLogging,AD_Column_UU,IsAllowCopy,SeqNoSelection,IsToolbarButton,IsSecure,IsHtml,IsPartitionKey) VALUES (217658,0,'Approved Vendor','Indicates that this vendor is approved to supply this product when approved vendor purchasing is required.','Select this option to approve the vendor for supplying this product. This setting is independent of Current Vendor. It is evaluated only when the product requires an approved vendor. Inactive or discontinued purchasing records are not considered approved.',210,'IsApprovedVendor','N',1,'N','N','Y','N','N',0,'N',20,0,0,'Y',TO_TIMESTAMP('2026-08-27 14:29:39','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:29:39','YYYY-MM-DD HH24:MI:SS'),100,204124,'Y','N','D','N','N','N','Y','01a04332-86fc-701b-9424-05ab4a8f1a21','Y',0,'N','N','N','N')
+;
+
+-- Aug 27, 2026, 2:29:43 PM CEST
+ALTER TABLE M_Product_PO ADD COLUMN IsApprovedVendor CHAR(1) DEFAULT 'N' CHECK (IsApprovedVendor IN ('Y','N')) NOT NULL
+;
+
+-- Aug 27, 2026, 2:30:15 PM CEST
+ALTER TABLE M_Product ADD COLUMN ApprovedVendorRequirement CHAR(1) DEFAULT 'C' NOT NULL
+;
+
+-- Aug 27, 2026, 2:31:14 PM CEST
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan) VALUES (209241,'Approved Vendor Required','Products in this category must normally be purchased from an approved vendor.','When selected, products in this category may only be purchased from vendors explicitly approved for the respective product. Individual products can override this setting.',189,217656,'Y',1,130,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2026-08-27 14:31:13','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:31:13','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','01a04333-f68d-76d4-b52c-d84cb9e534bd','Y',130,2,2)
+;
+
+-- Aug 27, 2026, 2:32:49 PM CEST
+UPDATE AD_Field SET SeqNo=70,Updated=TO_TIMESTAMP('2026-08-27 14:32:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=50181
+;
+
+-- Aug 27, 2026, 2:32:49 PM CEST
+UPDATE AD_Field SET SeqNo=80,Updated=TO_TIMESTAMP('2026-08-27 14:32:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=11203
+;
+
+-- Aug 27, 2026, 2:32:49 PM CEST
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=90, XPosition=5,Updated=TO_TIMESTAMP('2026-08-27 14:32:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=209241
+;
+
+-- Aug 27, 2026, 2:32:49 PM CEST
+UPDATE AD_Field SET SeqNo=100,Updated=TO_TIMESTAMP('2026-08-27 14:32:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=3748
+;
+
+-- Aug 27, 2026, 2:32:49 PM CEST
+UPDATE AD_Field SET SeqNo=110,Updated=TO_TIMESTAMP('2026-08-27 14:32:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=8614
+;
+
+-- Aug 27, 2026, 2:32:49 PM CEST
+UPDATE AD_Field SET SeqNo=120,Updated=TO_TIMESTAMP('2026-08-27 14:32:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=4459
+;
+
+-- Aug 27, 2026, 2:32:49 PM CEST
+UPDATE AD_Field SET SeqNo=130,Updated=TO_TIMESTAMP('2026-08-27 14:32:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=6134
+;
+
+-- Aug 27, 2026, 2:32:49 PM CEST
+UPDATE AD_Field SET SeqNo=140,Updated=TO_TIMESTAMP('2026-08-27 14:32:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=10261
+;
+
+-- Aug 27, 2026, 2:32:49 PM CEST
+UPDATE AD_Field SET SeqNo=0,Updated=TO_TIMESTAMP('2026-08-27 14:32:49','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=204948
+;
+
+-- Aug 27, 2026, 2:33:43 PM CEST
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,ColumnSpan) VALUES (209242,'Approved Vendor Requirement','Defines whether an approved vendor is required for purchasing this product.','Determines whether this product may only be purchased from an approved vendor. Use Product Category applies the setting from the product category. Required enforces vendor approval, while Not Required permits purchasing from any vendor.',180,217657,'Y',1,630,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2026-08-27 14:33:42','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:33:42','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','01a04336-3d75-70f8-b329-10db22e6f64f','Y',630,2)
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=470, XPosition=1,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=209242
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=480,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=1568
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=490,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=1569
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=500,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=5381
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=510,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=5383
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=520,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=12418
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=530,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=5910
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=540,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=5911
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=550,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=6130
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=560,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=8307
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=570,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=6343
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=580,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=6344
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=590,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=58973
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=600,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=8608
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=610,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=8613
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=620,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=52015
+;
+
+-- Aug 27, 2026, 2:36:18 PM CEST
+UPDATE AD_Field SET SeqNo=630,Updated=TO_TIMESTAMP('2026-08-27 14:36:18','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=52016
+;
+
+-- Aug 27, 2026, 2:38:19 PM CEST
+INSERT INTO AD_Field (AD_Field_ID,Name,Description,Help,AD_Tab_ID,AD_Column_ID,IsDisplayed,DisplayLength,SeqNo,IsSameLine,IsHeading,IsFieldOnly,IsEncrypted,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,IsReadOnly,IsCentrallyMaintained,EntityType,AD_Field_UU,IsDisplayedGrid,SeqNoGrid,XPosition,ColumnSpan) VALUES (209243,'Approved Vendor','Indicates that this vendor is approved to supply this product when approved vendor purchasing is required.','Select this option to approve the vendor for supplying this product. This setting is independent of Current Vendor. It is evaluated only when the product requires an approved vendor. Inactive or discontinued purchasing records are not considered approved.',239,217658,'Y',1,270,'N','N','N','N',0,0,'Y',TO_TIMESTAMP('2026-08-27 14:38:18','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:38:18','YYYY-MM-DD HH24:MI:SS'),100,'N','Y','D','01a0433a-7363-7cdd-a20c-450844c2de5d','Y',270,2,2)
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET IsDisplayed='Y', SeqNo=80, XPosition=5,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=209243
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=90,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=3818
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=100,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2898
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=110,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2322
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=120,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2899
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=130,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2900
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=140,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=5912
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=150,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2321
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=160,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=5333
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=170,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2310
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=180,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2319
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=190,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2320
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=200,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=3291
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=210,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=3290
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=220,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=3289
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=230,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2314
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=240,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2313
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=250,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=5913
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=260,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2311
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=270,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=2312
+;
+
+-- Aug 27, 2026, 2:39:42 PM CEST
+UPDATE AD_Field SET SeqNo=0,Updated=TO_TIMESTAMP('2026-08-27 14:39:42','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=202930
+;
+
+-- Aug 27, 2026, 2:41:18 PM CEST
+INSERT INTO AD_Message (MsgType,MsgText,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Message_ID,Value,EntityType,AD_Message_UU) VALUES ('I','Product "{0}" must be purchased from an approved vendor. Vendor "{1}" is not approved for this product.',0,0,'Y',TO_TIMESTAMP('2026-08-27 14:41:18','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-08-27 14:41:18','YYYY-MM-DD HH24:MI:SS'),100,201054,'ProductNotApprovedForVendor','D','01a0433d-2f29-7f59-a266-70986668c002')
+;
+
+-- Aug 27, 2026, 2:44:00 PM CEST
+UPDATE AD_Field SET DisplayLogic='@IsPurchased@=''Y''',Updated=TO_TIMESTAMP('2026-08-27 14:44:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=209242
+;

--- a/org.adempiere.base/src/org/compiere/model/I_M_Product.java
+++ b/org.adempiere.base/src/org/compiere/model/I_M_Product.java
@@ -62,6 +62,19 @@ public interface I_M_Product
 	  */
 	public int getAD_Org_ID();
 
+    /** Column name ApprovedVendorRequirement */
+    public static final String COLUMNNAME_ApprovedVendorRequirement = "ApprovedVendorRequirement";
+
+	/** Set Approved Vendor Requirement.
+	  * Defines whether an approved vendor is required for purchasing this product.
+	  */
+	public void setApprovedVendorRequirement (String ApprovedVendorRequirement);
+
+	/** Get Approved Vendor Requirement.
+	  * Defines whether an approved vendor is required for purchasing this product.
+	  */
+	public String getApprovedVendorRequirement();
+
     /** Column name C_RevenueRecognition_ID */
     public static final String COLUMNNAME_C_RevenueRecognition_ID = "C_RevenueRecognition_ID";
 

--- a/org.adempiere.base/src/org/compiere/model/I_M_Product_Category.java
+++ b/org.adempiere.base/src/org/compiere/model/I_M_Product_Category.java
@@ -22,7 +22,7 @@ import org.compiere.util.KeyNamePair;
 
 /** Generated Interface for M_Product_Category
  *  @author iDempiere (generated) 
- *  @version Release 13
+ *  @version Release 14
  */
 public interface I_M_Product_Category 
 {
@@ -135,6 +135,19 @@ public interface I_M_Product_Category
 	  * The record is active in the system
 	  */
 	public boolean isActive();
+
+    /** Column name IsApprovedVendorRequired */
+    public static final String COLUMNNAME_IsApprovedVendorRequired = "IsApprovedVendorRequired";
+
+	/** Set Approved Vendor Required.
+	  * Products in this category must normally be purchased from an approved vendor.
+	  */
+	public void setIsApprovedVendorRequired (boolean IsApprovedVendorRequired);
+
+	/** Get Approved Vendor Required.
+	  * Products in this category must normally be purchased from an approved vendor.
+	  */
+	public boolean isApprovedVendorRequired();
 
     /** Column name IsDefault */
     public static final String COLUMNNAME_IsDefault = "IsDefault";

--- a/org.adempiere.base/src/org/compiere/model/I_M_Product_PO.java
+++ b/org.adempiere.base/src/org/compiere/model/I_M_Product_PO.java
@@ -22,7 +22,7 @@ import org.compiere.util.KeyNamePair;
 
 /** Generated Interface for M_Product_PO
  *  @author iDempiere (generated) 
- *  @version Release 13
+ *  @version Release 14
  */
 public interface I_M_Product_PO 
 {
@@ -203,6 +203,19 @@ public interface I_M_Product_PO
 	  * The record is active in the system
 	  */
 	public boolean isActive();
+
+    /** Column name IsApprovedVendor */
+    public static final String COLUMNNAME_IsApprovedVendor = "IsApprovedVendor";
+
+	/** Set Approved Vendor.
+	  * Indicates that this vendor is approved to supply this product when approved vendor purchasing is required.
+	  */
+	public void setIsApprovedVendor (boolean IsApprovedVendor);
+
+	/** Get Approved Vendor.
+	  * Indicates that this vendor is approved to supply this product when approved vendor purchasing is required.
+	  */
+	public boolean isApprovedVendor();
 
     /** Column name IsCurrentVendor */
     public static final String COLUMNNAME_IsCurrentVendor = "IsCurrentVendor";

--- a/org.adempiere.base/src/org/compiere/model/MOrder.java
+++ b/org.adempiere.base/src/org/compiere/model/MOrder.java
@@ -1567,6 +1567,23 @@ public class MOrder extends X_C_Order implements DocAction
 			m_processMsg = "@NoLines@";
 			return DocAction.STATUS_Invalid;
 		}
+
+		if (!isSOTrx())
+		{
+			for (MOrderLine line : lines)
+			{
+				if (line.getM_Product_ID() <= 0)
+					continue;
+				MProduct product = line.getProduct();
+				if (product != null && product.isApprovedVendorRequired()
+						&& !MProductPO.isApprovedVendor(getCtx(), product.getM_Product_ID(), getC_BPartner_ID(), get_TrxName()))
+				{
+					m_processMsg = Msg.getMsg(getCtx(), "ProductNotApprovedForVendor",
+							new Object[] { product.getName(), MBPartner.get(getCtx(), getC_BPartner_ID()).getName() });
+					return DocAction.STATUS_Invalid;
+				}
+			}
+		}
 				
 		// Bug 1564431
 		if (MOrder.DELIVERYRULE_CompleteOrder.equals(getDeliveryRule()) )

--- a/org.adempiere.base/src/org/compiere/model/MProduct.java
+++ b/org.adempiere.base/src/org/compiere/model/MProduct.java
@@ -53,6 +53,11 @@ import org.idempiere.cache.ImmutablePOSupport;
  */
 public class MProduct extends X_M_Product implements ImmutablePOSupport
 {
+	private static final String COLUMN_APPROVED_VENDOR_REQUIREMENT = "ApprovedVendorRequirement";
+	private static final String APPROVED_VENDOR_USE_PRODUCT_CATEGORY = "C";
+	private static final String APPROVED_VENDOR_REQUIRED = "Y";
+	private static final String APPROVED_VENDOR_NOT_REQUIRED = "N";
+
 	/**
 	 * generated serial id
 	 */
@@ -254,6 +259,7 @@ public class MProduct extends X_M_Product implements ImmutablePOSupport
 	 * Set the initial defaults for a new record
 	 */
 	private void setInitialDefaults() {
+		set_Value(COLUMN_APPROVED_VENDOR_REQUIREMENT, APPROVED_VENDOR_USE_PRODUCT_CATEGORY);
 		setProductType (PRODUCTTYPE_Item);	// I
 		setIsBOM (false);	// N
 		setIsInvoicePrintDetails (false);
@@ -268,6 +274,24 @@ public class MProduct extends X_M_Product implements ImmutablePOSupport
 		setIsExcludeAutoDelivery(false);
 		setProcessing (false);	// N
 		setLowLevel(0);
+	}
+
+	/**
+	 * Determine whether purchases of this product require an approved vendor.
+	 * The product setting overrides the product category default.
+	 *
+	 * @return {@code true} if an approved vendor is required
+	 */
+	public boolean isApprovedVendorRequired()
+	{
+		String requirement = (String) get_Value(COLUMN_APPROVED_VENDOR_REQUIREMENT);
+		if (APPROVED_VENDOR_REQUIRED.equals(requirement))
+			return true;
+		if (APPROVED_VENDOR_NOT_REQUIRED.equals(requirement))
+			return false;
+
+		MProductCategory category = new MProductCategory(getCtx(), getM_Product_Category_ID(), get_TrxName());
+		return category.get_ID() > 0 && category.get_ValueAsBoolean("IsApprovedVendorRequired");
 	}
 
 	/**

--- a/org.adempiere.base/src/org/compiere/model/MProduct.java
+++ b/org.adempiere.base/src/org/compiere/model/MProduct.java
@@ -53,11 +53,6 @@ import org.idempiere.cache.ImmutablePOSupport;
  */
 public class MProduct extends X_M_Product implements ImmutablePOSupport
 {
-	private static final String COLUMN_APPROVED_VENDOR_REQUIREMENT = "ApprovedVendorRequirement";
-	private static final String APPROVED_VENDOR_USE_PRODUCT_CATEGORY = "C";
-	private static final String APPROVED_VENDOR_REQUIRED = "Y";
-	private static final String APPROVED_VENDOR_NOT_REQUIRED = "N";
-
 	/**
 	 * generated serial id
 	 */
@@ -259,7 +254,7 @@ public class MProduct extends X_M_Product implements ImmutablePOSupport
 	 * Set the initial defaults for a new record
 	 */
 	private void setInitialDefaults() {
-		set_Value(COLUMN_APPROVED_VENDOR_REQUIREMENT, APPROVED_VENDOR_USE_PRODUCT_CATEGORY);
+		setApprovedVendorRequirement(APPROVEDVENDORREQUIREMENT_UseProductCategory);
 		setProductType (PRODUCTTYPE_Item);	// I
 		setIsBOM (false);	// N
 		setIsInvoicePrintDetails (false);
@@ -284,14 +279,14 @@ public class MProduct extends X_M_Product implements ImmutablePOSupport
 	 */
 	public boolean isApprovedVendorRequired()
 	{
-		String requirement = (String) get_Value(COLUMN_APPROVED_VENDOR_REQUIREMENT);
-		if (APPROVED_VENDOR_REQUIRED.equals(requirement))
+		String requirement = getApprovedVendorRequirement();
+		if (APPROVEDVENDORREQUIREMENT_Required.equals(requirement))
 			return true;
-		if (APPROVED_VENDOR_NOT_REQUIRED.equals(requirement))
+		if (APPROVEDVENDORREQUIREMENT_NotRequired.equals(requirement))
 			return false;
 
 		MProductCategory category = new MProductCategory(getCtx(), getM_Product_Category_ID(), get_TrxName());
-		return category.get_ID() > 0 && category.get_ValueAsBoolean("IsApprovedVendorRequired");
+		return category.get_ID() > 0 && category.isApprovedVendorRequired();
 	}
 
 	/**

--- a/org.adempiere.base/src/org/compiere/model/MProductCategory.java
+++ b/org.adempiere.base/src/org/compiere/model/MProductCategory.java
@@ -164,6 +164,7 @@ public class MProductCategory extends X_M_Product_Category implements ImmutableP
 	 * Set the initial defaults for a new record
 	 */
 	private void setInitialDefaults() {
+		set_Value("IsApprovedVendorRequired", Boolean.FALSE);
 		setMMPolicy (MMPOLICY_FiFo);	// F
 		setPlannedMargin (Env.ZERO);
 		setIsDefault (false);

--- a/org.adempiere.base/src/org/compiere/model/MProductCategory.java
+++ b/org.adempiere.base/src/org/compiere/model/MProductCategory.java
@@ -164,7 +164,7 @@ public class MProductCategory extends X_M_Product_Category implements ImmutableP
 	 * Set the initial defaults for a new record
 	 */
 	private void setInitialDefaults() {
-		set_Value("IsApprovedVendorRequired", Boolean.FALSE);
+		setIsApprovedVendorRequired(false);
 		setMMPolicy (MMPOLICY_FiFo);	// F
 		setPlannedMargin (Env.ZERO);
 		setIsDefault (false);

--- a/org.adempiere.base/src/org/compiere/model/MProductPO.java
+++ b/org.adempiere.base/src/org/compiere/model/MProductPO.java
@@ -71,7 +71,7 @@ public class MProductPO extends X_M_Product_PO
 			return false;
 
 		String whereClause = COLUMNNAME_M_Product_ID + "=? AND "
-				+ COLUMNNAME_C_BPartner_ID + "=? AND IsApprovedVendor='Y' AND COALESCE("
+				+ COLUMNNAME_C_BPartner_ID + "=? AND " + COLUMNNAME_IsApprovedVendor + "='Y' AND COALESCE("
 				+ COLUMNNAME_Discontinued + ",'N')='N'";
 		return new Query(ctx, Table_Name, whereClause, trxName)
 				.setParameters(M_Product_ID, C_BPartner_ID)
@@ -110,7 +110,7 @@ public class MProductPO extends X_M_Product_PO
 	 * Set the initial defaults for a new record
 	 */
 	private void setInitialDefaults() {
-		set_Value("IsApprovedVendor", Boolean.FALSE);
+		setIsApprovedVendor(false);
 		setIsCurrentVendor (true);	// Y
 	}
 

--- a/org.adempiere.base/src/org/compiere/model/MProductPO.java
+++ b/org.adempiere.base/src/org/compiere/model/MProductPO.java
@@ -56,6 +56,29 @@ public class MProductPO extends X_M_Product_PO
 		return list.toArray(new MProductPO[list.size()]);
 	}	//	getOfProduct
 
+	/**
+	 * Test whether a vendor has an active, non-discontinued approval for a product.
+	 *
+	 * @param ctx context
+	 * @param M_Product_ID product
+	 * @param C_BPartner_ID vendor
+	 * @param trxName transaction
+	 * @return {@code true} if the vendor is approved for the product
+	 */
+	public static boolean isApprovedVendor(Properties ctx, int M_Product_ID, int C_BPartner_ID, String trxName)
+	{
+		if (M_Product_ID <= 0 || C_BPartner_ID <= 0)
+			return false;
+
+		String whereClause = COLUMNNAME_M_Product_ID + "=? AND "
+				+ COLUMNNAME_C_BPartner_ID + "=? AND IsApprovedVendor='Y' AND COALESCE("
+				+ COLUMNNAME_Discontinued + ",'N')='N'";
+		return new Query(ctx, Table_Name, whereClause, trxName)
+				.setParameters(M_Product_ID, C_BPartner_ID)
+				.setOnlyActiveRecords(true)
+				.match();
+	}
+
     /**
      * UUID based Constructor
      * @param ctx  Context
@@ -87,6 +110,7 @@ public class MProductPO extends X_M_Product_PO
 	 * Set the initial defaults for a new record
 	 */
 	private void setInitialDefaults() {
+		set_Value("IsApprovedVendor", Boolean.FALSE);
 		setIsCurrentVendor (true);	// Y
 	}
 

--- a/org.adempiere.base/src/org/compiere/model/X_M_Product.java
+++ b/org.adempiere.base/src/org/compiere/model/X_M_Product.java
@@ -34,7 +34,7 @@ public class X_M_Product extends PO implements I_M_Product, I_Persistent
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20260406L;
+	private static final long serialVersionUID = 20260827L;
 
     /** Standard Constructor */
     public X_M_Product (Properties ctx, int M_Product_ID, String trxName)
@@ -42,6 +42,8 @@ public class X_M_Product extends PO implements I_M_Product, I_Persistent
       super (ctx, M_Product_ID, trxName);
       /** if (M_Product_ID == 0)
         {
+			setApprovedVendorRequirement (null);
+// C
 			setC_TaxCategory_ID (0);
 			setC_UOM_ID (0);
 			setIsAutoProduce (false);
@@ -95,6 +97,8 @@ public class X_M_Product extends PO implements I_M_Product, I_Persistent
       super (ctx, M_Product_ID, trxName, virtualColumns);
       /** if (M_Product_ID == 0)
         {
+			setApprovedVendorRequirement (null);
+// C
 			setC_TaxCategory_ID (0);
 			setC_UOM_ID (0);
 			setIsAutoProduce (false);
@@ -148,6 +152,8 @@ public class X_M_Product extends PO implements I_M_Product, I_Persistent
       super (ctx, M_Product_UU, trxName);
       /** if (M_Product_UU == null)
         {
+			setApprovedVendorRequirement (null);
+// C
 			setC_TaxCategory_ID (0);
 			setC_UOM_ID (0);
 			setIsAutoProduce (false);
@@ -201,6 +207,8 @@ public class X_M_Product extends PO implements I_M_Product, I_Persistent
       super (ctx, M_Product_UU, trxName, virtualColumns);
       /** if (M_Product_UU == null)
         {
+			setApprovedVendorRequirement (null);
+// C
 			setC_TaxCategory_ID (0);
 			setC_UOM_ID (0);
 			setIsAutoProduce (false);
@@ -275,6 +283,31 @@ public class X_M_Product extends PO implements I_M_Product, I_Persistent
         .append(get_ID()).append(",Name=").append(getName()).append("]");
       return sb.toString();
     }
+
+	/** ApprovedVendorRequirement AD_Reference_ID=200289 */
+	public static final int APPROVEDVENDORREQUIREMENT_AD_Reference_ID=200289;
+	/** Use Product Category = C */
+	public static final String APPROVEDVENDORREQUIREMENT_UseProductCategory = "C";
+	/** Not Required = N */
+	public static final String APPROVEDVENDORREQUIREMENT_NotRequired = "N";
+	/** Required = Y */
+	public static final String APPROVEDVENDORREQUIREMENT_Required = "Y";
+	/** Set Approved Vendor Requirement.
+		@param ApprovedVendorRequirement Defines whether an approved vendor is required for purchasing this product.
+	*/
+	public void setApprovedVendorRequirement (String ApprovedVendorRequirement)
+	{
+
+		set_Value (COLUMNNAME_ApprovedVendorRequirement, ApprovedVendorRequirement);
+	}
+
+	/** Get Approved Vendor Requirement.
+		@return Defines whether an approved vendor is required for purchasing this product.
+	  */
+	public String getApprovedVendorRequirement()
+	{
+		return (String)get_Value(COLUMNNAME_ApprovedVendorRequirement);
+	}
 
 	@Deprecated(since="13") // use better methods with cache
 	public org.compiere.model.I_C_RevenueRecognition getC_RevenueRecognition() throws RuntimeException

--- a/org.adempiere.base/src/org/compiere/model/X_M_Product_Category.java
+++ b/org.adempiere.base/src/org/compiere/model/X_M_Product_Category.java
@@ -25,7 +25,7 @@ import org.compiere.util.KeyNamePair;
 
 /** Generated Model for M_Product_Category
  *  @author iDempiere (generated)
- *  @version Release 13 - $Id$ */
+ *  @version Release 14 - $Id$ */
 @org.adempiere.base.Model(table="M_Product_Category")
 public class X_M_Product_Category extends PO implements I_M_Product_Category, I_Persistent
 {
@@ -33,7 +33,7 @@ public class X_M_Product_Category extends PO implements I_M_Product_Category, I_
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20260309L;
+	private static final long serialVersionUID = 20260827L;
 
     /** Standard Constructor */
     public X_M_Product_Category (Properties ctx, int M_Product_Category_ID, String trxName)
@@ -41,6 +41,8 @@ public class X_M_Product_Category extends PO implements I_M_Product_Category, I_
       super (ctx, M_Product_Category_ID, trxName);
       /** if (M_Product_Category_ID == 0)
         {
+			setIsApprovedVendorRequired (false);
+// N
 			setIsDefault (false);
 			setIsSelfService (true);
 // Y
@@ -59,6 +61,8 @@ public class X_M_Product_Category extends PO implements I_M_Product_Category, I_
       super (ctx, M_Product_Category_ID, trxName, virtualColumns);
       /** if (M_Product_Category_ID == 0)
         {
+			setIsApprovedVendorRequired (false);
+// N
 			setIsDefault (false);
 			setIsSelfService (true);
 // Y
@@ -77,6 +81,8 @@ public class X_M_Product_Category extends PO implements I_M_Product_Category, I_
       super (ctx, M_Product_Category_UU, trxName);
       /** if (M_Product_Category_UU == null)
         {
+			setIsApprovedVendorRequired (false);
+// N
 			setIsDefault (false);
 			setIsSelfService (true);
 // Y
@@ -95,6 +101,8 @@ public class X_M_Product_Category extends PO implements I_M_Product_Category, I_
       super (ctx, M_Product_Category_UU, trxName, virtualColumns);
       /** if (M_Product_Category_UU == null)
         {
+			setIsApprovedVendorRequired (false);
+// N
 			setIsDefault (false);
 			setIsSelfService (true);
 // Y
@@ -207,6 +215,29 @@ public class X_M_Product_Category extends PO implements I_M_Product_Category, I_
 	public String getDescription()
 	{
 		return (String)get_Value(COLUMNNAME_Description);
+	}
+
+	/** Set Approved Vendor Required.
+		@param IsApprovedVendorRequired Products in this category must normally be purchased from an approved vendor.
+	*/
+	public void setIsApprovedVendorRequired (boolean IsApprovedVendorRequired)
+	{
+		set_Value (COLUMNNAME_IsApprovedVendorRequired, Boolean.valueOf(IsApprovedVendorRequired));
+	}
+
+	/** Get Approved Vendor Required.
+		@return Products in this category must normally be purchased from an approved vendor.
+	  */
+	public boolean isApprovedVendorRequired()
+	{
+		Object oo = get_Value(COLUMNNAME_IsApprovedVendorRequired);
+		if (oo != null)
+		{
+			 if (oo instanceof Boolean)
+				 return ((Boolean)oo).booleanValue();
+			return "Y".equals(oo);
+		}
+		return false;
 	}
 
 	/** Set Default.

--- a/org.adempiere.base/src/org/compiere/model/X_M_Product_PO.java
+++ b/org.adempiere.base/src/org/compiere/model/X_M_Product_PO.java
@@ -25,7 +25,7 @@ import org.compiere.util.Env;
 
 /** Generated Model for M_Product_PO
  *  @author iDempiere (generated)
- *  @version Release 13 - $Id$ */
+ *  @version Release 14 - $Id$ */
 @org.adempiere.base.Model(table="M_Product_PO")
 public class X_M_Product_PO extends PO implements I_M_Product_PO, I_Persistent
 {
@@ -33,7 +33,7 @@ public class X_M_Product_PO extends PO implements I_M_Product_PO, I_Persistent
 	/**
 	 *
 	 */
-	private static final long serialVersionUID = 20260309L;
+	private static final long serialVersionUID = 20260827L;
 
     /** Standard Constructor */
     public X_M_Product_PO (Properties ctx, int M_Product_PO_ID, String trxName)
@@ -42,6 +42,8 @@ public class X_M_Product_PO extends PO implements I_M_Product_PO, I_Persistent
       /** if (M_Product_PO_ID == 0)
         {
 			setC_BPartner_ID (0);
+			setIsApprovedVendor (false);
+// N
 			setIsCurrentVendor (true);
 // Y
 			setM_Product_ID (0);
@@ -58,6 +60,8 @@ public class X_M_Product_PO extends PO implements I_M_Product_PO, I_Persistent
       /** if (M_Product_PO_ID == 0)
         {
 			setC_BPartner_ID (0);
+			setIsApprovedVendor (false);
+// N
 			setIsCurrentVendor (true);
 // Y
 			setM_Product_ID (0);
@@ -74,6 +78,8 @@ public class X_M_Product_PO extends PO implements I_M_Product_PO, I_Persistent
       /** if (M_Product_PO_UU == null)
         {
 			setC_BPartner_ID (0);
+			setIsApprovedVendor (false);
+// N
 			setIsCurrentVendor (true);
 // Y
 			setM_Product_ID (0);
@@ -90,6 +96,8 @@ public class X_M_Product_PO extends PO implements I_M_Product_PO, I_Persistent
       /** if (M_Product_PO_UU == null)
         {
 			setC_BPartner_ID (0);
+			setIsApprovedVendor (false);
+// N
 			setIsCurrentVendor (true);
 // Y
 			setM_Product_ID (0);
@@ -308,6 +316,29 @@ public class X_M_Product_PO extends PO implements I_M_Product_PO, I_Persistent
 	public Timestamp getDiscontinuedAt()
 	{
 		return (Timestamp)get_Value(COLUMNNAME_DiscontinuedAt);
+	}
+
+	/** Set Approved Vendor.
+		@param IsApprovedVendor Indicates that this vendor is approved to supply this product when approved vendor purchasing is required.
+	*/
+	public void setIsApprovedVendor (boolean IsApprovedVendor)
+	{
+		set_Value (COLUMNNAME_IsApprovedVendor, Boolean.valueOf(IsApprovedVendor));
+	}
+
+	/** Get Approved Vendor.
+		@return Indicates that this vendor is approved to supply this product when approved vendor purchasing is required.
+	  */
+	public boolean isApprovedVendor()
+	{
+		Object oo = get_Value(COLUMNNAME_IsApprovedVendor);
+		if (oo != null)
+		{
+			 if (oo instanceof Boolean)
+				 return ((Boolean)oo).booleanValue();
+			return "Y".equals(oo);
+		}
+		return false;
 	}
 
 	/** Set Current vendor.


### PR DESCRIPTION
## Description

This change implements optional approved-vendor purchasing control for purchase orders. It allows organisations to restrict selected products to vendors that have been explicitly approved for supplying the respective product, without changing the purchasing behaviour for products that do not require that control.

JIRA: https://idempiere.atlassian.net/browse/IDEMPIERE-7086

## Functional behaviour

The effective requirement is resolved for every product line on a purchase order during preparation:

- Product Category defines the default through Approved Vendor Required.
- Product can override the category setting through Approved Vendor Requirement.
- Product values are Use Product Category, Required, and Not Required.
- A required product must have an active M_Product_PO record for the selected vendor with Approved Vendor selected.
- Discontinued product-vendor records do not qualify as approved.
- Lines without a product, including charge lines, are not subject to this validation.
- Sales orders are unaffected.

If a required product has no qualifying vendor record, preparation stops with ProductNotApprovedForVendor. The message identifies both the product and the vendor so that the purchaser can correct the vendor approval or choose a different vendor.

## Dictionary and UI changes

The migration creates the following dictionary objects for PostgreSQL and Oracle:

- Product Category: IsApprovedVendorRequired, default N.
- Product: ApprovedVendorRequirement, mandatory list with default C.
- Product Vendor: IsApprovedVendor, default N.
- List reference 200289 with values C = Use Product Category, Y = Required, and N = Not Required.
- The Product field uses Display Logic @IsPurchased@='Y' so it is hidden for products that are not purchased.
- Descriptions and help texts for the reference, list values, elements, columns, and fields.
- The ProductNotApprovedForVendor message.

## Implementation details

- MProduct.isApprovedVendorRequired() evaluates the product override and falls back to the product category.
- MProductPO.isApprovedVendor(...) looks up an active, non-discontinued, approved product-vendor record.
- MOrder invokes these reusable model methods for purchase-order lines during prepareIt().
- The six generated I_ and X_ model classes were regenerated from the Application Dictionary using the Maven model generator; no model API was added manually.

## Validation performed

- Compared PostgreSQL and Oracle migration scripts after normalising their intentional SQL dialect differences; their dictionary content is equivalent.
- Verified that the migration contains registration, schema changes, dictionary records, message, and display logic.
- Ran git diff --check successfully.
- Ran Maven package build successfully for org.idempiere.p2.targetplatform, org.apache.ecs, and org.adempiere.base with tests skipped.