### PR TITLE
IDEMPIERE-7084 Avoid invalid session access on logout

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/WebSocketServerPush.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/WebSocketServerPush.java
@@ -53,6 +53,7 @@ import org.zkoss.zk.ui.event.Events;
 import org.zkoss.zk.ui.impl.ExecutionCarryOver;
 import org.zkoss.zk.ui.sys.Scheduler;
 import org.zkoss.zk.ui.sys.ServerPush;
+import org.zkoss.zk.ui.sys.SessionCtrl;
 import org.zkoss.zk.ui.util.Clients;
 import org.zkoss.zk.ui.util.ExecutionInit;
 
@@ -424,7 +425,7 @@ public class WebSocketServerPush implements ServerPush {
         if (log.isDebugEnabled())
         	log.debug("Stopping server push for " + desktop);
 		var session = desktop.getSession();
-		if (session != null)
+		if (session instanceof SessionCtrl sessionCtrl && !sessionCtrl.isInvalidated())
 			session.removeAttribute(getLocalBaseUrlAttribute(desktop.getId()));
         Clients.response("org.idempiere.websocket.serverpush.stop", new AuScript(null, "org.idempiere.websocket.stopServerPush('" + desktop.getId() + "');"));
     }


### PR DESCRIPTION
## Description

Avoid accessing the ZK session after it has been invalidated during WebSocket server-push cleanup on logout.

JIRA: https://idempiere.atlassian.net/browse/IDEMPIERE-7084

## Root cause

`DesktopImpl.destroy()` stops server push after logout has invalidated the ZK session. `WebSocketServerPush.stop()` then attempted to remove the node-local connector attribute and Jetty raised `IllegalStateException` for the invalid session.

## Changes

- Check `SessionCtrl.isInvalidated()` before removing the per-desktop connector attribute.
- Keep cleanup unchanged for active sessions.

`desktop.isAlive()` is not suitable here because `DesktopImpl.destroy()` marks the desktop as not alive before invoking `ServerPush.stop()`.

## Validation

- `git diff --check`
- Focused 10-module Tycho build with `mvn -pl org.idempiere.p2.targetplatform,org.apache.ecs,org.adempiere.base,org.adempiere.base.process,org.adempiere.report.jasper,org.adempiere.server,org.adempiere.ui,org.idempiere.zk.extra,org.idempiere.zk.billboard,org.adempiere.ui.zk verify -DskipTests`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session cleanup during server push shutdown.
  * Prevented cleanup actions from running on invalidated sessions, reducing the risk of session-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->