### PR TITLE
IDEMPIERE-7089: Make remaining Java case conversions locale-independent

### DIFF
--- a/IDEMPIERE-7082-locale-case-classification.md
+++ b/IDEMPIERE-7082-locale-case-classification.md
@@ -1,0 +1,600 @@
+# IDEMPIERE-7082: Semantic Classification of Parameterless Case Conversions
+
+Baseline: commit `cae980e45dfb3d685594c326f2c00ab6b6c26160`
+
+## Scope and Method
+
+Inventory of all locations in tracked Java sources that use parameterless `.toUpperCase()` or `.toLowerCase()`. The inventory was generated with:
+
+```bash
+git grep -n -E '\.to(Lower|Upper)Case\(\)' -- '*.java'
+```
+
+The current PR state contains 410 remaining matches in 139 files. An additional 50 Java case conversions already removed by IDEMPIERE-7082 were reconstructed from the PR diff. Together with the two compatibility-sensitive locations deliberately retained in the PR, the classification covers 460 locations in 155 files. `H` means high confidence and `M` means medium confidence. Medium confidence identifies locations where the intended domain-specific or linguistic semantics must be confirmed before making a change.
+
+Important: This document is a basis for making decisions, not a recommendation for a mass replacement. User-facing text, database comparisons, and compatibility-sensitive APIs require different strategies.
+
+The original classification baseline is preserved below. A current `upstream/master` addendum near the end of this document records two locations resolved independently and three newly introduced locations. Consequently, the current IDEMPIERE-7089 implementation scope contains 409 active locations rather than the original 408.
+
+In the IDEMPIERE-7089 draft pull request, active source locations are marked with `// IDEMPIERE-7089-P1` through `// IDEMPIERE-7089-P6`. These markers identify the former planned PR groups while all work is now delivered in one pull request.
+
+## Summary
+
+| Code | Category | Count | Recommended Direction |
+|---|---|---:|---|
+| IDEMPIERE_7082_HANDLED | Handled separately by IDEMPIERE-7082 | 52 | Exclude from the new Jira scope; complete PR #3332 separately. |
+| DB_VALUE | Database value comparison | 14 | Bind the original value and apply the same database function to both operands. |
+| DB_SCHEMA_SQL | SQL/schema mechanics | 264 | Use `Locale.ROOT` or structural APIs; do not normalize SQL values differently in Java and the database. |
+| TECH_TOKEN | Technical token | 65 | Use `Locale.ROOT`, `equalsIgnoreCase()`, or an explicitly ASCII-specific strategy. |
+| USER_TEXT | User-facing text/UI search | 37 | Use an explicit login/user locale or `Collator`; do not apply `Locale.ROOT` indiscriminately. |
+| DOMAIN | Domain-specific canonicalization | 11 | Decide and document the strategy for each value type; for example, normalize IBAN values explicitly in a locale-neutral way. |
+| TEST | Test code | 9 | Set the locale explicitly in the test or verify the exact production strategy. |
+| VENDORED | Historic/vendored code | 5 | Do not make an isolated change without a maintenance or upgrade decision. |
+| INERT | Inactive comment | 3 | No runtime change is required; clean up when appropriate. |
+|  | **Total** | **460** | 52 are handled separately by IDEMPIERE-7082, leaving 408 to be evaluated under the new Jira ticket. |
+
+## Classification Rules
+
+- **IDEMPIERE_7082_HANDLED – Handled separately by IDEMPIERE-7082:** Java/database mismatches removed by PR #3332 and two deliberately preserved compatibility locations. Exclude these from the new Jira scope and handle them exclusively in the existing PR.
+- **DB_VALUE – Database value comparison:** A parameter transformed with Java case mapping is compared with `UPPER(...)` or `LOWER(...)` in SQL. Bind the original value and apply the same database function to both operands.
+- **DB_SCHEMA_SQL – SQL/schema mechanics:** SQL grammar, table/column/index names, and database metadata. Use `Locale.ROOT` or structural APIs; do not normalize SQL values differently in Java and the database.
+- **TECH_TOKEN – Technical token:** Protocols, paths, file extensions, class/property names, CSS/OSGi values, and internal keys. Use `Locale.ROOT`, `equalsIgnoreCase()`, or an explicitly ASCII-specific strategy.
+- **USER_TEXT – User-facing text/UI search:** Natural-language labels, search text, and autocomplete comparisons. Use an explicit login/user locale or `Collator`; do not apply `Locale.ROOT` indiscriminately.
+- **DOMAIN – Domain-specific canonicalization:** Business or configuration values with their own normalization contract. Decide and document the strategy for each value type; for example, normalize IBAN values explicitly in a locale-neutral way.
+- **TEST – Test code:** Locale-dependent transformations in tests. Set the locale explicitly in the test or verify the exact production strategy.
+- **VENDORED – Historic/vendored code:** Migration history or embedded third-party source. Do not make an isolated change without a maintenance or upgrade decision.
+- **INERT – Inactive comment:** The match exists only in commented-out code. No runtime change is required; clean up when appropriate.
+
+## Complete Classification
+
+### IDEMPIERE_7082_HANDLED – Already Handled Separately by IDEMPIERE-7082 (52)
+
+These entries belong to PR #3332 and are explicitly excluded from the follow-up Jira ticket. The first 50 references refer to the PR base version; these Java-side conversions were removed and the relevant comparisons were changed to use consistent database-side normalization. The final two entries are current compatibility-sensitive locations whose behavior was deliberately retained and reviewed in the same PR.
+
+#### Removed Java-Side Search Conversions (50)
+
+- **H** — `org.adempiere.base.process/src/org/compiere/process/InventoryCountCreate.java:213` *(PR base)* — `pstmt.setString(index++, p_LocatorValue.toUpperCase());`
+- **H** — `org.adempiere.base.process/src/org/compiere/process/InventoryCountCreate.java:215` *(PR base)* — `pstmt.setString(index++, p_ProductValue.toUpperCase());`
+- **H** — `org.adempiere.base/src/org/compiere/model/MLabel.java:182` *(PR base)* — `.setParameters(Env.getAD_Client_ID(ctx), name.toUpperCase())`
+- **H** — `org.adempiere.base/src/org/compiere/model/MUserQuery.java:246` *(PR base)* — `pstmt.setString (3, name.toUpperCase());`
+- **H** — `org.adempiere.base/src/org/compiere/model/MUserQuery.java:277` *(PR base)* — `.setParameters(Env.getAD_Client_ID (ctx), AD_Tab_ID, name.toUpperCase(), Env.getAD_User_ID(ctx))`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WAccountEditor.java:198` *(PR base)* — `pstmt.setString(2, text.toUpperCase());`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WAccountEditor.java:199` *(PR base)* — `pstmt.setString(3, text.toUpperCase());`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WLocatorEditor.java:382` *(PR base)* — `text = text.toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WLocatorEditor.java:384` *(PR base)* — `text = text.toUpperCase() + "%";`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoAssetPanel.java:291` *(PR base)* — `String value = fieldValue.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoAssetPanel.java:298` *(PR base)* — `String name = fieldName.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoAssetPanel.java:341` *(PR base)* — `String value = fieldValue.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoAssetPanel.java:354` *(PR base)* — `String name = fieldName.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoBPartnerPanel.java:381` *(PR base)* — `String value = fieldValue.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoBPartnerPanel.java:390` *(PR base)* — `String name = fieldName.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoBPartnerPanel.java:399` *(PR base)* — `String contact = fieldContact.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoBPartnerPanel.java:408` *(PR base)* — `String email = fieldEMail.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoBPartnerPanel.java:417` *(PR base)* — `String phone = fieldPhone.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoBPartnerPanel.java:426` *(PR base)* — `String postal = fieldPostal.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoBPartnerPanel.java:448` *(PR base)* — `String value = fieldValue.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoBPartnerPanel.java:452` *(PR base)* — `String name = fieldName.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoBPartnerPanel.java:456` *(PR base)* — `String contact = fieldContact.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoBPartnerPanel.java:460` *(PR base)* — `String email = fieldEMail.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoBPartnerPanel.java:464` *(PR base)* — `String phone = fieldPhone.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoBPartnerPanel.java:468` *(PR base)* — `String postal = fieldPostal.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoCashLinePanel.java:482` *(PR base)* — `String s = f.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoGeneralPanel.java:685` *(PR base)* — `addSQLWhere (sql, 0, txt1.getText().toUpperCase());`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoGeneralPanel.java:686` *(PR base)* — `addSQLWhere (sql, 1, txt2.getText().toUpperCase());`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoGeneralPanel.java:687` *(PR base)* — `addSQLWhere (sql, 2, txt3.getText().toUpperCase());`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoGeneralPanel.java:688` *(PR base)* — `addSQLWhere (sql, 3, txt4.getText().toUpperCase());`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoGeneralPanel.java:708` *(PR base)* — `String s = f.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoInOutPanel.java:420` *(PR base)* — `String s = f.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoInvoicePanel.java:550` *(PR base)* — `String s = f.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoOrderPanel.java:513` *(PR base)* — `String s = f.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoPaymentPanel.java:481` *(PR base)* — `String s = f.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoProductPanel.java:1048` *(PR base)* — `String value = fieldValue.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoProductPanel.java:1053` *(PR base)* — `String name = fieldName.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoProductPanel.java:1058` *(PR base)* — `String upc = fieldUPC.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoProductPanel.java:1063` *(PR base)* — `String sku = fieldSKU.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoProductPanel.java:1067` *(PR base)* — `String vendor = fieldVendor.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoProductPanel.java:1128` *(PR base)* — `String value = fieldValue.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoProductPanel.java:1138` *(PR base)* — `String name = fieldName.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoProductPanel.java:1148` *(PR base)* — `String upc = fieldUPC.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoProductPanel.java:1158` *(PR base)* — `String sku = fieldSKU.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoProductPanel.java:1168` *(PR base)* — `String vendor = fieldVendor.getText().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/FindWindow.java:3029` *(PR base)* — `StringBuilder valueStr = new StringBuilder(value.toString().toUpperCase());`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WAccountDialog.java:859` *(PR base)* — `String value = f_Alias.getValue().toString().toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WAccountDialog.java:867` *(PR base)* — `String value = f_Combination.getValue().toString().toUpperCase();`
+- **H** — `org.adempiere.ui/src/org/compiere/apps/form/StatementCreateFromBatch.java:201` *(PR base)* — `String s = text.toUpperCase();`
+- **H** — `org.adempiere.ui/src/org/compiere/grid/CreateFromBatch.java:231` *(PR base)* — `String s = text.toUpperCase();`
+
+#### Deliberately Retained Compatibility Behavior (2)
+
+- **H** — `org.adempiere.base/src/org/compiere/model/PO.java:5763` *(current PR state)* — `return query.toUpperCase();` — Protected legacy helper retained for plugin compatibility and marked as deprecated.
+- **H** — `org.adempiere.ui/src/org/compiere/apps/form/StatementCreateFromBatch.java:163` *(current PR state)* — `pstmt.setString(index++, getSQLText(AuthCode).toUpperCase());` — Existing behavior for authorization codes retained after changing the shared helper.
+
+
+### DB_VALUE – Database Value Comparison (14)
+
+A parameter transformed with Java case mapping is compared with `UPPER(...)` or `LOWER(...)` in SQL. Recommendation: bind the original value and apply the same database function to both operands.
+
+- **H** — `org.adempiere.base/src/org/compiere/model/MColumn.java:1315` — `int duplicateId = DB.getSQLValueEx(column.get_TrxName(), "SELECT AD_Column_ID FROM AD_Column WHERE Upper(FkConstraintName)=?", fkConstraintName.toUpperCase());`
+- **H** — `org.adempiere.base/src/org/compiere/model/MColumn.java:1324` — `duplicateId = DB.getSQLValueEx(column.get_TrxName(), "SELECT AD_Column_ID FROM AD_Column WHERE Upper(FkConstraintName)=?", fkConstraintName.toUpperCase());`
+- **H** — `org.adempiere.base/src/org/compiere/model/MQuery.java:198` — `int cnt = DB.getSQLValueEx(null, "SELECT Count(*) From AD_Column WHERE IsActive='Y' AND AD_Client_ID=0 AND Upper(ColumnName)=? AND AD_Reference_ID=?", ParameterName.toUpperCase(), DisplayType.ChosenMultipleSelectionList);`
+- **H** — `org.adempiere.base/src/org/compiere/model/MSearchDefinition.java:107` — `pstmt.setString(1, transactionCode.toUpperCase());`
+- **H** — `org.adempiere.base/src/org/compiere/model/MSearchDefinition.java:145` — `pstmt.setString(1, transactionCode.toUpperCase());`
+- **H** — `org.adempiere.base/src/org/compiere/model/M_Element.java:101` — `.setParameters(columnName.toUpperCase())`
+- **H** — `org.adempiere.base/src/org/compiere/model/M_Element.java:197` — `int no = DB.getSQLValue(null, sql.toString(), columnName.toUpperCase());`
+- **H** — `org.adempiere.base/src/org/compiere/model/M_Element.java:250` — `.append(DB.TO_STRING(getColumnName().toUpperCase()))`
+- **H** — `org.adempiere.base/src/org/compiere/util/Msg.java:593` — `pstmt.setString(1, ColumnName.toUpperCase());`
+- **H** — `org.adempiere.pipo/src/org/adempiere/pipo2/IDFinder.java:113` — `paramList.add(s.toUpperCase());`
+- **H** — `org.adempiere.pipo/src/org/adempiere/pipo2/IDFinder.java:127` — `params = new Object[]{ ((String)value).toUpperCase()};`
+- **H** — `org.adempiere.pipo/src/org/adempiere/pipo2/IDFinder.java:344` — `pstmt.setString(1, name.toUpperCase());`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/DocumentSearchController.java:681` — `query.setParameters(transactionCode.toUpperCase());`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java:1449` — `int cnt = DB.getSQLValueEx(null, "SELECT Count(*) From AD_Column WHERE IsActive='Y' AND AD_Client_ID=0 AND Upper(ColumnName)=? AND AD_Reference_ID=?", column.toUpperCase(), DisplayType.ChosenMultipleSelectionList);`
+
+### DB_SCHEMA_SQL – SQL/Schema Mechanics (264)
+
+SQL grammar, table/column/index names, and database metadata. Recommendation: use `Locale.ROOT` or structural APIs; do not normalize SQL values differently in Java and the database.
+
+- **H** — `org.adempiere.base.process/src/org/compiere/process/ColumnSync.java:123` — `tableName = tableName.toUpperCase();`
+- **H** — `org.adempiere.base.process/src/org/compiere/process/ColumnSync.java:127` — `tableName = tableName.toLowerCase();`
+- **H** — `org.adempiere.base.process/src/org/compiere/process/CreateFromInOut.java:150` — `if (ColumnName.toUpperCase().endsWith("_ID"))`
+- **H** — `org.adempiere.base.process/src/org/compiere/process/CreateFromInvoice.java:148` — `if (ColumnName.toUpperCase().endsWith("_ID"))`
+- **H** — `org.adempiere.base.process/src/org/compiere/process/CreateFromRMA.java:140` — `if (ColumnName.toUpperCase().endsWith("_ID"))`
+- **H** — `org.adempiere.base.process/src/org/compiere/process/CreateWindowFromTable.java:193` — `if (table.getTableName().toLowerCase().endsWith("_trl")) {`
+- **H** — `org.adempiere.base.process/src/org/compiere/process/TableCreateColumns.java:114` — `tableName = tableName.toUpperCase();`
+- **H** — `org.adempiere.base.process/src/org/compiere/process/TableCreateColumns.java:117` — `tableName = tableName.toLowerCase();`
+- **H** — `org.adempiere.base.process/src/org/compiere/process/TableCreateColumns.java:167` — `String tn = tableName.toUpperCase();`
+- **H** — `org.adempiere.base.process/src/org/compiere/process/TableCreateColumns.java:195` — `tableName = tableName.toUpperCase();`
+- **H** — `org.adempiere.base.process/src/org/compiere/process/TableCreateColumns.java:198` — `tableName = tableName.toLowerCase();`
+- **H** — `org.adempiere.base.process/src/org/compiere/process/TableCreateColumns.java:288` — `else if (columnName.toUpperCase().endsWith ("_ID"))`
+- **H** — `org.adempiere.base.process/src/org/compiere/process/TableCreateColumns.java:348` — `|| columnName.toUpperCase().startsWith("CREATED")`
+- **H** — `org.adempiere.base.process/src/org/compiere/process/TableCreateColumns.java:349` — `|| columnName.toUpperCase().equals("UPDATED") ))`
+- **H** — `org.adempiere.base.process/src/org/idempiere/process/CreateTable.java:452` — `&& !table.getTableName().toUpperCase().endsWith("_TRL")`
+- **H** — `org.adempiere.base.process/src/org/idempiere/process/CreateTable.java:525` — `if (p_isCreateTranslationTable && !table.getTableName().toUpperCase().endsWith("_TRL"))`
+- **H** — `org.adempiere.base.process/src/org/idempiere/process/CreateTable.java:541` — `if (p_isCreateTranslationTable && !table.getTableName().toUpperCase().endsWith("_TRL"))`
+- **H** — `org.adempiere.base/src/org/adempiere/process/UUIDGenerator.java:298` — `tableName = tableName.toUpperCase();`
+- **H** — `org.adempiere.base/src/org/adempiere/process/UUIDGenerator.java:302` — `tableName = tableName.toLowerCase();`
+- **H** — `org.adempiere.base/src/org/adempiere/util/ModelClassGenerator.java:548` — `if (columnName.toLowerCase().startsWith("is"))`
+- **H** — `org.adempiere.base/src/org/adempiere/util/ModelClassGenerator.java:657` — `.append("\n\tpublic static final int ").append(columnName.toUpperCase())`
+- **H** — `org.adempiere.base/src/org/adempiere/util/ModelClassGenerator.java:737` — `retValue.append("\n\tpublic static final String ").append(columnName.toUpperCase())`
+- **H** — `org.adempiere.base/src/org/adempiere/util/ModelInterfaceGenerator.java:361` — `if (columnName.toLowerCase().startsWith("is"))`
+- **H** — `org.adempiere.base/src/org/adempiere/util/ModelInterfaceGenerator.java:815` — `StringBuilder tableLike = new StringBuilder().append(tableName.trim().toUpperCase().replace("'", ""));`
+- **H** — `org.adempiere.base/src/org/compiere/db/StatementProxy.java:117` — `logSql = getSql().toUpperCase();`
+- **H** — `org.adempiere.base/src/org/compiere/dbPort/Convert.java:364` — `if (sqlStatement.toUpperCase().indexOf("EXCEPTION WHEN") != -1) {`
+- **H** — `org.adempiere.base/src/org/compiere/dbPort/Convert.java:626` — `String uppStmt = statement.toUpperCase().trim();`
+- **H** — `org.adempiere.base/src/org/compiere/dbPort/Convert_SQL92.java:57` — `int fromIndex = Util.findIndexOf (sqlStatement.toUpperCase(), " FROM ");`
+- **H** — `org.adempiere.base/src/org/compiere/dbPort/Convert_SQL92.java:58` — `int whereIndex = Util.findIndexOf(sqlStatement.toUpperCase(), " WHERE ");`
+- **H** — `org.adempiere.base/src/org/compiere/dbPort/Convert_SQL92.java:59` — `int endWhereIndex = Util.findIndexOf(sqlStatement.toUpperCase(), " GROUP BY ");`
+- **H** — `org.adempiere.base/src/org/compiere/dbPort/Convert_SQL92.java:61` — `endWhereIndex = Util.findIndexOf(sqlStatement.toUpperCase(), " ORDER BY ");`
+- **H** — `org.adempiere.base/src/org/compiere/dbPort/Convert_SQL92.java:331` — `int index = statement.toUpperCase().indexOf("DECODE", fromIndex);`
+- **H** — `org.adempiere.base/src/org/compiere/dbPort/Convert_SQL92.java:417` — `int index = sqlStatement.toUpperCase().indexOf("DELETE ");`
+- **H** — `org.adempiere.base/src/org/compiere/model/GridField.java:687` — `&& m_vo.DefaultValue.toUpperCase().equals("NULL")) // IDEMPIERE-2678`
+- **H** — `org.adempiere.base/src/org/compiere/model/GridField.java:1075` — `if (value == null || value.toString().length() == 0 || value.toUpperCase().equals("NULL"))`
+- **H** — `org.adempiere.base/src/org/compiere/model/MColumn.java:557` — `if (tableName.toLowerCase().endsWith("_trl")) {`
+- **H** — `org.adempiere.base/src/org/compiere/model/MColumn.java:823` — `|| (!caseSensitive && columnName.toUpperCase().indexOf("Name".toUpperCase()) != -1) )`
+- **H** — `org.adempiere.base/src/org/compiere/model/MColumn.java:1057` — `referenceTableName = referenceTableName.toUpperCase();`
+- **H** — `org.adempiere.base/src/org/compiere/model/MColumn.java:1058` — `tableName = tableName.toUpperCase();`
+- **H** — `org.adempiere.base/src/org/compiere/model/MColumn.java:1060` — `referenceTableName = referenceTableName.toLowerCase();`
+- **H** — `org.adempiere.base/src/org/compiere/model/MColumn.java:1061` — `tableName = tableName.toLowerCase();`
+- **H** — `org.adempiere.base/src/org/compiere/model/MColumn.java:1077` — `String key = dbFKName.toLowerCase();`
+- **H** — `org.adempiere.base/src/org/compiere/model/MColumn.java:1236` — `tableName = tableName.toUpperCase();`
+- **H** — `org.adempiere.base/src/org/compiere/model/MColumn.java:1238` — `tableName = tableName.toLowerCase();`
+- **H** — `org.adempiere.base/src/org/compiere/model/MColumn.java:1304` — `if (columnName.toUpperCase().endsWith("_ID"))`
+- **H** — `org.adempiere.base/src/org/compiere/model/MColumn.java:1416` — `if (! newColumnName.toLowerCase().equals(getColumnName().toLowerCase())) {`
+- **H** — `org.adempiere.base/src/org/compiere/model/MQuery.java:2011` — `int selectIndex = ColumnName.toLowerCase().indexOf("select ");`
+- **H** — `org.adempiere.base/src/org/compiere/model/MQuery.java:2012` — `int fromIndex = ColumnName.toLowerCase().indexOf(" from ");`
+- **H** — `org.adempiere.base/src/org/compiere/model/MQuery.java:2032` — `if (ColumnName.toUpperCase().startsWith("UPPER(")) {`
+- **H** — `org.adempiere.base/src/org/compiere/model/MQuery.java:2111` — `int selectIndex = ColumnName.toLowerCase().indexOf("select ");`
+- **H** — `org.adempiere.base/src/org/compiere/model/MQuery.java:2112` — `int fromIndex = ColumnName.toLowerCase().indexOf(" from ");`
+- **H** — `org.adempiere.base/src/org/compiere/model/MQuery.java:2126` — `boolean useUpper = (Code instanceof String) && ColumnName.toUpperCase().startsWith("UPPER(");`
+- **H** — `org.adempiere.base/src/org/compiere/model/MRole.java:2146` — `if (TableName.toUpperCase().endsWith("_TRL")) continue;`
+- **H** — `org.adempiere.base/src/org/compiere/model/MRole.java:2199` — `if (mainSql.toUpperCase().startsWith("SELECT COUNT(*) FROM ")) {`
+- **H** — `org.adempiere.base/src/org/compiere/model/MSequence.java:881` — `pstmt.setString(1, tableName.toUpperCase());`
+- **H** — `org.adempiere.base/src/org/compiere/model/MTable.java:173` — `pstmt.setString(1, tableName.toUpperCase());`
+- **H** — `org.adempiere.base/src/org/compiere/model/MTable.java:396` — `m_columnNameMap.put(column.getColumnName().toUpperCase(), list.size() - 1);`
+- **H** — `org.adempiere.base/src/org/compiere/model/MTable.java:441` — `Integer i = m_columnNameMap.get(ColumnName.toUpperCase());`
+- **H** — `org.adempiere.base/src/org/compiere/model/MTable.java:556` — `return m_columnNameMap.get(uuColName.toUpperCase()) != null;`
+- **H** — `org.adempiere.base/src/org/compiere/model/MViewComponent.java:178` — `if (colSQL == null || colSQL.toUpperCase().equals("NULL"))`
+- **H** — `org.adempiere.base/src/org/compiere/model/PO.java:914` — `&& value.toString().toUpperCase().indexOf("=NULL") != -1)`
+- **H** — `org.adempiere.base/src/org/compiere/model/POInfo.java:226` — `m_columnNameMap.put(ColumnName.toUpperCase(), list.size() - 1);`
+- **H** — `org.adempiere.base/src/org/compiere/model/POInfo.java:317` — `Integer i = m_columnNameMap.get(ColumnName.toUpperCase());`
+- **H** — `org.adempiere.base/src/org/compiere/model/Query.java:192` — `if (this.orderBy != null && this.orderBy.toUpperCase().startsWith("ORDER BY"))`
+- **H** — `org.adempiere.base/src/org/compiere/model/SetGetUtil.java:204` — `columnNames[i - 1] = rsmd.getColumnName(i).toUpperCase();`
+- **H** — `org.adempiere.base/src/org/compiere/print/DataEngine.java:239` — `if (format.isTranslationView() && tableName.toLowerCase().endsWith("_v"))	//	_vt not just _v`
+- **H** — `org.adempiere.base/src/org/compiere/print/DataEngine.java:340` — `if (tableName.toLowerCase().endsWith("_vt")){`
+- **H** — `org.adempiere.base/src/org/compiere/print/DataEngine.java:362` — `if (tableName.toLowerCase().endsWith("_vt")){`
+- **H** — `org.adempiere.base/src/org/compiere/print/MPrintFormat.java:479` — `if (m_translationViewLanguage != null && query != null && query.getTableName().toUpperCase().endsWith("_V"))`
+- **H** — `org.adempiere.base/src/org/compiere/process/CreateForeignKey.java:150` — `tableName = tableName.toUpperCase();`
+- **H** — `org.adempiere.base/src/org/compiere/process/CreateForeignKey.java:152` — `tableName = tableName.toLowerCase();`
+- **H** — `org.adempiere.base/src/org/compiere/process/CreateForeignKey.java:166` — `String key = dbFKName.toLowerCase();`
+- **H** — `org.adempiere.base/src/org/compiere/process/CreateForeignKey.java:204` — `int AD_Column_ID = DB.getSQLValue(null, getColumnIDSql, table.getAD_Table_ID(), columnName.toLowerCase());`
+- **H** — `org.adempiere.base/src/org/compiere/process/CreateTableIndex.java:125` — `tableName = tableName.toUpperCase();`
+- **H** — `org.adempiere.base/src/org/compiere/process/CreateTableIndex.java:127` — `tableName = tableName.toLowerCase();`
+- **H** — `org.adempiere.base/src/org/compiere/process/CreateTableIndex.java:140` — `String key = dbIndexName.toLowerCase();`
+- **H** — `org.adempiere.base/src/org/compiere/process/CreateTableIndex.java:176` — `tableName = tableName.toUpperCase();`
+- **H** — `org.adempiere.base/src/org/compiere/process/CreateTableIndex.java:178` — `tableName = tableName.toLowerCase();`
+- **H** — `org.adempiere.base/src/org/compiere/process/CreateTableIndex.java:184` — `String key = primaryKeyName.toLowerCase();`
+- **H** — `org.adempiere.base/src/org/compiere/process/CreateTableIndex.java:199` — `String key = tableIndex.getName().toLowerCase();`
+- **H** — `org.adempiere.base/src/org/compiere/process/CreateTableIndex.java:228` — `int AD_Column_ID = DB.getSQLValue(null, getColumnIDSql, table.getAD_Table_ID(), dbIndexColumn.toLowerCase());`
+- **H** — `org.adempiere.base/src/org/compiere/process/DatabaseElementColumnRename.java:64` — `|| p_NewColumnName.toLowerCase().equals(element.getColumnName().toLowerCase())) {`
+- **H** — `org.adempiere.base/src/org/compiere/process/DatabaseTableRename.java:77` — `|| p_NewTableName.toLowerCase().equals(oldTableName.toLowerCase())) {`
+- **H** — `org.adempiere.base/src/org/compiere/process/DatabaseTableRename.java:82` — `p_NewTableName.toLowerCase());`
+- **H** — `org.adempiere.base/src/org/compiere/process/DatabaseTableRename.java:163` — `String colPrefix = oldTableName.toLowerCase();`
+- **H** — `org.adempiere.base/src/org/compiere/process/DatabaseTableRename.java:170` — `if (element.getColumnName().toLowerCase().endsWith("_id")) {`
+- **H** — `org.adempiere.base/src/org/compiere/process/DatabaseViewValidate.java:73` — `tableName = tableName.toUpperCase();`
+- **H** — `org.adempiere.base/src/org/compiere/process/DatabaseViewValidate.java:75` — `tableName = tableName.toLowerCase();`
+- **H** — `org.adempiere.base/src/org/compiere/process/TableIndexValidate.java:70` — `tableName = tableName.toUpperCase();`
+- **H** — `org.adempiere.base/src/org/compiere/process/TableIndexValidate.java:72` — `tableName = tableName.toLowerCase();`
+- **H** — `org.adempiere.base/src/org/compiere/util/DB.java:2489` — `tblName = tableName.toUpperCase();`
+- **H** — `org.adempiere.base/src/org/compiere/util/DB.java:2491` — `tblName = tableName.toLowerCase();`
+- **H** — `org.adempiere.base/src/org/compiere/util/DB.java:2900` — `String cleanSql = sql.toLowerCase().replaceAll(removeComments, "").replaceAll(removeQuotedStrings, "").replaceFirst(removeLeadingSpaces, "");`
+- **H** — `org.adempiere.base/src/org/idempiere/fa/feature/UseLifeImpl.java:330` — `String columnName = mField.getColumnName().toUpperCase();`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:223` — `p_tablesToExcludeList.add(tableName.toUpperCase());`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:229` — `p_excludeTablesWhere.append(DB.TO_STRING(tableName.toUpperCase()));`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:274` — `p_tablesToPreserveIDsList.add(tableName.toUpperCase());`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:530` — `stmtRC.setString(1, tableName.toUpperCase());`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:537` — `p_columnsVerifiedList.add(tableName.toUpperCase() + "." + columnName.toUpperCase());`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:547` — `p_tablesVerifiedList.add(tableName.toUpperCase());`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:622` — `.append(" WHERE UPPER(AD_Table.TableName)='").append(tableName.toUpperCase())`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:623` — `.append("' AND UPPER(AD_Column.ColumnName)='").append(columnName.toUpperCase()).append("'))")`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:677` — `if (! p_idSystemConversionList.contains(foreignTableName.toUpperCase() + "." + foreignID)) {`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:692` — `p_columnsVerifiedList.add(tableName.toUpperCase() + "." + columnName.toUpperCase());`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:721` — `.append("WHERE  UPPER(t.TableName)=").append(DB.TO_STRING(tableName.toUpperCase()))`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:722` — `.append("       AND UPPER(c.ColumnName)=").append(DB.TO_STRING(columnName.toUpperCase()))`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:804` — `if (! p_tablesVerifiedList.contains(tableName.toUpperCase())) {`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:810` — `keyCol = uuidCol.toUpperCase();`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:812` — `keyCol = tableName.toUpperCase() + "_ID";`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:813` — `if (! p_columnsVerifiedList.contains(tableName.toUpperCase() + "." + keyCol))`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:836` — `if (p_isPreserveAll || p_tablesToPreserveIDsList.contains(tableName.toUpperCase())) {`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:869` — `stmtInsertConv.setString(2, tableName.toUpperCase());`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:883` — `new Object[] {getAD_PInstance_ID(), tableName.toUpperCase(), source_Key.toString(), target_Key.toString(), null},`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:930` — `if (! p_tablesVerifiedList.contains(tableName.toUpperCase())) {`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:944` — `if (! p_columnsVerifiedList.contains(tableName.toUpperCase() + "." + columnName.toUpperCase())) {`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:1064` — `if (att.toUpperCase().endsWith("_ID")) {`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:1151` — `String newUUID = DB.getSQLValueStringEx(get_TrxName(), queryT_MoveClient, getAD_PInstance_ID(), tableName.toUpperCase(), oldUUID);`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:1272` — `if (p_tablesToExcludeList.contains(convertTable.toUpperCase())) {`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:1298` — `getAD_PInstance_ID(), convertTable.toUpperCase(), String.valueOf(key));`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:1314` — `new Object[] {getAD_PInstance_ID(), convertTable.toUpperCase(), key.toString(), convertedId.toString(), null},`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:1538` — `new Object[] {getAD_PInstance_ID(), foreignTableName.toUpperCase(), foreign_Key, local_Key, identifier},`
+- **H** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:1540` — `p_idSystemConversionList.add(foreignTableName.toUpperCase() + "." + foreign_Key);`
+- **H** — `org.adempiere.base/src/org/idempiere/process/VerifyMigration.java:212` — `listDict.add(columnName.toUpperCase());`
+- **H** — `org.adempiere.base/src/org/idempiere/process/VerifyMigration.java:213` — `mapDict.put(columnName.toUpperCase(), vcol);`
+- **H** — `org.adempiere.base/src/org/idempiere/process/VerifyMigration.java:232` — `tableName = tableName.toUpperCase();`
+- **H** — `org.adempiere.base/src/org/idempiere/process/VerifyMigration.java:234` — `tableName = tableName.toLowerCase();`
+- **H** — `org.adempiere.base/src/org/idempiere/process/VerifyMigration.java:238` — `listDB.add(columnName.toUpperCase());`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/AttributeElementHandler.java:74` — `if (!excludes.contains(column.getColumnName().toLowerCase()))`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/AttributeElementHandler.java:76` — `excludes.add(column.getColumnName().toLowerCase());`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/AttributeElementHandler.java:83` — `if (excludes.contains(keycol.toLowerCase()))`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/AttributeUseElementHandler.java:78` — `if (!excludes.contains(column.getColumnName().toLowerCase()))`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/AttributeUseElementHandler.java:80` — `excludes.add(column.getColumnName().toLowerCase());`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/AttributeUseElementHandler.java:87` — `if (excludes.contains(keycol.toLowerCase()))`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/ColumnElementHandler.java:250` — `tableName = tableName.toUpperCase();`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/ColumnElementHandler.java:251` — `columnName = columnName.toUpperCase();`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/ColumnElementHandler.java:253` — `tableName = tableName.toLowerCase();`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/ColumnElementHandler.java:254` — `columnName = columnName.toLowerCase();`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/GenericPOElementHandler.java:145` — `boolean checkExcluded = ! sql.toLowerCase().startsWith("select *");`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/GenericPOElementHandler.java:166` — `if (!excludes.contains(column.getColumnName().toLowerCase())) {`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/GenericPOElementHandler.java:167` — `excludes.add(column.getColumnName().toLowerCase());`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/GenericPOElementHandler.java:172` — `if (excludes.contains(keycol.toLowerCase())) {`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/GenericPOElementHandler.java:176` — `if (excludes.contains(po.getUUIDColumnName().toLowerCase())) {`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/MenuElementHandler.java:139` — `String colName = meta.getColumnName(q).toUpperCase();`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/SQLMandatoryElementHandler.java:59` — `if (sql.endsWith(";") && !(sql.toLowerCase().endsWith("end;")))`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/SQLMandatoryElementHandler.java:96` — `if (sql.toLowerCase().startsWith("delete from ")) {`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/SQLMandatoryElementHandler.java:99` — `String tableName = DB.getSQLValueString(null, "SELECT TableName FROM AD_Table WHERE LOWER(TableName)=?", table.toLowerCase());`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/SQLStatementElementHandler.java:51` — `if (sql.endsWith(";") && !(sql.toLowerCase().endsWith("end;")))`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/SQLStatementElementHandler.java:97` — `if (sql.toLowerCase().startsWith("delete from ")) {`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/SQLStatementElementHandler.java:100` — `String tableName = DB.getSQLValueString(null, "SELECT TableName FROM AD_Table WHERE LOWER(TableName)=?", table.toLowerCase());`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/TableAttributeElementHandler.java:84` — `if (!excludes.contains(column.getColumnName().toLowerCase()))`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/TableAttributeElementHandler.java:86` — `excludes.add(column.getColumnName().toLowerCase());`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/TableAttributeElementHandler.java:93` — `if (excludes.contains(keycol.toLowerCase()))`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/TableAttributeSetElementHandler.java:77` — `if (!excludes.contains(column.getColumnName().toLowerCase()))`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/TableAttributeSetElementHandler.java:79` — `excludes.add(column.getColumnName().toLowerCase());`
+- **H** — `org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/TableAttributeSetElementHandler.java:86` — `if (excludes.contains(keycol.toLowerCase()))`
+- **H** — `org.adempiere.pipo/src/org/adempiere/pipo2/GridTab2PackExporter.java:74` — `if (child.getTableName().toLowerCase().endsWith("_trl")) // ignore trl tabs as they are exported as translation`
+- **H** — `org.adempiere.pipo/src/org/adempiere/pipo2/GridTab2PackExporter.java:186` — `if (gridTab.getTableName().toLowerCase().endsWith("_trl"))`
+- **H** — `org.adempiere.pipo/src/org/adempiere/pipo2/PackInHandler.java:459` — `if (fkConstraintSql.toLowerCase().contains(" ad_sequence(ad_sequence_id)"))`
+- **H** — `org.adempiere.report.jasper/src/org/adempiere/report/jasper/ReportStarter.java:336` — `if (subreports[i].getName().toLowerCase().endsWith(".jasper")`
+- **H** — `org.adempiere.report.jasper/src/org/adempiere/report/jasper/ReportStarter.java:337` — `|| subreports[i].getName().toLowerCase().endsWith(".jrxml"))`
+- **H** — `org.adempiere.report.jasper/src/org/adempiere/report/jasper/ReportStarter.java:638` — `String originalQueryTemp = originalQueryText.toUpperCase();`
+- **H** — `org.adempiere.report.jasper/src/org/adempiere/report/jasper/ReportStarter.java:639` — `int index1 = originalQueryTemp.indexOf(" " + tableName.toUpperCase());`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WSQLProcess.java:229` — `String SQL = sql.toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WSQLQuery.java:209` — `String SQL = sql.toUpperCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WSQLQuery.java:273` — `String colName = header.get(col).toLowerCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WTableDirEditor.java:308` — `if (tableName.toUpperCase().equals("C_BPARTNER_LOCATION"))`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java:1192` — `if (! colSQL.toUpperCase().contains(" AS "))`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java:1295` — `if (! colSQL.toUpperCase().contains(" AS "))`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java:1423` — `int asIndex = columnName.toUpperCase().lastIndexOf(" AS ");`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java:1502` — `if (columnClause.toUpperCase().startsWith("UPPER(")) {`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java:1514` — `if (columnClause.toUpperCase().startsWith("UPPER(")) {`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java:1528` — `if (columnClause.toUpperCase().startsWith("UPPER(")) {`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java:2565` — `if(sql.substring(i, i+6).toUpperCase().matches("^(\\s+FROM)(\\s)") && parenthesisLevel == 0)`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java:2981` — `if (! colSQL.toUpperCase().contains(" AS "))`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/RelatedInfoWindow.java:542` — `if (tmp.toLowerCase().endsWith("as"))`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoPanel.java:1544` — `if (tmp.toLowerCase().endsWith("as") && hasAlias)`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/config/ConfigOracle.java:95` — `list.add(def.toLowerCase());`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/config/ConfigOracle.java:96` — `dblist.add(def.toLowerCase());`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/config/ConfigOracle.java:117` — `String entry = entries[e].toLowerCase();`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/config/ConfigOracle.java:269` — `String entry = line.substring(0, line.indexOf('=')).trim().toLowerCase();`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/config/ConfigOracle.java:277` — `&& line.toUpperCase().indexOf("SERVICE_NAME") != -1)`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/config/ConfigOracle.java:279` — `String entry = line.substring(line.indexOf('=')+1).trim().toLowerCase();`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/config/ConfigOracle.java:340` — `data.setProperty(ConfigurationData.ADEMPIERE_DB_PATH, data.getDatabaseType().toLowerCase());`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/partition/TablePartitionService.java:67` — `return DB.getSQLValueEx(trxName, sql, table.getTableName().toUpperCase()) == 1;`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/partition/TablePartitionService.java:182` — `String partKeyColumn = DB.getSQLValueString(trxName, sql, table.getTableName().toUpperCase());`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/partition/TablePartitionService.java:270` — `stmt.setString(1, table.getTableName().toUpperCase());`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/partition/TablePartitionService.java:271` — `stmt.setString(2, primaryPartition.getName().toUpperCase());`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/partition/TablePartitionService.java:352` — `List<List<Object>> columnNames = DB.getSQLArrayObjectsEx(trxName, sql, table.getTableName().toUpperCase());`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/partition/TablePartitionService.java:384` — `String intervalColumn = DB.getSQLValueString(trxName, sql, table.getTableName().toUpperCase());`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/partition/TablePartitionService.java:386` — `if (partitionKeyColumn.getColumnName().toUpperCase().equals(intervalColumn)) {`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/partition/TablePartitionService.java:387` — `if (!interval.toUpperCase().equals(expression)) {`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/partition/TablePartitionService.java:409` — `List<List<Object>> columnNames = DB.getSQLArrayObjectsEx(trxName, sql, table.getTableName().toUpperCase());`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/partition/TablePartitionService.java:450` — `stmt.setString(1, table.getTableName().toUpperCase());`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/partition/TablePartitionService.java:488` — `String autoList = DB.getSQLValueStringEx(trxName, sql, table.getTableName().toUpperCase());`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/partition/TablePartitionService.java:504` — `String interval = DB.getSQLValueStringEx(trxName, sql, table.getTableName().toUpperCase());`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/partition/TablePartitionService.java:520` — `String type = DB.getSQLValueStringEx(trxName, sql, table.getTableName().toUpperCase());`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/partition/TablePartitionService.java:735` — `stmt.setString(1, table.getTableName().toUpperCase());`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/partition/TablePartitionService.java:736` — `stmt.setString(2, table.getTableName().toUpperCase());`
+- **H** — `org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/partition/TablePartitionService.java:737` — `stmt.setString(3, table.getTableName().toUpperCase());`
+- **H** — `org.compiere.db.oracle.provider/src/org/compiere/db/DB_Oracle.java:300` — `return m_userName.toUpperCase();`
+- **H** — `org.compiere.db.oracle.provider/src/org/compiere/db/DB_Oracle.java:841` — `int m_sequence_id = DB.getSQLValueEx(trxName, "SELECT "+name.toUpperCase()+".nextval FROM DUAL");`
+- **H** — `org.compiere.db.oracle.provider/src/org/compiere/db/DB_Oracle.java:848` — `final int cnt = DB.getSQLValueEx(trxName, "SELECT COUNT(*) FROM USER_SEQUENCES WHERE UPPER(sequence_name)=?", name.toUpperCase());`
+- **H** — `org.compiere.db.oracle.provider/src/org/compiere/db/DB_Oracle.java:856` — `no = DB.executeUpdate("CREATE SEQUENCE "+name.toUpperCase()`
+- **H** — `org.compiere.db.oracle.provider/src/org/compiere/db/DB_Oracle.java:867` — `no = DB.executeUpdate("ALTER SEQUENCE "+name.toUpperCase()`
+- **H** — `org.compiere.db.oracle.provider/src/org/compiere/db/DB_Oracle.java:872` — `while (DB.getSQLValue(trxName, "SELECT " + name.toUpperCase() + ".NEXTVAL FROM DUAL") < start) {`
+- **H** — `org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/config/ConfigPostgreSQL.java:110` — `data.setProperty(ConfigurationData.ADEMPIERE_DB_PATH, data.getDatabaseType().toLowerCase());`
+- **H** — `org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java:150` — `lowerCasePartitionKeyColumnNames.add(partitionKeyColumnName.toLowerCase());`
+- **H** — `org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java:188` — `if (constraint_definition.indexOf(getDefaultPartitionName(table).toLowerCase()) >= 0) {`
+- **H** — `org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java:189` — `constraint_definition = constraint_definition.replace(getDefaultPartitionName(table).toLowerCase(), table.getTableName().toLowerCase());`
+- **H** — `org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java:227` — `stmt.setString(1, getDefaultPartitionName(table).toLowerCase());`
+- **H** — `org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java:245` — `String conindid = DB.getSQLValueString(trxName, consql, table.getTableName().toLowerCase(), indexName.toLowerCase());`
+- **H** — `org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java:252` — `if (!indexdef.contains(partitionKey.toLowerCase()+",") && !indexdef.contains(partitionKey.toLowerCase()+")")) {`
+- **H** — `org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java:253` — `int whereIndex = indexdef.toLowerCase().indexOf(" where ");`
+- **H** — `org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java:257` — `indexdef = indexdef.substring(0, indexdef.length()-1)+", "+partitionKey.toLowerCase()+")";`
+- **H** — `org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java:260` — `indexdef = indexdef.substring(0, indexdef.length()-1)+", "+partitionKey.toLowerCase()+")";`
+- **H** — `org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java:268` — `indexdef = indexdef.replace(" ON adempiere."+getDefaultPartitionName(table).toLowerCase()+" ", " ON adempiere."+table.getTableName().toLowerCase()+" ");`
+- **H** — `org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java:276` — `String conindid = DB.getSQLValueString(trxName, consql, table.getTableName().toLowerCase(), indexName.toLowerCase());`
+- **H** — `org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java:285` — `indexdef = indexdef.replace(" ON adempiere."+getDefaultPartitionName(table).toLowerCase()+" ", " ON adempiere."+table.getTableName().toLowerCase()+" ");`
+- **H** — `org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java:454` — `String defaultPartitionName = getDefaultPartitionName(table).toLowerCase();`
+- **H** — `org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java:455` — `String tableName = table.getTableName().toLowerCase();`
+- **H** — `org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java:479` — `stmt1.setString(1, viewName.toLowerCase());`
+- **H** — `org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java:569` — `currentPartitionKey += " (" + partitionKeyColumn.getColumnName().toLowerCase() + ")";`
+- **H** — `org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java:751` — `X_AD_TablePartition partition = createNewRangePartition(rangePartitionInterval, tablePartitionNames, table, partitionKeyColumn, table.getTableName().toLowerCase(),`
+- **H** — `org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java:790` — `if (partition.getName().toLowerCase().endsWith("_default_partition"))`
+- **H** — `org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java:950` — `List<X_AD_TablePartition> partitions = generateListPartition(table, table.getTableName().toLowerCase(), getDefaultPartitionName(table), partitionKeyColumn, columnValues, null, trxName);`
+- **H** — `org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java:991` — `if (partition.getName().toLowerCase().endsWith("_default_partition"))`
+- **H** — `org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java:1102` — `if (!partitionKey.toLowerCase().startsWith(currentPartitionKey.toLowerCase()))`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/db/DB_PostgreSQL.java:857` — `if (IXName.toUpperCase().endsWith("_KEY"))`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/db/DB_PostgreSQL.java:922` — `m_sequence_id = DB.getSQLValueEx(trxName, "SELECT nextval('"+name.toLowerCase()+"')");`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/db/DB_PostgreSQL.java:938` — `final int cnt = DB.getSQLValueEx(trxName, "SELECT COUNT(*) FROM pg_class WHERE UPPER(relname)=? AND relkind='S'", name.toUpperCase());`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/db/DB_PostgreSQL.java:946` — `no = DB.executeUpdate("CREATE SEQUENCE "+name.toUpperCase()`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/db/DB_PostgreSQL.java:956` — `no = DB.executeUpdate("ALTER SEQUENCE "+name.toUpperCase()`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/db/DB_PostgreSQL.java:1165` — `String lowerCase = columnName.toLowerCase();`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:111` — `String cmpString = statement.toUpperCase();`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:260` — `int found = retValue.toUpperCase().indexOf("DECODE");`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:265` — `found = retValue.toUpperCase().indexOf("DECODE", fromIndex);`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:269` — `int index = retValue.toUpperCase().indexOf("SELECT ");`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:307` — `String datatype = convertMap.get("\\b"+arg2.toUpperCase()+"\\b");`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:476` — `String sqlUpper = sqlStatement.toUpperCase();`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:690` — `(previousToken != null && previousToken.toUpperCase().endsWith("SELECT"))))`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:816` — `String fieldsUpper = fields.toUpperCase();`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:913` — `if ("SELECT".equalsIgnoreCase(t.toString().toUpperCase()))`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1057` — `if (sqlStatement.toUpperCase().indexOf("ALTER TABLE ") == 0) {`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1060` — `if (sqlStatement.toUpperCase().indexOf(" MODIFY ") > 0) {`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1062` — `begin_col = sqlStatement.toUpperCase().indexOf(" MODIFY ")`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1064` — `} else if (sqlStatement.toUpperCase().indexOf(" ADD ") > 0) {`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1065` — `if (sqlStatement.toUpperCase().indexOf(" ADD CONSTRAINT ") < 0 &&`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1066` — `sqlStatement.toUpperCase().indexOf(" ADD FOREIGN KEY " ) < 0 )`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1069` — `begin_col = sqlStatement.toUpperCase().indexOf(" ADD ")`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1104` — `if (rest.toUpperCase().indexOf(" DEFAULT ") != -1) {`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1105` — `String beforeDefault = rest.substring(0, rest.toUpperCase().indexOf(" DEFAULT "));`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1106` — `begin_default = rest.toUpperCase().indexOf(`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1161` — `if (rest.toUpperCase().startsWith("NOT ") || rest.toUpperCase().startsWith("NULL ")`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1162` — `|| rest.toUpperCase().equals("NULL") || rest.toUpperCase().equals("NOT NULL"))`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1173` — `if (rest.toUpperCase().indexOf(" DEFAULT ") != -1) {`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1174` — `begin_default = rest.toUpperCase().indexOf(`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1195` — `if (rest != null && rest.toUpperCase().indexOf("NOT NULL") >= 0)`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1197` — `else if (rest != null && rest.toUpperCase().indexOf("NULL") >= 0)`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1202` — `else if ( rest != null && rest.toUpperCase().indexOf("NOT NULL") >= 0 ) {`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1206` — `else if ( rest != null && rest.toUpperCase().indexOf("NULL") >= 0) {`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1213` — `tableName = tableName.toUpperCase().replace("ALTER TABLE", "");`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1214` — `tableName = tableName.trim().toLowerCase();`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1244` — `if (statement.toUpperCase().matches(".*\\bCLOB\\b.*\\bCONSTRAINT\\b.*CHECK\\b.*\\bIS JSON\\).*")) {`
+
+- **H** — `org.adempiere.base/src/org/compiere/model/MMeasureCalc.java:266` — `index = selectFrom.toUpperCase().indexOf("FROM ");`
+
+### TECH_TOKEN – Technical Token (65)
+
+Protocols, paths, file extensions, class/property names, CSS/OSGi values, and internal keys. Recommendation: use `Locale.ROOT`, `equalsIgnoreCase()`, or an explicitly ASCII-specific strategy.
+
+- **H** — `org.adempiere.base.process/src/org/adempiere/process/PrepareMigrationScripts.java:72` — `return name.toLowerCase().endsWith(".sql");`
+- **H** — `org.adempiere.base.process/src/org/compiere/process/RequestEMailProcessor.java:173` — `if(str_Protocol.toLowerCase().equals("imaps"))`
+- **H** — `org.adempiere.base.process/src/org/compiere/process/RequestEMailProcessor.java:175` — `else if(str_Protocol.toLowerCase().equals("imap"))`
+- **H** — `org.adempiere.base/src/org/adempiere/base/MappedColumnCalloutFactory.java:71` — `key.append(tableName.toLowerCase()).append("|").append(columnName.toLowerCase());`
+- **H** — `org.adempiere.base/src/org/adempiere/base/MappedColumnCalloutFactory.java:73` — `key1.append("*|").append(columnName.toLowerCase());`
+- **H** — `org.adempiere.base/src/org/adempiere/base/MappedColumnCalloutFactory.java:75` — `key2.append(tableName.toLowerCase()).append("|*");`
+- **H** — `org.adempiere.base/src/org/adempiere/base/MappedColumnCalloutFactory.java:96` — `key.append(tableName.toLowerCase()).append("|").append(columnName.toLowerCase());`
+- **H** — `org.adempiere.base/src/org/adempiere/base/MappedColumnCalloutFactory.java:110` — `key.append(tableName.toLowerCase()).append("|").append(columnName.toLowerCase());`
+- **H** — `org.adempiere.base/src/org/adempiere/base/sso/SSOUtils.java:141` — `String[] urlpath = request.getServletPath().toLowerCase().split("/");`
+- **H** — `org.adempiere.base/src/org/compiere/model/GridTab.java:3021` — `if (cmd.toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) {`
+- **H** — `org.adempiere.base/src/org/compiere/model/MAttachmentEntry.java:398` — `return m_name.toLowerCase().endsWith(".pdf");`
+- **H** — `org.adempiere.base/src/org/compiere/model/MAttachmentEntry.java:407` — `String m_lowname = m_name.toLowerCase();`
+- **H** — `org.adempiere.base/src/org/compiere/model/MMeasure.java:657` — `if (cmd.toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) {`
+- **H** — `org.adempiere.base/src/org/compiere/model/MProcess.java:482` — `if (pi.getClassName().toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) {`
+- **H** — `org.adempiere.base/src/org/compiere/model/MSession.java:528` — `skipChangeLogForUpdateSet.add(tableName.toUpperCase());`
+- **H** — `org.adempiere.base/src/org/compiere/model/MSession.java:537` — `skipChangeLogForUpdateSet.remove(tableName.toUpperCase());`
+- **H** — `org.adempiere.base/src/org/compiere/model/MSession.java:546` — `return skipChangeLogForUpdateSet.contains(tableName.toUpperCase());`
+- **H** — `org.adempiere.base/src/org/compiere/model/MSystem.java:402` — `setDBAddress(dbAddress.toLowerCase());`
+- **H** — `org.adempiere.base/src/org/compiere/model/MSystem.java:423` — `setDBInstance(dbName.toLowerCase());`
+- **H** — `org.adempiere.base/src/org/compiere/print/MPrintPaper.java:270` — `if (getCode().toLowerCase().startsWith("custom"))`
+- **H** — `org.adempiere.base/src/org/compiere/process/ServerProcessCtl.java:337` — `if (m_pi.getClassName().toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) {`
+- **H** — `org.adempiere.base/src/org/compiere/process/SvrProcess.java:833` — `map.put(name.toLowerCase(), field);`
+- **H** — `org.adempiere.base/src/org/compiere/process/SvrProcess.java:842` — `String name = parameter.getParameterName().trim().toLowerCase();`
+- **H** — `org.adempiere.base/src/org/compiere/util/EmailSrv.java:93` — `this.isSSL = this.imapHost.toLowerCase().startsWith ("imap.gmail.com");`
+- **H** — `org.adempiere.base/src/org/compiere/util/EmailSrv.java:113` — `this (imapHost, imapUser, imapPass, (imapHost != null && imapHost.toLowerCase().startsWith ("imap.gmail.com"))? 993 : 143, (imapHost != null && imapHost.toLowerCase().startsWith ("imap.gmail.com"))? true : false);`
+- **H** — `org.adempiere.base/src/org/compiere/util/Env.java:2285` — `osName = osName.toLowerCase();`
+- **H** — `org.adempiere.base/src/org/compiere/util/Env.java:2296` — `osName = osName.toLowerCase();`
+- **H** — `org.adempiere.base/src/org/compiere/util/MimeType.java:48` — `if (type[0].equals(extension.toLowerCase()))`
+- **H** — `org.adempiere.base/src/org/compiere/util/Msg.java:495` — `className += language.getLanguageCode().toUpperCase();`
+- **H** — `org.adempiere.base/src/org/idempiere/process/TranslationImpExp.java:126` — `if (! p_FileName.toLowerCase().endsWith(".zip")) {`
+- **H** — `org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/PackInApplicationActivator.java:295` — `if (toProcess.getName().toLowerCase().endsWith(".zip"))`
+- **H** — `org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/PackInApplicationActivator.java:304` — `if (file.getName().toUpperCase().endsWith(".ZIP") || file.isDirectory())`
+- **H** — `org.adempiere.report.jasper/src/org/adempiere/report/jasper/AttachmentResourceLoader.java:180` — `if (entries[i].getName().toLowerCase().endsWith(".jrxml")`
+- **H** — `org.adempiere.report.jasper/src/org/adempiere/report/jasper/AttachmentResourceLoader.java:181` — `|| entries[i].getName().toLowerCase().endsWith(".jasper")) {`
+- **H** — `org.adempiere.report.jasper/src/org/adempiere/report/jasper/ColumnLookup.java:130` — `} else if (t.toLowerCase().startsWith("chart/") && (key instanceof Number)) {`
+- **H** — `org.adempiere.report.jasper/src/org/adempiere/report/jasper/ColumnLookup.java:145` — `} else if (t.toLowerCase().startsWith("attachment/")) {`
+- **H** — `org.adempiere.report.jasper/src/org/adempiere/report/jasper/FileResourceLoader.java:128` — `String lower = name.toLowerCase();`
+- **H** — `org.adempiere.server/src/main/server/org/compiere/server/EMailProcessor.java:687` — `else if (p.getContentType().toUpperCase().startsWith("TEXT"))`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/AdempiereIdGenerator.java:104` — `return name.toLowerCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/AdempiereWebUI.java:667` — `ua = ua.toLowerCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/WLogin.java:80` — `ua = ua.toLowerCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WArchiveViewer.java:161` — `if (   media != null && iframe.getSrc() == null && media.getName().toLowerCase().endsWith(".pdf")`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WPluginManager.java:298` — `if (!Util.isEmpty(fFilter.getValue()) && !bundle.getSymbolicName().toUpperCase().contains(fFilter.getValue().toUpperCase()))`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/FlexHlayout.java:38` — `setPack(PackType.valueOf(pack.toUpperCase()));`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/FlexHlayout.java:52` — `setAlign(AlignType.valueOf(align.toUpperCase()));`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/FlexVlayout.java:38` — `setPack(PackType.valueOf(pack.toUpperCase()));`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/FlexVlayout.java:52` — `setAlign(AlignType.valueOf(align.toUpperCase()));`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WEditor.java:748` — `if (style != null && style.toLowerCase().startsWith(MStyle.SCLASS_PREFIX)) {`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WEditor.java:751` — `} else if (style != null && style.toLowerCase().startsWith(MStyle.ZCLASS_PREFIX)) {`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/ButtonFactory.java:101` — `String className = "btn-" + name.toLowerCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/ZulDashboardGadgetFactory.java:32` — `if (uri != null && uri.toLowerCase().endsWith(".zul")) {`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/LoginPanel.java:897` — `String baselang = s.substring(0, 2).toLowerCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/LoginPanel.java:898` — `StringBuffer lang = new StringBuffer(baselang).append("_").append(s.substring(3).toUpperCase());`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/LoginPanel.java:904` — `if (s.length() == 2 && !arrstr.contains(s.toLowerCase()))`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/LoginPanel.java:905` — `arrstr.add(s.toLowerCase());`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/sso/filter/SSOWebUIFilter.java:115` — `isAdminResRequest = isAdminResRequest || httpRequest.getServletPath().toLowerCase().startsWith("/admin");`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/sso/filter/SSOWebUIFilter.java:118` — `if (httpRequest.getServletPath().toLowerCase().startsWith("/index") || httpRequest.getServletPath().equalsIgnoreCase("/"))`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/sso/filter/SSOWebUIFilter.java:123` — `if (isAdminResRequest && httpRequest.getServletPath().toLowerCase().endsWith("admin"))`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/theme/ThemeManager.java:133` — `if (styleSheet.toLowerCase().startsWith("https://")) {`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WMediaDialog.java:288` — `if (data.toUpperCase().indexOf("<html>") >= 0)`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/ZkReportViewer.java:1958` — `if (jasperProcess.getClassname().toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) {`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/servlet/AttachmentImageServlet.java:66` — `if (imageData.name() != null && imageData.name().toLowerCase().endsWith(".svg")) {`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/ServerPushEndPoint.java:270` — `String lowerAttr = attr.toLowerCase();`
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/zkforge/keylistener/Keylistener.java:138` — `final String s = keys.substring(j + 1, k).toLowerCase();`
+- **H** — `org.adempiere.ui/src/org/compiere/apps/AbstractProcessCtl.java:359` — `if (m_pi.getClassName().toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) {`
+
+### USER_TEXT – User-Facing Text/UI Search (37)
+
+Natural-language labels, search text, and autocomplete comparisons. Recommendation: use an explicit login/user locale or `Collator`; do not apply `Locale.ROOT` indiscriminately.
+
+- **M** — `org.adempiere.install/src/org/compiere/install/util/AppsAction.java:101` — `Character ch = Character.valueOf(toolTipText.toUpperCase().charAt(pos+1));`
+- **M** — `org.adempiere.server/src/main/server/org/compiere/server/RequestProcessor.java:626` — `QText = QText.toUpperCase();`
+- **M** — `org.adempiere.server/src/main/server/org/compiere/server/RequestProcessor.java:642` — `StringTokenizer st = new StringTokenizer(keyword.toUpperCase(), " ,;\t\n\r\f");`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/DocumentSearchController.java:190` — `String matchString = searchString.toLowerCase();`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/DocumentSearchController.java:193` — `matchString = searchString.substring(searchString.indexOf(" ") + 1).toLowerCase();`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/DocumentSearchController.java:423` — `int match = inputString.toLowerCase().indexOf(matchString);`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/DocumentSearchController.java:439` — `match = inputString.toLowerCase().indexOf(matchString);`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/DocumentSearchController.java:635` — `int match = label.toLowerCase().indexOf(matchString);`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/DocumentSearchController.java:649` — `match = label.toLowerCase().indexOf(matchString);`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/DocumentSearchController.java:738` — `text = text.toLowerCase();`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/DocumentSearchController.java:753` — `} else if (firstStart == null && result.getLabel().toLowerCase().startsWith(text) && text.length() >= 3) {`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/LabelsSearchController.java:197` — `if (rs.getString(2).toUpperCase().equals(value.toUpperCase())) {`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/MenuSearchController.java:590` — `label2 = Util.deleteAccents(label2.toLowerCase());`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/MenuSearchController.java:593` — `compare = Util.deleteAccents(compare.toLowerCase());`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/MenuSearchController.java:662` — `text = text.toLowerCase();`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/MenuSearchController.java:675` — `} else if (firstStart == null && label.toLowerCase().startsWith(text) && text.length() >= 3) {`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/MenuSearchController.java:733` — `if (!Util.isEmpty(highlightText, true) && Util.deleteAccents(data.getLabel()).toLowerCase().contains(Util.deleteAccents(highlightText).toLowerCase())) {`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/MenuSearchController.java:738` — `String matchString = Util.deleteAccents(highlightText.toLowerCase());`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/MenuSearchController.java:739` — `int match = unaccentedLabel.toLowerCase().indexOf(matchString);`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/MenuSearchController.java:755` — `match = unaccentedLabel.toLowerCase().indexOf(matchString);`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WTreeMaintenance.java:325` — `filter = Util.deleteAccents(filter.trim().toUpperCase());`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WTreeMaintenance.java:366` — `String valueItem = item.toString() == null ? "" : Util.deleteAccents(item.toString().toUpperCase());`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/AutoComplete.java:175` — `String compare = val.toLowerCase().trim();`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/AutoComplete.java:183` — `match = comboItems[i].toLowerCase().startsWith(compare);`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/AutoComplete.java:187` — `match = comboItems[i].toLowerCase().contains(compare);`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/WAppsAction.java:80` — `Character ch = Character.valueOf(newToolTipText.toLowerCase().charAt(pos + 1));`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/FindWindow.java:1725` — `return value.toString().toLowerCase().startsWith(key.toString().toLowerCase());`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/RecordTimeLinePanel.java:251` — `.append(Msg.getMsg(Env.getCtx(), "AND").toLowerCase())`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WAutoCompleterCity.java:101` — `search = search.toUpperCase();`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WAutoCompleterCity.java:104` — `if (vo.CityName.toUpperCase().startsWith(search)) {`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/zkoss/addon/chosenbox/Chosenbox.java:664` — `if (prefix == null || s.toLowerCase().startsWith(prefix.toLowerCase()))`
+- **M** — `org.adempiere.ui.zk/WEB-INF/src/org/zkoss/addon/chosenbox/Chosenbox.java:670` — `if (prefix == null || s.toLowerCase().startsWith(prefix.toLowerCase()))`
+- **M** — `org.idempiere.extension.manager/src/org/idempiere/extension/manager/form/ExtensionBrowserFormController.java:599` — `String filterLower = filter.toLowerCase();`
+- **M** — `org.idempiere.extension.manager/src/org/idempiere/extension/manager/form/ExtensionBrowserFormController.java:611` — `if (tag.getAsString().toLowerCase().contains(searchStr)) {`
+- **M** — `org.idempiere.extension.manager/src/org/idempiere/extension/manager/form/ExtensionBrowserFormController.java:620` — `if (cat.getAsString().toLowerCase().contains(searchStr)) {`
+- **M** — `org.idempiere.extension.manager/src/org/idempiere/extension/manager/form/ExtensionBrowserFormController.java:627` — `if (ext.getName() != null && ext.getName().toLowerCase().contains(searchStr)) {`
+- **M** — `org.idempiere.extension.manager/src/org/idempiere/extension/manager/form/ExtensionBrowserFormController.java:629` — `} else if (ext.getDescription() != null && ext.getDescription().toLowerCase().contains(searchStr)) {`
+
+### DOMAIN – Domain-Specific Canonicalization (11)
+
+Business or configuration values with their own normalization contract. Recommendation: decide and document the strategy for each value type; for example, normalize IBAN values explicitly in a locale-neutral way.
+
+- **M** — `org.adempiere.base/src/org/adempiere/process/SalesOrderRateInquiryProcess.java:228` — `unit = unit.toUpperCase();`
+- **M** — `org.adempiere.base/src/org/compiere/model/MAuthorizationCredential.java:198` — `if (preferred_username != null && ! email.toLowerCase().equals(preferred_username.toLowerCase()) && EMail.validate(preferred_username)) {`
+- **M** — `org.adempiere.base/src/org/compiere/model/MIFixedAsset.java:83` — `key = key.toUpperCase();`
+- **M** — `org.adempiere.base/src/org/compiere/model/NaturalAccountMap.java:249` — `IsDocControlled.toUpperCase().startsWith("Y"),`
+- **M** — `org.adempiere.base/src/org/compiere/model/NaturalAccountMap.java:250` — `IsSummary.toUpperCase().startsWith("Y"), m_trxName);`
+- **M** — `org.adempiere.base/src/org/compiere/model/NaturalAccountMap.java:255` — `put((K)Default_Account.toUpperCase(), (V)na);`
+- **M** — `org.adempiere.base/src/org/compiere/util/IBAN.java:31` — `return iban.trim().replace(" ", "").toUpperCase() ;`
+- **M** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:333` — `int cntCW = DB.getSQLValueEx(get_TrxName(), "SELECT COUNT(*) FROM W_Store WHERE WebContext=?", p_ClientValue.toLowerCase());`
+- **M** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:335` — `throw new AdempiereUserError("WebStore with context " + p_ClientValue.toLowerCase() + " already exists in database");`
+- **M** — `org.adempiere.base/src/org/idempiere/process/MoveClient.java:1172` — `parameters[i] = p_ClientValue.toLowerCase();`
+- **M** — `org.idempiere.acct/src/org/idempiere/acct/AccountingSetupServiceImpl.java:565` — `int C_ElementValue_ID = setupCtx.m_nap.getC_ElementValue_ID(key.toUpperCase());`
+
+### TEST – Test Code (9)
+
+Locale-dependent transformations in tests. Recommendation: set the locale explicitly in the test or verify the exact production strategy.
+
+- **H** — `org.idempiere.test/src/org/idempiere/test/adwindow/GridTabTest.java:202` — `query.addRestriction("Upper("+MBPartner.COLUMNNAME_Name+")", MQuery.EQUAL, bpartner.getName().toUpperCase());`
+- **H** — `org.idempiere.test/src/org/idempiere/test/base/MTableTest.java:438` — `assertTrue(indexName.toUpperCase().contains("AD_USER"), "UUID index name should contain the table name");`
+- **H** — `org.idempiere.test/src/org/idempiere/test/base/M_ElementTest.java:171` — `String resolved = M_Element.getColumnName(columnName.toUpperCase());`
+- **H** — `org.idempiere.test/src/org/idempiere/test/base/M_ElementTest.java:256` — `duplicate.setColumnName(columnName.toUpperCase());`
+- **H** — `org.idempiere.test/src/org/idempiere/test/base/POTest.java:1360` — `MBPartnerInfo[] bpInfos = MBPartnerInfo.find(Env.getCtx(), null, bp.getName().toLowerCase(), "", null, "%", null);`
+- **H** — `org.idempiere.test/src/org/idempiere/test/base/QueryTest.java:439` — `assertTrue(sql.toLowerCase().contains("inner join c_bpartner on (ad_user.c_bpartner_id=c_bpartner.c_bpartner_id)"), "Unexpected SQL clause generated from query");`
+- **H** — `org.idempiere.test/src/org/idempiere/test/base/ReportTest.java:167` — `assertTrue(entry.getName() != null && entry.getName().toUpperCase().contains(".PDF"), "No PDF report attach to notice");`
+- **H** — `org.idempiere.test/src/org/idempiere/test/model/CalloutTest.java:164` — `if (cmd.toLowerCase().startsWith(MRule.SCRIPT_PREFIX))`
+- **H** — `org.idempiere.test/src/org/idempiere/test/tracking/AuditTraceContextTest.java:176` — `assertTrue(entry.getName() != null && entry.getName().toUpperCase().contains(".PDF"), "No PDF report attach to notice");`
+
+### VENDORED – Historic/Vendored Code (5)
+
+Migration history or embedded third-party source. Recommendation: do not make an isolated change without a maintenance or upgrade decision.
+
+- **H** — `migration-historic/src/oracle/Column.java:81` — `if (defaultValue.toUpperCase().equals("NULL")) {`
+- **H** — `migration-historic/src/oracle/Constraint.java:175` — `if(deleteRule!=null && deleteRule.trim().toUpperCase().equals("NO ACTION")){`
+- **H** — `migration-historic/src/oracle/DBDifference.java:1224` — `} else if (searchCondition.toUpperCase().indexOf("IS NOT NULL") != -1) {`
+- **H** — `org.apache.ecs/src/org/apache/ecs/GenericElement.java:357` — `return value.toUpperCase();`
+- **H** — `org.apache.ecs/src/org/apache/ecs/GenericElement.java:359` — `return value.toLowerCase();`
+
+### INERT – Inactive Comment (3)
+
+The match exists only in commented-out code. Recommendation: no runtime change is required; clean up when appropriate.
+
+- **H** — `org.adempiere.base.process/src/org/compiere/process/TableCreateColumns.java:293` — `// || columnName.toUpperCase().indexOf("DATE") != -1`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1075` — `// sqlStatement.toUpperCase().indexOf(" MODIFY "));`
+- **H** — `org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java:1077` — `// sqlStatement.toUpperCase().indexOf(" ADD "));`
+
+## Current upstream/master Addendum
+
+Current comparison baseline:
+
+```text
+28acd37703
+```
+
+### TECH_TOKEN_ADDED – Added After the Original Classification (3)
+
+These current language-independent technical-token conversions belong to implementation phase `P2`:
+
+- **H** — `org.adempiere.base/src/org/adempiere/base/Core.java:1318` — `String extension = fileExtension != null ? fileExtension.toLowerCase() : "";`
+- **H** — `org.adempiere.base/src/org/adempiere/base/Core.java:1382` — `String extension = fileExtension != null ? fileExtension.toLowerCase() : "";`
+- **H** — `org.adempiere.report.jasper/src/org/adempiere/report/jasper/JasperReportContentRendererFactory.java:129` — `boolean ok = process.getClassname().toLowerCase().startsWith(MRule.SCRIPT_PREFIX)`
+
+### RESOLVED_UPSTREAM – Removed or Corrected Independently (2)
+
+These original `TECH_TOKEN` locations no longer require an IDEMPIERE-7089 source change:
+
+- **H** — `org.adempiere.base/src/org/compiere/util/MimeType.java:48` *(original baseline)* — The conversion now uses `toLowerCase(Locale.ROOT)` through IDEMPIERE-7077.
+- **H** — `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/ZkReportViewer.java:1958` *(original baseline)* — The old code path was removed through IDEMPIERE-7070.
+
+The current `master` source contains 460 parameterless case-conversion lines. Of the 52 historical `IDEMPIERE_7082_HANDLED` locations, 51 currently exist on `master`; the additional authorization-code compatibility location is introduced by PR #3332 itself. Excluding those 51 leaves 409 active IDEMPIERE-7089 locations. After rebasing onto PR #3332, the expected result is 411 parameterless source lines, including the two deliberately retained IDEMPIERE-7082 compatibility locations, and the same 409-location IDEMPIERE-7089 scope.
+
+## Prioritization
+
+1. **Exclude IDEMPIERE_7082_HANDLED:** These 52 entries are handled exclusively by PR #3332.
+2. **Address DB_VALUE first:** These locations may contain the same defect class, but they do not belong to the existing PR. Review the SQL expression and bound parameter together.
+3. **Address TECH_TOKEN next:** Most changes to `Locale.ROOT` or `equalsIgnoreCase()` should be low risk, but they should be implemented in small semantic groups with tests.
+4. **Handle USER_TEXT and DOMAIN separately:** Define the locale/collation contract before changing code.
+5. **Handle TEST, VENDORED, and INERT last:** Change these only together with the corresponding production change or maintenance decision.
+
+## Known Limitations
+
+- The classification is static and evaluates the visible call context; runtime configurations and external plugin contracts were not exercised.
+- Line numbers for the 410 remaining matches refer to the baseline commit above. The 50 removed IDEMPIERE-7082 locations instead use line numbers from the PR base version.
+- `Character.toUpperCase(...)`/`Character.toLowerCase(...)` and methods already called with an explicit `Locale` are outside the scope of this inventory.
+- DB_VALUE requires validation on PostgreSQL and Oracle. USER_TEXT should be tested with at least Turkish and German locale cases.

--- a/IDEMPIERE-7089-implementation-proposal.md
+++ b/IDEMPIERE-7089-implementation-proposal.md
@@ -41,7 +41,7 @@ Before an IDEMPIERE-7089 pull request is finalized, the branch should be rebased
 
 IDEMPIERE-7089 will be delivered in one draft pull request. The current 409-location scope remains divided into six internal implementation phases so that database behavior, technical normalization, UI behavior, domain decisions, and maintenance code remain separately reviewable within the same pull request.
 
-The current `workspace/IDEMPIERE-7089` branch is the single draft pull request. Its WIP commits are organized according to the six phases below; the initial code commit implements Phase 1 and the remaining locations carry explicit phase markers until their implementation is completed.
+The current `workspace/IDEMPIERE-7089` branch is the single draft pull request. Its WIP commits are organized according to the six phases below. The current implementation covers 364 of the 409 active locations; the remaining 45 locations carry explicit phase markers until their product or maintenance decision is completed.
 
 During the draft stage, affected source locations are marked with compact comments that preserve the originally proposed pull-request grouping:
 
@@ -197,7 +197,7 @@ Menu search, autocomplete, document search, city search, and extension-manager s
 
 Scope: 11 `DOMAIN` locations.
 
-Document the normalization contract for every value type before changing code. Likely dispositions include:
+Document the normalization contract for every value type before changing code. The current implementation applies explicit `java.util.Locale.ROOT` normalization to the technical domain values in this category. The email comparison remains a candidate for a later `equalsIgnoreCase()` refinement. Likely dispositions include:
 
 - IBAN: explicit locale-neutral uppercase canonicalization;
 - fixed-asset and account keys: explicit technical-key normalization;

--- a/IDEMPIERE-7089-implementation-proposal.md
+++ b/IDEMPIERE-7089-implementation-proposal.md
@@ -1,0 +1,258 @@
+# IDEMPIERE-7089 Implementation Proposal
+
+## Ticket
+
+[IDEMPIERE-7089: Audit remaining locale-dependent Java case conversions outside IDEMPIERE-7082](https://idempiere.atlassian.net/browse/IDEMPIERE-7089)
+
+## Objective
+
+Remove unintended dependencies on `Locale.getDefault()` from Java case conversion while preserving the correct semantics for database values, technical tokens, SQL/schema identifiers, user-facing text, and domain-specific values.
+
+This must be a semantic migration. It must not be implemented as a global replacement of every parameterless `toUpperCase()` or `toLowerCase()` call with `Locale.ROOT`.
+
+## Baseline and Scope Boundary
+
+The implementation branch is based on `upstream/master` at commit:
+
+```text
+28acd37703
+```
+
+At this commit, tracked Java sources contain 460 parameterless case-conversion locations. This differs from the 410 locations visible on the original IDEMPIERE-7082 PR branch because PR #3332 has not yet been merged into `master` and because `master` has evolved since that PR branch was created.
+
+The original ticket baseline is:
+
+- 460 classified locations in total;
+- 52 locations classified as `IDEMPIERE_7082_HANDLED` and excluded from IDEMPIERE-7089;
+- 408 locations in scope for IDEMPIERE-7089.
+
+The 52 excluded locations consist of 50 conversions that PR #3332 removes and two compatibility-sensitive conversions that it deliberately retains. IDEMPIERE-7089 must not modify any of them.
+
+The current `master` delta is:
+
+- two original `TECH_TOKEN` locations have already been removed or corrected independently;
+- three new `TECH_TOKEN` locations have been introduced;
+- the active IDEMPIERE-7089 implementation scope is therefore 409 locations;
+- the active `TECH_TOKEN` implementation scope is 66 locations.
+
+Before an IDEMPIERE-7089 pull request is finalized, the branch should be rebased after PR #3332 is merged. Until then, reviews and automated scans must subtract the 52 `IDEMPIERE_7082_HANDLED` locations from the raw `master` result.
+
+## Delivery Strategy
+
+IDEMPIERE-7089 will be delivered in one draft pull request. The current 409-location scope remains divided into six internal implementation phases so that database behavior, technical normalization, UI behavior, domain decisions, and maintenance code remain separately reviewable within the same pull request.
+
+The current `workspace/IDEMPIERE-7089` branch is the single draft pull request. Its WIP commits are organized according to the six phases below; the initial code commit implements Phase 1 and the remaining locations carry explicit phase markers until their implementation is completed.
+
+During the draft stage, affected source locations are marked with compact comments that preserve the originally proposed pull-request grouping:
+
+- `// IDEMPIERE-7089-P1` — `DB_VALUE`
+- `// IDEMPIERE-7089-P2` — `TECH_TOKEN`
+- `// IDEMPIERE-7089-P3` — `DB_SCHEMA_SQL`
+- `// IDEMPIERE-7089-P4` — `USER_TEXT`
+- `// IDEMPIERE-7089-P5` — `DOMAIN`
+- `// IDEMPIERE-7089-P6` — `TEST`, `VENDORED`, and `INERT`
+
+The comments are work-in-progress markers. Each marker must be replaced by the final implementation or an explicit source-level justification before the draft is marked ready for review.
+
+### Phase 1: Database Value Comparisons
+
+Implement the 14 high-priority `DB_VALUE` locations. Each currently applies `UPPER(...)` to the database expression but applies Java `toUpperCase()` to the value. The proposed change is:
+
+```sql
+-- Before
+UPPER(column_name) = ?
+```
+
+```java
+statement.setString(index, value.toUpperCase());
+```
+
+```sql
+-- After
+UPPER(column_name) = UPPER(?)
+```
+
+```java
+statement.setString(index, value);
+```
+
+This delegates both mappings to the same database engine, removes dependence on the JVM default locale, and preserves the existing case-insensitive equality contract.
+
+#### Proposed Source Changes
+
+1. `org.adempiere.base/src/org/compiere/model/MColumn.java`
+   - Change both foreign-key constraint-name duplicate checks to `UPPER(FkConstraintName)=UPPER(?)`.
+   - Bind `fkConstraintName` without Java case conversion.
+
+2. `org.adempiere.base/src/org/compiere/model/MQuery.java`
+   - Change the `AD_Column.ColumnName` lookup to `UPPER(ColumnName)=UPPER(?)`.
+   - Pass `ParameterName` unchanged.
+
+3. `org.adempiere.base/src/org/compiere/model/MSearchDefinition.java`
+   - Change both transaction-code lookups to `UPPER(TransactionCode)=UPPER(?)`.
+   - Bind `transactionCode` unchanged.
+
+4. `org.adempiere.base/src/org/compiere/model/M_Element.java`
+   - Change the static element lookup and duplicate check to normalize both SQL operands.
+   - Bind `columnName` unchanged.
+   - In the dynamically constructed `AD_Process_Para` update, apply database `UPPER(...)` to the quoted original value instead of applying Java `toUpperCase()` before quoting it.
+
+5. `org.adempiere.base/src/org/compiere/util/Msg.java`
+   - Change both base-language and translated element queries to `UPPER(ColumnName)=UPPER(?)`.
+   - Bind `ColumnName` unchanged.
+
+6. `org.adempiere.pipo/src/org/adempiere/pipo2/IDFinder.java`
+   - For all three `ignoreCase` paths, generate `UPPER(column)=UPPER(?)`.
+   - Preserve decoded and direct values without Java case conversion.
+   - Preserve the case-sensitive paths unchanged.
+
+7. `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/DocumentSearchController.java`
+   - Change the transaction-code predicate to `UPPER(TransactionCode)=UPPER(?)`.
+   - Pass `transactionCode` unchanged.
+
+8. `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java`
+   - Change the `AD_Column.ColumnName` metadata lookup to `UPPER(ColumnName)=UPPER(?)`.
+   - Pass `column` unchanged.
+
+#### Phase 1 Non-Goals
+
+- Do not modify any of the 52 `IDEMPIERE_7082_HANDLED` locations.
+- Do not add `Locale.ROOT` to database-bound values.
+- Do not change equality to `LIKE`, wildcard handling, or accent behavior.
+- Do not introduce database-specific functions.
+- Do not address the 264 `DB_SCHEMA_SQL` or 66 active `TECH_TOKEN` locations in this phase.
+- Do not change user-facing text or domain-value semantics.
+
+#### Phase 1 Tests
+
+Add focused integration tests that:
+
+- set the JVM default locale to `tr-TR` and restore it in `finally` or test cleanup;
+- prevent parallel execution while the global default locale is changed;
+- verify a public lookup containing the ASCII letter `i`, for example an `M_Element` column-name lookup, using a differently cased input;
+- verify that the lookup result is identical under `Locale.ROOT`, `en-US`, `de-DE`, and `tr-TR`;
+- verify a database value containing `ß` where a suitable isolated test record can be created;
+- execute on both PostgreSQL and Oracle;
+- confirm that case-sensitive `IDFinder` paths remain case-sensitive;
+- confirm that transaction-code and column-name equality semantics are unchanged.
+
+The test must restore the original default locale even when an assertion or database operation fails. Because `Locale.setDefault(...)` changes global JVM state, the test must use the test suite's global resource lock or an equivalent serialization mechanism.
+
+#### Phase 1 Validation
+
+```bash
+git grep -n -E '\.to(Lower|Upper)Case\(\)' -- '*.java'
+git diff --check
+mvn -pl org.idempiere.test verify
+```
+
+The exact Maven module selection may be narrowed during implementation if the repository's Tycho setup requires a different invocation, but the final verification must exercise the affected base, PIPO, and ZK code paths.
+
+## Subsequent Phases in the Same Pull Request
+
+### Phase 2: Technical Tokens
+
+Scope: 66 active `TECH_TOKEN` locations, including three additions and excluding two locations already resolved independently on `master`.
+
+Use the following decision order:
+
+1. Prefer `equalsIgnoreCase()` for equality checks.
+2. Prefer `regionMatches(true, ...)` or a focused helper for case-insensitive prefix/suffix checks when it improves clarity.
+3. Use `Locale.ROOT` when a normalized string is required for a map key, enum conversion, protocol token, file extension, path, MIME value, CSS/OSGi value, or similar language-independent value.
+4. Use an explicitly ASCII-specific implementation only where the protocol or file format defines ASCII semantics and the code benefits from enforcing that contract.
+
+Group changes by module and add Turkish-default-locale tests for protocols, paths, file extensions, MIME values, and internal keys.
+
+### Phase 3: SQL and Schema Mechanics
+
+Scope: 264 `DB_SCHEMA_SQL` locations.
+
+These are high-confidence technical strings but form the largest category. Split them further by subsystem if necessary:
+
+- SQL conversion and parsing;
+- Oracle identifier handling;
+- PostgreSQL identifier handling;
+- application-dictionary table and column handling;
+- model and migration code generation;
+- metadata, constraint, sequence, index, and partition names.
+
+Prefer structural metadata or parser APIs where available. Otherwise use `Locale.ROOT` for unavoidable Java normalization of SQL keywords and identifiers. Preserve the explicit Oracle-uppercase and PostgreSQL-lowercase identifier conventions.
+
+### Phase 4: User-Facing Text
+
+Scope: 37 `USER_TEXT` locations.
+
+Do not implement this category until the expected product behavior is confirmed. For each location, decide whether comparison follows:
+
+- the login/user locale;
+- Unicode case-insensitive comparison;
+- a `Collator` with a documented strength;
+- database collation;
+- accent-normalized search already defined by that subsystem; or
+- exact case-sensitive behavior.
+
+Menu search, autocomplete, document search, city search, and extension-manager search should be treated as separate behavior groups. `Locale.ROOT` is not the default answer for natural-language text.
+
+### Phase 5: Domain-Specific Values
+
+Scope: 11 `DOMAIN` locations.
+
+Document the normalization contract for every value type before changing code. Likely dispositions include:
+
+- IBAN: explicit locale-neutral uppercase canonicalization;
+- fixed-asset and account keys: explicit technical-key normalization;
+- unit codes: follow the code-system specification;
+- email/preferred username: define equality semantics before changing behavior;
+- Web Store context: define whether it is a path, identifier, or user-configurable value.
+
+Do not combine unresolved domain decisions with mechanical technical-token changes.
+
+### Phase 6: Tests and Maintenance Sources
+
+Scope: 9 `TEST`, 5 `VENDORED`, and 3 `INERT` locations.
+
+- Update test conversions to match the production strategy they verify.
+- Set locales explicitly in locale-sensitive tests.
+- Do not modify embedded third-party or historical migration code without an explicit maintenance decision.
+- Remove commented-out occurrences only as non-functional cleanup.
+
+## Implementation Rules
+
+Every changed location must receive one explicit disposition:
+
+- `DB_BOTH_OPERANDS`
+- `LOCALE_ROOT`
+- `CASE_INSENSITIVE_API`
+- `USER_LOCALE_OR_COLLATOR`
+- `DOMAIN_SPECIFIC`
+- `TEST_ONLY`
+- `VENDORED_OR_HISTORIC`
+- `INERT`
+
+The companion classification should be updated with the selected disposition and the implementing PR for every completed location. This provides an auditable path from the original 460-location inventory to the final code.
+
+## Review and Compatibility Requirements
+
+- Preserve all public and protected API signatures unless separately approved.
+- Preserve PR #3332's compatibility decisions, including `PO.getFindParameter(String)` and the authorization-code handling in `StatementCreateFromBatch`.
+- Keep prepared-statement binding; do not concatenate user values into SQL.
+- Verify PostgreSQL and Oracle behavior for database changes.
+- Review query plans where a change adds or moves a SQL function. In Phase 1, the indexed column expression remains unchanged and only the parameter gains the matching function.
+- Preserve existing ASCII behavior unless a deliberate correction is documented.
+- Do not include accent-insensitive search or global collation changes.
+- Avoid tests that leak a changed JVM default locale into other tests.
+
+## Proposed Definition of Done
+
+IDEMPIERE-7089 is complete when:
+
+1. all 52 `IDEMPIERE_7082_HANDLED` locations remain excluded;
+2. each of the 409 currently active in-scope locations has a reviewed final disposition;
+3. all approved first-party changes are implemented in one pull request with semantically grouped phases and commits;
+4. technical normalization no longer depends unintentionally on `Locale.getDefault()`;
+5. database-value comparisons apply the same database function to both operands;
+6. user-text and domain behavior follow explicitly documented policies;
+7. PostgreSQL and Oracle validation succeeds where applicable;
+8. locale tests cover at least `Locale.ROOT`, `en-US`, `de-DE`, and `tr-TR`;
+9. the classification records the implementing PR or follow-up decision for every location; and
+10. remaining product or compatibility decisions have dedicated follow-up tickets.

--- a/migration-historic/src/oracle/Column.java
+++ b/migration-historic/src/oracle/Column.java
@@ -78,7 +78,7 @@ public class Column {
 				// default value of NULL is eaqual to default value not set
 				if (defaultValue != null) {
 					defaultValue = defaultValue.trim();
-					if (defaultValue.toUpperCase().equals("NULL")) {
+					if (defaultValue.toUpperCase().equals("NULL")) { // IDEMPIERE-7089-P6
 						defaultValue = null;
 					}
 				}

--- a/migration-historic/src/oracle/Constraint.java
+++ b/migration-historic/src/oracle/Constraint.java
@@ -172,7 +172,7 @@ public class Constraint {
 
 	public void setDeleteRule(String deleteRule) {
 		this.deleteRule = deleteRule;
-		if(deleteRule!=null && deleteRule.trim().toUpperCase().equals("NO ACTION")){
+		if(deleteRule!=null && deleteRule.trim().toUpperCase().equals("NO ACTION")){ // IDEMPIERE-7089-P6
 			this.deleteRule = null;
 		}
 

--- a/migration-historic/src/oracle/DBDifference.java
+++ b/migration-historic/src/oracle/DBDifference.java
@@ -1221,7 +1221,7 @@ public class DBDifference {
 				final String searchCondition = rs2.getString("SEARCH_CONDITION");
 				if (searchCondition == null) {
 					continue;
-				} else if (searchCondition.toUpperCase().indexOf("IS NOT NULL") != -1) {
+				} else if (searchCondition.toUpperCase().indexOf("IS NOT NULL") != -1) { // IDEMPIERE-7089-P6
 					// not null constraints are handled by alter table
 					continue;
 				}

--- a/org.adempiere.base.process/src/org/adempiere/process/PrepareMigrationScripts.java
+++ b/org.adempiere.base.process/src/org/adempiere/process/PrepareMigrationScripts.java
@@ -69,7 +69,7 @@ public class PrepareMigrationScripts extends SvrProcess {
 
 		FilenameFilter filter = new FilenameFilter() {
 			public boolean accept(File dir, String name) {
-				return name.toLowerCase().endsWith(".sql"); // IDEMPIERE-7089-P2
+				return name.toLowerCase(java.util.Locale.ROOT).endsWith(".sql"); // IDEMPIERE-7089-P2
 			}
 		};
 		dirList = dir.listFiles(filter);

--- a/org.adempiere.base.process/src/org/adempiere/process/PrepareMigrationScripts.java
+++ b/org.adempiere.base.process/src/org/adempiere/process/PrepareMigrationScripts.java
@@ -69,7 +69,7 @@ public class PrepareMigrationScripts extends SvrProcess {
 
 		FilenameFilter filter = new FilenameFilter() {
 			public boolean accept(File dir, String name) {
-				return name.toLowerCase().endsWith(".sql");
+				return name.toLowerCase().endsWith(".sql"); // IDEMPIERE-7089-P2
 			}
 		};
 		dirList = dir.listFiles(filter);

--- a/org.adempiere.base.process/src/org/compiere/process/ColumnSync.java
+++ b/org.adempiere.base.process/src/org/compiere/process/ColumnSync.java
@@ -120,11 +120,11 @@ public class ColumnSync extends SvrProcess
 			String tableName = table.getTableName();
 			if (md.storesUpperCaseIdentifiers())
 			{
-				tableName = tableName.toUpperCase();
+				tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
 			}
 			else if (md.storesLowerCaseIdentifiers())
 			{
-				tableName = tableName.toLowerCase();
+				tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
 			}
 			int noColumns = 0;
 			String sql = null;

--- a/org.adempiere.base.process/src/org/compiere/process/ColumnSync.java
+++ b/org.adempiere.base.process/src/org/compiere/process/ColumnSync.java
@@ -120,11 +120,11 @@ public class ColumnSync extends SvrProcess
 			String tableName = table.getTableName();
 			if (md.storesUpperCaseIdentifiers())
 			{
-				tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
+				tableName = tableName.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 			}
 			else if (md.storesLowerCaseIdentifiers())
 			{
-				tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
+				tableName = tableName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 			}
 			int noColumns = 0;
 			String sql = null;

--- a/org.adempiere.base.process/src/org/compiere/process/CreateFromInOut.java
+++ b/org.adempiere.base.process/src/org/compiere/process/CreateFromInOut.java
@@ -147,7 +147,7 @@ public class CreateFromInOut extends SvrProcess
 				String Value_String = rs.getString("Value_String");
 				
 				Object Value_Number = null;
-				if (ColumnName.toUpperCase().endsWith("_ID"))
+				if (ColumnName.toUpperCase().endsWith("_ID")) // IDEMPIERE-7089-P3
 					Value_Number = rs.getInt("Value_Number");
 				else
 					Value_Number = rs.getBigDecimal("Value_Number");

--- a/org.adempiere.base.process/src/org/compiere/process/CreateFromInOut.java
+++ b/org.adempiere.base.process/src/org/compiere/process/CreateFromInOut.java
@@ -147,7 +147,7 @@ public class CreateFromInOut extends SvrProcess
 				String Value_String = rs.getString("Value_String");
 				
 				Object Value_Number = null;
-				if (ColumnName.toUpperCase().endsWith("_ID")) // IDEMPIERE-7089-P3
+				if (ColumnName.toUpperCase(java.util.Locale.ROOT).endsWith("_ID")) // IDEMPIERE-7089-P3
 					Value_Number = rs.getInt("Value_Number");
 				else
 					Value_Number = rs.getBigDecimal("Value_Number");

--- a/org.adempiere.base.process/src/org/compiere/process/CreateFromInvoice.java
+++ b/org.adempiere.base.process/src/org/compiere/process/CreateFromInvoice.java
@@ -145,7 +145,7 @@ public class CreateFromInvoice extends SvrProcess
 				String Value_String = rs.getString("Value_String");
 				
 				Object Value_Number = null;
-				if (ColumnName.toUpperCase().endsWith("_ID")) // IDEMPIERE-7089-P3
+				if (ColumnName.toUpperCase(java.util.Locale.ROOT).endsWith("_ID")) // IDEMPIERE-7089-P3
 					Value_Number = rs.getInt("Value_Number");
 				else
 					Value_Number = rs.getBigDecimal("Value_Number");

--- a/org.adempiere.base.process/src/org/compiere/process/CreateFromInvoice.java
+++ b/org.adempiere.base.process/src/org/compiere/process/CreateFromInvoice.java
@@ -145,7 +145,7 @@ public class CreateFromInvoice extends SvrProcess
 				String Value_String = rs.getString("Value_String");
 				
 				Object Value_Number = null;
-				if (ColumnName.toUpperCase().endsWith("_ID"))
+				if (ColumnName.toUpperCase().endsWith("_ID")) // IDEMPIERE-7089-P3
 					Value_Number = rs.getInt("Value_Number");
 				else
 					Value_Number = rs.getBigDecimal("Value_Number");

--- a/org.adempiere.base.process/src/org/compiere/process/CreateFromRMA.java
+++ b/org.adempiere.base.process/src/org/compiere/process/CreateFromRMA.java
@@ -137,7 +137,7 @@ public class CreateFromRMA extends SvrProcess
 				String Value_String = rs.getString("Value_String");
 				
 				Object Value_Number = null;
-				if (ColumnName.toUpperCase().endsWith("_ID"))
+				if (ColumnName.toUpperCase().endsWith("_ID")) // IDEMPIERE-7089-P3
 					Value_Number = rs.getInt("Value_Number");
 				else
 					Value_Number = rs.getBigDecimal("Value_Number");

--- a/org.adempiere.base.process/src/org/compiere/process/CreateFromRMA.java
+++ b/org.adempiere.base.process/src/org/compiere/process/CreateFromRMA.java
@@ -137,7 +137,7 @@ public class CreateFromRMA extends SvrProcess
 				String Value_String = rs.getString("Value_String");
 				
 				Object Value_Number = null;
-				if (ColumnName.toUpperCase().endsWith("_ID")) // IDEMPIERE-7089-P3
+				if (ColumnName.toUpperCase(java.util.Locale.ROOT).endsWith("_ID")) // IDEMPIERE-7089-P3
 					Value_Number = rs.getInt("Value_Number");
 				else
 					Value_Number = rs.getBigDecimal("Value_Number");

--- a/org.adempiere.base.process/src/org/compiere/process/CreateWindowFromTable.java
+++ b/org.adempiere.base.process/src/org/compiere/process/CreateWindowFromTable.java
@@ -190,7 +190,7 @@ public class CreateWindowFromTable extends SvrProcess
 			else 
 				tab.setOrderByClause(table.getTableName() + ".Created DESC");
 
-			if (table.getTableName().toLowerCase().endsWith("_trl")) {
+			if (table.getTableName().toLowerCase().endsWith("_trl")) { // IDEMPIERE-7089-P3
 				tab.setIsTranslationTab(true);
 				tab.setIsInsertRecord(false);
 				if (table.columnExistsInDB("AD_Language"))

--- a/org.adempiere.base.process/src/org/compiere/process/CreateWindowFromTable.java
+++ b/org.adempiere.base.process/src/org/compiere/process/CreateWindowFromTable.java
@@ -190,7 +190,7 @@ public class CreateWindowFromTable extends SvrProcess
 			else 
 				tab.setOrderByClause(table.getTableName() + ".Created DESC");
 
-			if (table.getTableName().toLowerCase().endsWith("_trl")) { // IDEMPIERE-7089-P3
+			if (table.getTableName().toLowerCase(java.util.Locale.ROOT).endsWith("_trl")) { // IDEMPIERE-7089-P3
 				tab.setIsTranslationTab(true);
 				tab.setIsInsertRecord(false);
 				if (table.columnExistsInDB("AD_Language"))

--- a/org.adempiere.base.process/src/org/compiere/process/RequestEMailProcessor.java
+++ b/org.adempiere.base.process/src/org/compiere/process/RequestEMailProcessor.java
@@ -170,9 +170,9 @@ public class RequestEMailProcessor extends SvrProcess implements ProcessEmailHan
 		
 		if(imapProtocolIndex > 0) {
 			String str_Protocol = p_IMAPHost.substring(0, imapProtocolIndex);
-			if(str_Protocol.toLowerCase().equals("imaps")) // IDEMPIERE-7089-P2
+			if(str_Protocol.toLowerCase(java.util.Locale.ROOT).equals("imaps")) // IDEMPIERE-7089-P2
 				isSSL  = true;
-			else if(str_Protocol.toLowerCase().equals("imap")) // IDEMPIERE-7089-P2
+			else if(str_Protocol.toLowerCase(java.util.Locale.ROOT).equals("imap")) // IDEMPIERE-7089-P2
 				isSSL = false;
 			else
 				log.warning("Unrecognized protocol - " + str_Protocol);

--- a/org.adempiere.base.process/src/org/compiere/process/RequestEMailProcessor.java
+++ b/org.adempiere.base.process/src/org/compiere/process/RequestEMailProcessor.java
@@ -170,9 +170,9 @@ public class RequestEMailProcessor extends SvrProcess implements ProcessEmailHan
 		
 		if(imapProtocolIndex > 0) {
 			String str_Protocol = p_IMAPHost.substring(0, imapProtocolIndex);
-			if(str_Protocol.toLowerCase().equals("imaps"))
+			if(str_Protocol.toLowerCase().equals("imaps")) // IDEMPIERE-7089-P2
 				isSSL  = true;
-			else if(str_Protocol.toLowerCase().equals("imap"))
+			else if(str_Protocol.toLowerCase().equals("imap")) // IDEMPIERE-7089-P2
 				isSSL = false;
 			else
 				log.warning("Unrecognized protocol - " + str_Protocol);

--- a/org.adempiere.base.process/src/org/compiere/process/TableCreateColumns.java
+++ b/org.adempiere.base.process/src/org/compiere/process/TableCreateColumns.java
@@ -111,10 +111,10 @@ public class TableCreateColumns extends SvrProcess
 				if (log.isLoggable(Level.INFO)) log.info(table.getTableName() + ", EntityType=" + p_EntityType);
 				String tableName = table.getTableName();
 				if (DB.isOracle())
-					tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
+					tableName = tableName.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 	            // globalqss 2005-10-24
 				if (DB.isPostgreSQL())
-				    tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
+				    tableName = tableName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 				// end globalqss 2005-10-24
 				ResultSet rs = null;
 				try {
@@ -164,7 +164,7 @@ public class TableCreateColumns extends SvrProcess
 				//	Create new ?
 				if (table == null)
 				{
-					String tn = tableName.toUpperCase(); // IDEMPIERE-7089-P3
+					String tn = tableName.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 					if (tn.startsWith("T_SELECTION")	//	temp table
 						|| tn.endsWith("_VT")			//	print trl views
 						|| tn.endsWith("_V")			//	views
@@ -192,10 +192,10 @@ public class TableCreateColumns extends SvrProcess
 				}
 				//	Check Columns
 				if (DB.isOracle())
-					tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
+					tableName = tableName.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 				// globalqss 2005-10-24
 				if (DB.isPostgreSQL())
-				    tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
+				    tableName = tableName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 				// end globalqss 2005-10-24
 				try {
 					rsC = md.getColumns(catalog, schema, tableName, null);
@@ -285,7 +285,7 @@ public class TableCreateColumns extends SvrProcess
 				&& size == 10)
 				column.setAD_Reference_ID (DisplayType.Account);
 			// ID
-			else if (columnName.toUpperCase().endsWith ("_ID")) // IDEMPIERE-7089-P3
+			else if (columnName.toUpperCase(java.util.Locale.ROOT).endsWith ("_ID")) // IDEMPIERE-7089-P3
 				column.setAD_Reference_ID (DisplayType.TableDir);
 			// Date
 			else if (dataType == Types.DATE || dataType == Types.TIME
@@ -345,8 +345,8 @@ public class TableCreateColumns extends SvrProcess
 				&& (table.isView()
 					|| columnName.equalsIgnoreCase("AD_Client_ID") 
 					|| columnName.equalsIgnoreCase("AD_Org_ID")
-					|| columnName.toUpperCase().startsWith("CREATED")  // IDEMPIERE-7089-P3
-					|| columnName.toUpperCase().equals("UPDATED") )) // IDEMPIERE-7089-P3
+					|| columnName.toUpperCase(java.util.Locale.ROOT).startsWith("CREATED")  // IDEMPIERE-7089-P3
+					|| columnName.toUpperCase(java.util.Locale.ROOT).equals("UPDATED") )) // IDEMPIERE-7089-P3
 				column.setIsUpdateable(false);
 			
 			//	Done

--- a/org.adempiere.base.process/src/org/compiere/process/TableCreateColumns.java
+++ b/org.adempiere.base.process/src/org/compiere/process/TableCreateColumns.java
@@ -111,10 +111,10 @@ public class TableCreateColumns extends SvrProcess
 				if (log.isLoggable(Level.INFO)) log.info(table.getTableName() + ", EntityType=" + p_EntityType);
 				String tableName = table.getTableName();
 				if (DB.isOracle())
-					tableName = tableName.toUpperCase();
+					tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
 	            // globalqss 2005-10-24
 				if (DB.isPostgreSQL())
-				    tableName = tableName.toLowerCase();
+				    tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
 				// end globalqss 2005-10-24
 				ResultSet rs = null;
 				try {
@@ -164,7 +164,7 @@ public class TableCreateColumns extends SvrProcess
 				//	Create new ?
 				if (table == null)
 				{
-					String tn = tableName.toUpperCase();
+					String tn = tableName.toUpperCase(); // IDEMPIERE-7089-P3
 					if (tn.startsWith("T_SELECTION")	//	temp table
 						|| tn.endsWith("_VT")			//	print trl views
 						|| tn.endsWith("_V")			//	views
@@ -192,10 +192,10 @@ public class TableCreateColumns extends SvrProcess
 				}
 				//	Check Columns
 				if (DB.isOracle())
-					tableName = tableName.toUpperCase();
+					tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
 				// globalqss 2005-10-24
 				if (DB.isPostgreSQL())
-				    tableName = tableName.toLowerCase();
+				    tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
 				// end globalqss 2005-10-24
 				try {
 					rsC = md.getColumns(catalog, schema, tableName, null);
@@ -285,12 +285,12 @@ public class TableCreateColumns extends SvrProcess
 				&& size == 10)
 				column.setAD_Reference_ID (DisplayType.Account);
 			// ID
-			else if (columnName.toUpperCase().endsWith ("_ID"))
+			else if (columnName.toUpperCase().endsWith ("_ID")) // IDEMPIERE-7089-P3
 				column.setAD_Reference_ID (DisplayType.TableDir);
 			// Date
 			else if (dataType == Types.DATE || dataType == Types.TIME
 				|| dataType == Types.TIMESTAMP
-				// || columnName.toUpperCase().indexOf("DATE") != -1
+				// || columnName.toUpperCase().indexOf("DATE") != -1 // IDEMPIERE-7089-P6
 				|| columnName.equalsIgnoreCase ("Created")
 				|| columnName.equalsIgnoreCase ("Updated"))
 				column.setAD_Reference_ID (DisplayType.DateTime);
@@ -345,8 +345,8 @@ public class TableCreateColumns extends SvrProcess
 				&& (table.isView()
 					|| columnName.equalsIgnoreCase("AD_Client_ID") 
 					|| columnName.equalsIgnoreCase("AD_Org_ID")
-					|| columnName.toUpperCase().startsWith("CREATED") 
-					|| columnName.toUpperCase().equals("UPDATED") ))
+					|| columnName.toUpperCase().startsWith("CREATED")  // IDEMPIERE-7089-P3
+					|| columnName.toUpperCase().equals("UPDATED") )) // IDEMPIERE-7089-P3
 				column.setIsUpdateable(false);
 			
 			//	Done

--- a/org.adempiere.base.process/src/org/idempiere/process/CreateTable.java
+++ b/org.adempiere.base.process/src/org/idempiere/process/CreateTable.java
@@ -449,7 +449,7 @@ public class CreateTable extends SvrProcess {
 		if (columnThatExists != null) {
 			if (   p_isCreateTranslationTable
 				&& !columnThatExists.isTranslated()
-				&& !table.getTableName().toUpperCase().endsWith("_TRL")
+				&& !table.getTableName().toUpperCase().endsWith("_TRL") // IDEMPIERE-7089-P3
 				&& (   (p_isCreateColName && columnName.equals("Name"))
 					|| (p_isCreateColHelp && columnName.equals("Help"))
 					|| (p_isCreateColDescription && columnName.equals("Description")))) {
@@ -522,7 +522,7 @@ public class CreateTable extends SvrProcess {
 				length = LENGTH_60;
 				column.setIsMandatory(true);
 				column.setIsIdentifier(true);
-				if (p_isCreateTranslationTable && !table.getTableName().toUpperCase().endsWith("_TRL"))
+				if (p_isCreateTranslationTable && !table.getTableName().toUpperCase().endsWith("_TRL")) // IDEMPIERE-7089-P3
 					column.setIsTranslated(true);
 			}
 			else if (columnName.equals("DocumentNo"))
@@ -538,7 +538,7 @@ public class CreateTable extends SvrProcess {
 			else if (columnName.equals("Help"))
 				length = LENGTH_2000;
 			column.setFieldLength(length);
-			if (p_isCreateTranslationTable && !table.getTableName().toUpperCase().endsWith("_TRL"))
+			if (p_isCreateTranslationTable && !table.getTableName().toUpperCase().endsWith("_TRL")) // IDEMPIERE-7089-P3
 				column.setIsTranslated(true);
 		}
 		else if (columnName.equals("C_Currency_ID")) {

--- a/org.adempiere.base.process/src/org/idempiere/process/CreateTable.java
+++ b/org.adempiere.base.process/src/org/idempiere/process/CreateTable.java
@@ -449,7 +449,7 @@ public class CreateTable extends SvrProcess {
 		if (columnThatExists != null) {
 			if (   p_isCreateTranslationTable
 				&& !columnThatExists.isTranslated()
-				&& !table.getTableName().toUpperCase().endsWith("_TRL") // IDEMPIERE-7089-P3
+				&& !table.getTableName().toUpperCase(java.util.Locale.ROOT).endsWith("_TRL") // IDEMPIERE-7089-P3
 				&& (   (p_isCreateColName && columnName.equals("Name"))
 					|| (p_isCreateColHelp && columnName.equals("Help"))
 					|| (p_isCreateColDescription && columnName.equals("Description")))) {
@@ -522,7 +522,7 @@ public class CreateTable extends SvrProcess {
 				length = LENGTH_60;
 				column.setIsMandatory(true);
 				column.setIsIdentifier(true);
-				if (p_isCreateTranslationTable && !table.getTableName().toUpperCase().endsWith("_TRL")) // IDEMPIERE-7089-P3
+				if (p_isCreateTranslationTable && !table.getTableName().toUpperCase(java.util.Locale.ROOT).endsWith("_TRL")) // IDEMPIERE-7089-P3
 					column.setIsTranslated(true);
 			}
 			else if (columnName.equals("DocumentNo"))
@@ -538,7 +538,7 @@ public class CreateTable extends SvrProcess {
 			else if (columnName.equals("Help"))
 				length = LENGTH_2000;
 			column.setFieldLength(length);
-			if (p_isCreateTranslationTable && !table.getTableName().toUpperCase().endsWith("_TRL")) // IDEMPIERE-7089-P3
+			if (p_isCreateTranslationTable && !table.getTableName().toUpperCase(java.util.Locale.ROOT).endsWith("_TRL")) // IDEMPIERE-7089-P3
 				column.setIsTranslated(true);
 		}
 		else if (columnName.equals("C_Currency_ID")) {

--- a/org.adempiere.base/src/org/adempiere/base/Core.java
+++ b/org.adempiere.base/src/org/adempiere/base/Core.java
@@ -1315,7 +1315,7 @@ public class Core {
 		IReportContentRenderer renderer = getReportContentRenderer(request);
 		File content = renderer != null ? renderer.getContent(contentType, fileExtension) : null;
 		if (content == null && request.reportEngine() != null) {
-			String extension = fileExtension != null ? fileExtension.toLowerCase() : "";
+			String extension = fileExtension != null ? fileExtension.toLowerCase() : ""; // IDEMPIERE-7089-P2
 			content = switch (extension) {
 				case "html" -> request.reportEngine().getHTML();
 				case "csv" -> request.reportEngine().getCSV();
@@ -1379,7 +1379,7 @@ public class Core {
 
 		@Override
 		public File getContent(String contentType, String fileExtension) {
-			String extension = fileExtension != null ? fileExtension.toLowerCase() : "";
+			String extension = fileExtension != null ? fileExtension.toLowerCase() : ""; // IDEMPIERE-7089-P2
 			if (!List.of("pdf", "html", "csv", "xls", "xlsx").contains(extension))
 				return null;
 			try {

--- a/org.adempiere.base/src/org/adempiere/base/Core.java
+++ b/org.adempiere.base/src/org/adempiere/base/Core.java
@@ -1315,7 +1315,7 @@ public class Core {
 		IReportContentRenderer renderer = getReportContentRenderer(request);
 		File content = renderer != null ? renderer.getContent(contentType, fileExtension) : null;
 		if (content == null && request.reportEngine() != null) {
-			String extension = fileExtension != null ? fileExtension.toLowerCase() : ""; // IDEMPIERE-7089-P2
+			String extension = fileExtension != null ? fileExtension.toLowerCase(java.util.Locale.ROOT) : ""; // IDEMPIERE-7089-P2
 			content = switch (extension) {
 				case "html" -> request.reportEngine().getHTML();
 				case "csv" -> request.reportEngine().getCSV();
@@ -1379,7 +1379,7 @@ public class Core {
 
 		@Override
 		public File getContent(String contentType, String fileExtension) {
-			String extension = fileExtension != null ? fileExtension.toLowerCase() : ""; // IDEMPIERE-7089-P2
+			String extension = fileExtension != null ? fileExtension.toLowerCase(java.util.Locale.ROOT) : ""; // IDEMPIERE-7089-P2
 			if (!List.of("pdf", "html", "csv", "xls", "xlsx").contains(extension))
 				return null;
 			try {

--- a/org.adempiere.base/src/org/adempiere/base/MappedColumnCalloutFactory.java
+++ b/org.adempiere.base/src/org/adempiere/base/MappedColumnCalloutFactory.java
@@ -68,11 +68,11 @@ public class MappedColumnCalloutFactory implements IColumnCalloutFactory, IMappe
 	public IColumnCallout[] getColumnCallouts(String tableName, String columnName) {
 		List<IColumnCallout> calloutList = new ArrayList<IColumnCallout>();
 		StringBuilder key = new StringBuilder();
-		key.append(tableName.toLowerCase()).append("|").append(columnName.toLowerCase()); // IDEMPIERE-7089-P2
+		key.append(tableName.toLowerCase(java.util.Locale.ROOT)).append("|").append(columnName.toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P2
 		StringBuilder key1 = new StringBuilder();
-		key1.append("*|").append(columnName.toLowerCase()); // IDEMPIERE-7089-P2
+		key1.append("*|").append(columnName.toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P2
 		StringBuilder key2 = new StringBuilder();
-		key2.append(tableName.toLowerCase()).append("|*"); // IDEMPIERE-7089-P2
+		key2.append(tableName.toLowerCase(java.util.Locale.ROOT)).append("|*"); // IDEMPIERE-7089-P2
 		synchronized (calloutMap) {
 			List<Supplier<IColumnCallout>> list = calloutMap.get(key.toString());
 			if (list != null && list.size() > 0) {
@@ -93,7 +93,7 @@ public class MappedColumnCalloutFactory implements IColumnCalloutFactory, IMappe
 	@Override
 	public void addMapping(String tableName, String columnName, Supplier<IColumnCallout> supplier) {
 		StringBuilder key = new StringBuilder();
-		key.append(tableName.toLowerCase()).append("|").append(columnName.toLowerCase()); // IDEMPIERE-7089-P2
+		key.append(tableName.toLowerCase(java.util.Locale.ROOT)).append("|").append(columnName.toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P2
 		synchronized (calloutMap) {
 			List<Supplier<IColumnCallout>> list = calloutMap.get(key.toString());
 			if (list == null) {
@@ -107,7 +107,7 @@ public class MappedColumnCalloutFactory implements IColumnCalloutFactory, IMappe
 	@Override
 	public void removeMapping(String tableName, String columnName, Supplier<IColumnCallout> supplier) {
 		StringBuilder key = new StringBuilder();
-		key.append(tableName.toLowerCase()).append("|").append(columnName.toLowerCase()); // IDEMPIERE-7089-P2
+		key.append(tableName.toLowerCase(java.util.Locale.ROOT)).append("|").append(columnName.toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P2
 		synchronized (calloutMap) {
 			List<Supplier<IColumnCallout>> list = calloutMap.get(key.toString());
 			if (list != null) {

--- a/org.adempiere.base/src/org/adempiere/base/MappedColumnCalloutFactory.java
+++ b/org.adempiere.base/src/org/adempiere/base/MappedColumnCalloutFactory.java
@@ -68,11 +68,11 @@ public class MappedColumnCalloutFactory implements IColumnCalloutFactory, IMappe
 	public IColumnCallout[] getColumnCallouts(String tableName, String columnName) {
 		List<IColumnCallout> calloutList = new ArrayList<IColumnCallout>();
 		StringBuilder key = new StringBuilder();
-		key.append(tableName.toLowerCase()).append("|").append(columnName.toLowerCase());
+		key.append(tableName.toLowerCase()).append("|").append(columnName.toLowerCase()); // IDEMPIERE-7089-P2
 		StringBuilder key1 = new StringBuilder();
-		key1.append("*|").append(columnName.toLowerCase());
+		key1.append("*|").append(columnName.toLowerCase()); // IDEMPIERE-7089-P2
 		StringBuilder key2 = new StringBuilder();
-		key2.append(tableName.toLowerCase()).append("|*");
+		key2.append(tableName.toLowerCase()).append("|*"); // IDEMPIERE-7089-P2
 		synchronized (calloutMap) {
 			List<Supplier<IColumnCallout>> list = calloutMap.get(key.toString());
 			if (list != null && list.size() > 0) {
@@ -93,7 +93,7 @@ public class MappedColumnCalloutFactory implements IColumnCalloutFactory, IMappe
 	@Override
 	public void addMapping(String tableName, String columnName, Supplier<IColumnCallout> supplier) {
 		StringBuilder key = new StringBuilder();
-		key.append(tableName.toLowerCase()).append("|").append(columnName.toLowerCase());
+		key.append(tableName.toLowerCase()).append("|").append(columnName.toLowerCase()); // IDEMPIERE-7089-P2
 		synchronized (calloutMap) {
 			List<Supplier<IColumnCallout>> list = calloutMap.get(key.toString());
 			if (list == null) {
@@ -107,7 +107,7 @@ public class MappedColumnCalloutFactory implements IColumnCalloutFactory, IMappe
 	@Override
 	public void removeMapping(String tableName, String columnName, Supplier<IColumnCallout> supplier) {
 		StringBuilder key = new StringBuilder();
-		key.append(tableName.toLowerCase()).append("|").append(columnName.toLowerCase());
+		key.append(tableName.toLowerCase()).append("|").append(columnName.toLowerCase()); // IDEMPIERE-7089-P2
 		synchronized (calloutMap) {
 			List<Supplier<IColumnCallout>> list = calloutMap.get(key.toString());
 			if (list != null) {

--- a/org.adempiere.base/src/org/adempiere/base/sso/SSOUtils.java
+++ b/org.adempiere.base/src/org/adempiere/base/sso/SSOUtils.java
@@ -138,7 +138,7 @@ public class SSOUtils
 	 */
 	public static boolean isResourceRequest(HttpServletRequest request, boolean isWebUI)
 	{
-		String[] urlpath = request.getServletPath().toLowerCase().split("/");
+		String[] urlpath = request.getServletPath().toLowerCase().split("/"); // IDEMPIERE-7089-P2
 		if (isWebUI)
 			return urlpath != null && urlpath.length > 1 && ignoreResourceURL.contains(urlpath[1]);
 		else

--- a/org.adempiere.base/src/org/adempiere/base/sso/SSOUtils.java
+++ b/org.adempiere.base/src/org/adempiere/base/sso/SSOUtils.java
@@ -138,7 +138,7 @@ public class SSOUtils
 	 */
 	public static boolean isResourceRequest(HttpServletRequest request, boolean isWebUI)
 	{
-		String[] urlpath = request.getServletPath().toLowerCase().split("/"); // IDEMPIERE-7089-P2
+		String[] urlpath = request.getServletPath().toLowerCase(java.util.Locale.ROOT).split("/"); // IDEMPIERE-7089-P2
 		if (isWebUI)
 			return urlpath != null && urlpath.length > 1 && ignoreResourceURL.contains(urlpath[1]);
 		else

--- a/org.adempiere.base/src/org/adempiere/process/SalesOrderRateInquiryProcess.java
+++ b/org.adempiere.base/src/org/adempiere/process/SalesOrderRateInquiryProcess.java
@@ -225,7 +225,7 @@ public class SalesOrderRateInquiryProcess extends SvrProcess
 		boolean isPound = false;
 		if (unit != null)
 		{
-			unit = unit.toUpperCase();
+			unit = unit.toUpperCase(); // IDEMPIERE-7089-P5
 			if (unit.equals("LB") || unit.equals("LBS"))
 				isPound = true;
 		}

--- a/org.adempiere.base/src/org/adempiere/process/SalesOrderRateInquiryProcess.java
+++ b/org.adempiere.base/src/org/adempiere/process/SalesOrderRateInquiryProcess.java
@@ -225,7 +225,7 @@ public class SalesOrderRateInquiryProcess extends SvrProcess
 		boolean isPound = false;
 		if (unit != null)
 		{
-			unit = unit.toUpperCase(); // IDEMPIERE-7089-P5
+			unit = unit.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P5
 			if (unit.equals("LB") || unit.equals("LBS"))
 				isPound = true;
 		}

--- a/org.adempiere.base/src/org/adempiere/process/UUIDGenerator.java
+++ b/org.adempiere.base/src/org/adempiere/process/UUIDGenerator.java
@@ -295,11 +295,11 @@ public class UUIDGenerator extends SvrProcess {
 			String tableName = table.getTableName();
 			if (md.storesUpperCaseIdentifiers())
 			{
-				tableName = tableName.toUpperCase();
+				tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
 			}
 			else if (md.storesLowerCaseIdentifiers())
 			{
-				tableName = tableName.toLowerCase();
+				tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
 			}
 			int noColumns = 0;
 			StringBuilder sql = null;

--- a/org.adempiere.base/src/org/adempiere/process/UUIDGenerator.java
+++ b/org.adempiere.base/src/org/adempiere/process/UUIDGenerator.java
@@ -295,11 +295,11 @@ public class UUIDGenerator extends SvrProcess {
 			String tableName = table.getTableName();
 			if (md.storesUpperCaseIdentifiers())
 			{
-				tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
+				tableName = tableName.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 			}
 			else if (md.storesLowerCaseIdentifiers())
 			{
-				tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
+				tableName = tableName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 			}
 			int noColumns = 0;
 			StringBuilder sql = null;

--- a/org.adempiere.base/src/org/adempiere/util/ModelClassGenerator.java
+++ b/org.adempiere.base/src/org/adempiere/util/ModelClassGenerator.java
@@ -545,7 +545,7 @@ public class ModelClassGenerator
 		if (clazz.equals(Boolean.class))
 		{
 			sb.append(" is");
-			if (columnName.toLowerCase().startsWith("is"))
+			if (columnName.toLowerCase().startsWith("is")) // IDEMPIERE-7089-P3
 				sb.append(columnName.substring(2));
 			else
 				sb.append(columnName);
@@ -654,7 +654,7 @@ public class ModelClassGenerator
 		if (AD_Reference_ID <= MTable.MAX_OFFICIAL_ID)
 		{
 			retValue.append("\n\t/** ").append(columnName).append(" AD_Reference_ID=").append(AD_Reference_ID) .append(" */")
-				.append("\n\tpublic static final int ").append(columnName.toUpperCase())
+				.append("\n\tpublic static final int ").append(columnName.toUpperCase()) // IDEMPIERE-7089-P3
 				.append("_AD_Reference_ID=").append(AD_Reference_ID).append(";");
 		}
 		//
@@ -734,7 +734,7 @@ public class ModelClassGenerator
 					}
 				}
 				retValue.append("\n\t/** ").append(Util.maskHTML(name)).append(" = ").append(Util.maskHTML(value)).append(" */");
-				retValue.append("\n\tpublic static final String ").append(columnName.toUpperCase())
+				retValue.append("\n\tpublic static final String ").append(columnName.toUpperCase()) // IDEMPIERE-7089-P3
 					.append("_").append(nameClean)
 					.append(" = \"").append(value).append("\";");
 			}

--- a/org.adempiere.base/src/org/adempiere/util/ModelClassGenerator.java
+++ b/org.adempiere.base/src/org/adempiere/util/ModelClassGenerator.java
@@ -545,7 +545,7 @@ public class ModelClassGenerator
 		if (clazz.equals(Boolean.class))
 		{
 			sb.append(" is");
-			if (columnName.toLowerCase().startsWith("is")) // IDEMPIERE-7089-P3
+			if (columnName.toLowerCase(java.util.Locale.ROOT).startsWith("is")) // IDEMPIERE-7089-P3
 				sb.append(columnName.substring(2));
 			else
 				sb.append(columnName);
@@ -654,7 +654,7 @@ public class ModelClassGenerator
 		if (AD_Reference_ID <= MTable.MAX_OFFICIAL_ID)
 		{
 			retValue.append("\n\t/** ").append(columnName).append(" AD_Reference_ID=").append(AD_Reference_ID) .append(" */")
-				.append("\n\tpublic static final int ").append(columnName.toUpperCase()) // IDEMPIERE-7089-P3
+				.append("\n\tpublic static final int ").append(columnName.toUpperCase(java.util.Locale.ROOT)) // IDEMPIERE-7089-P3
 				.append("_AD_Reference_ID=").append(AD_Reference_ID).append(";");
 		}
 		//
@@ -734,7 +734,7 @@ public class ModelClassGenerator
 					}
 				}
 				retValue.append("\n\t/** ").append(Util.maskHTML(name)).append(" = ").append(Util.maskHTML(value)).append(" */");
-				retValue.append("\n\tpublic static final String ").append(columnName.toUpperCase()) // IDEMPIERE-7089-P3
+				retValue.append("\n\tpublic static final String ").append(columnName.toUpperCase(java.util.Locale.ROOT)) // IDEMPIERE-7089-P3
 					.append("_").append(nameClean)
 					.append(" = \"").append(value).append("\";");
 			}

--- a/org.adempiere.base/src/org/adempiere/util/ModelInterfaceGenerator.java
+++ b/org.adempiere.base/src/org/adempiere/util/ModelInterfaceGenerator.java
@@ -358,7 +358,7 @@ public class ModelInterfaceGenerator
 		sb.append("\tpublic ").append(dataType);
 		if (clazz.equals(Boolean.class)) {
 			sb.append(" is");
-			if (columnName.toLowerCase().startsWith("is"))
+			if (columnName.toLowerCase().startsWith("is")) // IDEMPIERE-7089-P3
 				sb.append(columnName.substring(2));
 			else
 				sb.append(columnName);
@@ -812,7 +812,7 @@ public class ModelInterfaceGenerator
 		if (tableName == null || tableName.trim().length() == 0)
 			throw new IllegalArgumentException("Must specify table name");
 
-		StringBuilder tableLike = new StringBuilder().append(tableName.trim().toUpperCase().replace("'", ""));
+		StringBuilder tableLike = new StringBuilder().append(tableName.trim().toUpperCase().replace("'", "")); // IDEMPIERE-7089-P3
 
 		StringBuilder entityTypeFilter = new StringBuilder();
 		if (entityType != null && entityType.trim().length() > 0)

--- a/org.adempiere.base/src/org/adempiere/util/ModelInterfaceGenerator.java
+++ b/org.adempiere.base/src/org/adempiere/util/ModelInterfaceGenerator.java
@@ -358,7 +358,7 @@ public class ModelInterfaceGenerator
 		sb.append("\tpublic ").append(dataType);
 		if (clazz.equals(Boolean.class)) {
 			sb.append(" is");
-			if (columnName.toLowerCase().startsWith("is")) // IDEMPIERE-7089-P3
+			if (columnName.toLowerCase(java.util.Locale.ROOT).startsWith("is")) // IDEMPIERE-7089-P3
 				sb.append(columnName.substring(2));
 			else
 				sb.append(columnName);
@@ -812,7 +812,7 @@ public class ModelInterfaceGenerator
 		if (tableName == null || tableName.trim().length() == 0)
 			throw new IllegalArgumentException("Must specify table name");
 
-		StringBuilder tableLike = new StringBuilder().append(tableName.trim().toUpperCase().replace("'", "")); // IDEMPIERE-7089-P3
+		StringBuilder tableLike = new StringBuilder().append(tableName.trim().toUpperCase(java.util.Locale.ROOT).replace("'", "")); // IDEMPIERE-7089-P3
 
 		StringBuilder entityTypeFilter = new StringBuilder();
 		if (entityType != null && entityType.trim().length() > 0)

--- a/org.adempiere.base/src/org/compiere/db/StatementProxy.java
+++ b/org.adempiere.base/src/org/compiere/db/StatementProxy.java
@@ -114,7 +114,7 @@ public class StatementProxy implements InvocationHandler {
 		{
 			if (name.equals("executeUpdate") || name.equals("execute"))
 			{
-				logSql = getSql().toUpperCase(); // IDEMPIERE-7089-P3
+				logSql = getSql().toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 				if (logSql.startsWith("UPDATE ")) {
 					logSql = logSql.substring("UPDATE ".length()).trim();
 					logOperation = "Update";

--- a/org.adempiere.base/src/org/compiere/db/StatementProxy.java
+++ b/org.adempiere.base/src/org/compiere/db/StatementProxy.java
@@ -114,7 +114,7 @@ public class StatementProxy implements InvocationHandler {
 		{
 			if (name.equals("executeUpdate") || name.equals("execute"))
 			{
-				logSql = getSql().toUpperCase();
+				logSql = getSql().toUpperCase(); // IDEMPIERE-7089-P3
 				if (logSql.startsWith("UPDATE ")) {
 					logSql = logSql.substring("UPDATE ".length()).trim();
 					logOperation = "Update";

--- a/org.adempiere.base/src/org/compiere/dbPort/Convert.java
+++ b/org.adempiere.base/src/org/compiere/dbPort/Convert.java
@@ -361,7 +361,7 @@ public abstract class Convert
 	 */
 	private String applyConvertMap(String sqlStatement) {
 		// Error Checks
-		if (sqlStatement.toUpperCase().indexOf("EXCEPTION WHEN") != -1) { // IDEMPIERE-7089-P3
+		if (sqlStatement.toUpperCase(java.util.Locale.ROOT).indexOf("EXCEPTION WHEN") != -1) { // IDEMPIERE-7089-P3
 			String error = "Exception clause needs to be converted: "
 					+ sqlStatement;
 			if (log.isLoggable(Level.INFO))
@@ -623,7 +623,7 @@ public abstract class Convert
 		// Do not log *Access records - teo_Sarca BF [ 2782095 ]
 		// IDEMPIERE-323 Migration script log AD_Document_Action_Access (nmicoud / CarlosRuiz_globalqss)
 
-		String uppStmt = statement.toUpperCase().trim(); // IDEMPIERE-7089-P3
+		String uppStmt = statement.toUpperCase(java.util.Locale.ROOT).trim(); // IDEMPIERE-7089-P3
 		// don't log selects
 		if (uppStmt.startsWith("SELECT "))
 			return true;

--- a/org.adempiere.base/src/org/compiere/dbPort/Convert.java
+++ b/org.adempiere.base/src/org/compiere/dbPort/Convert.java
@@ -361,7 +361,7 @@ public abstract class Convert
 	 */
 	private String applyConvertMap(String sqlStatement) {
 		// Error Checks
-		if (sqlStatement.toUpperCase().indexOf("EXCEPTION WHEN") != -1) {
+		if (sqlStatement.toUpperCase().indexOf("EXCEPTION WHEN") != -1) { // IDEMPIERE-7089-P3
 			String error = "Exception clause needs to be converted: "
 					+ sqlStatement;
 			if (log.isLoggable(Level.INFO))
@@ -623,7 +623,7 @@ public abstract class Convert
 		// Do not log *Access records - teo_Sarca BF [ 2782095 ]
 		// IDEMPIERE-323 Migration script log AD_Document_Action_Access (nmicoud / CarlosRuiz_globalqss)
 
-		String uppStmt = statement.toUpperCase().trim();
+		String uppStmt = statement.toUpperCase().trim(); // IDEMPIERE-7089-P3
 		// don't log selects
 		if (uppStmt.startsWith("SELECT "))
 			return true;

--- a/org.adempiere.base/src/org/compiere/dbPort/Convert_SQL92.java
+++ b/org.adempiere.base/src/org/compiere/dbPort/Convert_SQL92.java
@@ -54,11 +54,11 @@ public abstract class Convert_SQL92 extends Convert {
 	{
 		boolean trace = false;
 		//
-		int fromIndex = Util.findIndexOf (sqlStatement.toUpperCase(), " FROM "); // IDEMPIERE-7089-P3
-		int whereIndex = Util.findIndexOf(sqlStatement.toUpperCase(), " WHERE "); // IDEMPIERE-7089-P3
-		int endWhereIndex = Util.findIndexOf(sqlStatement.toUpperCase(), " GROUP BY "); // IDEMPIERE-7089-P3
+		int fromIndex = Util.findIndexOf (sqlStatement.toUpperCase(java.util.Locale.ROOT), " FROM "); // IDEMPIERE-7089-P3
+		int whereIndex = Util.findIndexOf(sqlStatement.toUpperCase(java.util.Locale.ROOT), " WHERE "); // IDEMPIERE-7089-P3
+		int endWhereIndex = Util.findIndexOf(sqlStatement.toUpperCase(java.util.Locale.ROOT), " GROUP BY "); // IDEMPIERE-7089-P3
 		if (endWhereIndex == -1)
-			endWhereIndex = Util.findIndexOf(sqlStatement.toUpperCase(), " ORDER BY "); // IDEMPIERE-7089-P3
+			endWhereIndex = Util.findIndexOf(sqlStatement.toUpperCase(java.util.Locale.ROOT), " ORDER BY "); // IDEMPIERE-7089-P3
 		if (endWhereIndex == -1)
 			endWhereIndex = sqlStatement.length();
 		//
@@ -328,7 +328,7 @@ public abstract class Convert_SQL92 extends Convert {
 		String statement = sqlStatement;
 		StringBuilder sb = new StringBuilder("CASE");
 
-		int index = statement.toUpperCase().indexOf("DECODE", fromIndex); // IDEMPIERE-7089-P3
+		int index = statement.toUpperCase(java.util.Locale.ROOT).indexOf("DECODE", fromIndex); // IDEMPIERE-7089-P3
 		if (index <= 0) return sqlStatement;
 		
 		char previousChar = statement.charAt(index - 1);
@@ -414,7 +414,7 @@ public abstract class Convert_SQL92 extends Convert {
 	 */
 	protected String convertDelete(String sqlStatement) {
 
-		int index = sqlStatement.toUpperCase().indexOf("DELETE "); // IDEMPIERE-7089-P3
+		int index = sqlStatement.toUpperCase(java.util.Locale.ROOT).indexOf("DELETE "); // IDEMPIERE-7089-P3
 		if (index < 7) {
 			return "DELETE FROM " + sqlStatement.substring(index + 7);
 

--- a/org.adempiere.base/src/org/compiere/dbPort/Convert_SQL92.java
+++ b/org.adempiere.base/src/org/compiere/dbPort/Convert_SQL92.java
@@ -54,11 +54,11 @@ public abstract class Convert_SQL92 extends Convert {
 	{
 		boolean trace = false;
 		//
-		int fromIndex = Util.findIndexOf (sqlStatement.toUpperCase(), " FROM ");
-		int whereIndex = Util.findIndexOf(sqlStatement.toUpperCase(), " WHERE ");
-		int endWhereIndex = Util.findIndexOf(sqlStatement.toUpperCase(), " GROUP BY ");
+		int fromIndex = Util.findIndexOf (sqlStatement.toUpperCase(), " FROM "); // IDEMPIERE-7089-P3
+		int whereIndex = Util.findIndexOf(sqlStatement.toUpperCase(), " WHERE "); // IDEMPIERE-7089-P3
+		int endWhereIndex = Util.findIndexOf(sqlStatement.toUpperCase(), " GROUP BY "); // IDEMPIERE-7089-P3
 		if (endWhereIndex == -1)
-			endWhereIndex = Util.findIndexOf(sqlStatement.toUpperCase(), " ORDER BY ");
+			endWhereIndex = Util.findIndexOf(sqlStatement.toUpperCase(), " ORDER BY "); // IDEMPIERE-7089-P3
 		if (endWhereIndex == -1)
 			endWhereIndex = sqlStatement.length();
 		//
@@ -328,7 +328,7 @@ public abstract class Convert_SQL92 extends Convert {
 		String statement = sqlStatement;
 		StringBuilder sb = new StringBuilder("CASE");
 
-		int index = statement.toUpperCase().indexOf("DECODE", fromIndex);
+		int index = statement.toUpperCase().indexOf("DECODE", fromIndex); // IDEMPIERE-7089-P3
 		if (index <= 0) return sqlStatement;
 		
 		char previousChar = statement.charAt(index - 1);
@@ -414,7 +414,7 @@ public abstract class Convert_SQL92 extends Convert {
 	 */
 	protected String convertDelete(String sqlStatement) {
 
-		int index = sqlStatement.toUpperCase().indexOf("DELETE ");
+		int index = sqlStatement.toUpperCase().indexOf("DELETE "); // IDEMPIERE-7089-P3
 		if (index < 7) {
 			return "DELETE FROM " + sqlStatement.substring(index + 7);
 

--- a/org.adempiere.base/src/org/compiere/model/GridField.java
+++ b/org.adempiere.base/src/org/compiere/model/GridField.java
@@ -684,7 +684,7 @@ public class GridField
 		for (Character seqType : seqGetDefaultValue){
 			if (   seqType == DEFAULT_LOGIC  // default from Expression 
 				&& m_vo.DefaultValue != null
-				&& m_vo.DefaultValue.toUpperCase().equals("NULL")) // IDEMPIERE-2678 // IDEMPIERE-7089-P3
+				&& m_vo.DefaultValue.toUpperCase(java.util.Locale.ROOT).equals("NULL")) // IDEMPIERE-2678 // IDEMPIERE-7089-P3
 				return null;
 			defaultValue = getDefaultValueByType(seqType);
 			if (defaultValue != null)
@@ -1072,7 +1072,7 @@ public class GridField
 	private Object createDefault (String value)
 	{
 		//	true NULL
-		if (value == null || value.toString().length() == 0 || value.toUpperCase().equals("NULL")) // IDEMPIERE-7089-P3
+		if (value == null || value.toString().length() == 0 || value.toUpperCase(java.util.Locale.ROOT).equals("NULL")) // IDEMPIERE-7089-P3
 			return null;
 		//	see also MTable.readData
 		try

--- a/org.adempiere.base/src/org/compiere/model/GridField.java
+++ b/org.adempiere.base/src/org/compiere/model/GridField.java
@@ -684,7 +684,7 @@ public class GridField
 		for (Character seqType : seqGetDefaultValue){
 			if (   seqType == DEFAULT_LOGIC  // default from Expression 
 				&& m_vo.DefaultValue != null
-				&& m_vo.DefaultValue.toUpperCase().equals("NULL")) // IDEMPIERE-2678
+				&& m_vo.DefaultValue.toUpperCase().equals("NULL")) // IDEMPIERE-2678 // IDEMPIERE-7089-P3
 				return null;
 			defaultValue = getDefaultValueByType(seqType);
 			if (defaultValue != null)
@@ -1072,7 +1072,7 @@ public class GridField
 	private Object createDefault (String value)
 	{
 		//	true NULL
-		if (value == null || value.toString().length() == 0 || value.toUpperCase().equals("NULL"))
+		if (value == null || value.toString().length() == 0 || value.toUpperCase().equals("NULL")) // IDEMPIERE-7089-P3
 			return null;
 		//	see also MTable.readData
 		try

--- a/org.adempiere.base/src/org/compiere/model/GridTab.java
+++ b/org.adempiere.base/src/org/compiere/model/GridTab.java
@@ -3018,7 +3018,7 @@ public class GridTab implements DataStatusListener, Evaluatee, Serializable
 				// FR [1877902]
 				// CarlosRuiz - globalqss - implement beanshell callout
 				// Victor Perez  - vpj-cd implement JSR 223 Scripting
-				if (cmd.toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) { // IDEMPIERE-7089-P2
+				if (cmd.toLowerCase(java.util.Locale.ROOT).startsWith(MRule.SCRIPT_PREFIX)) { // IDEMPIERE-7089-P2
 
 					MRule rule = MRule.get(m_vo.ctx, cmd.substring(MRule.SCRIPT_PREFIX.length()));
 					if (rule == null) {

--- a/org.adempiere.base/src/org/compiere/model/GridTab.java
+++ b/org.adempiere.base/src/org/compiere/model/GridTab.java
@@ -3018,7 +3018,7 @@ public class GridTab implements DataStatusListener, Evaluatee, Serializable
 				// FR [1877902]
 				// CarlosRuiz - globalqss - implement beanshell callout
 				// Victor Perez  - vpj-cd implement JSR 223 Scripting
-				if (cmd.toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) {
+				if (cmd.toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) { // IDEMPIERE-7089-P2
 
 					MRule rule = MRule.get(m_vo.ctx, cmd.substring(MRule.SCRIPT_PREFIX.length()));
 					if (rule == null) {

--- a/org.adempiere.base/src/org/compiere/model/MAttachmentEntry.java
+++ b/org.adempiere.base/src/org/compiere/model/MAttachmentEntry.java
@@ -395,7 +395,7 @@ public class MAttachmentEntry
 	 */
 	public boolean isPDF()
 	{
-		return m_name.toLowerCase().endsWith(".pdf");
+		return m_name.toLowerCase().endsWith(".pdf"); // IDEMPIERE-7089-P2
 	}	//	isPDF
 	
 	/**
@@ -404,7 +404,7 @@ public class MAttachmentEntry
 	 */
 	public boolean isGraphic()
 	{
-		String m_lowname = m_name.toLowerCase();
+		String m_lowname = m_name.toLowerCase(); // IDEMPIERE-7089-P2
 		return m_lowname.endsWith(".gif") || m_lowname.endsWith(".jpg") || m_lowname.endsWith(".png");
 	}	//	isGraphic
 	

--- a/org.adempiere.base/src/org/compiere/model/MAttachmentEntry.java
+++ b/org.adempiere.base/src/org/compiere/model/MAttachmentEntry.java
@@ -395,7 +395,7 @@ public class MAttachmentEntry
 	 */
 	public boolean isPDF()
 	{
-		return m_name.toLowerCase().endsWith(".pdf"); // IDEMPIERE-7089-P2
+		return m_name.toLowerCase(java.util.Locale.ROOT).endsWith(".pdf"); // IDEMPIERE-7089-P2
 	}	//	isPDF
 	
 	/**
@@ -404,7 +404,7 @@ public class MAttachmentEntry
 	 */
 	public boolean isGraphic()
 	{
-		String m_lowname = m_name.toLowerCase(); // IDEMPIERE-7089-P2
+		String m_lowname = m_name.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P2
 		return m_lowname.endsWith(".gif") || m_lowname.endsWith(".jpg") || m_lowname.endsWith(".png");
 	}	//	isGraphic
 	

--- a/org.adempiere.base/src/org/compiere/model/MAuthorizationCredential.java
+++ b/org.adempiere.base/src/org/compiere/model/MAuthorizationCredential.java
@@ -195,7 +195,7 @@ public class MAuthorizationCredential extends X_AD_AuthorizationCredential {
 			if (account == null) {
 				account = new MAuthorizationAccount(ctx, 0, get_TrxName());
 				account.setEMail(email);
-				if (preferred_username != null && ! email.toLowerCase().equals(preferred_username.toLowerCase()) && EMail.validate(preferred_username)) {
+				if (preferred_username != null && ! email.toLowerCase().equals(preferred_username.toLowerCase()) && EMail.validate(preferred_username)) { // IDEMPIERE-7089-P5
 					account.setPreferred_UserName(preferred_username);
 				}
 				account.setAD_AuthorizationCredential_ID(getAD_AuthorizationCredential_ID());

--- a/org.adempiere.base/src/org/compiere/model/MAuthorizationCredential.java
+++ b/org.adempiere.base/src/org/compiere/model/MAuthorizationCredential.java
@@ -195,7 +195,7 @@ public class MAuthorizationCredential extends X_AD_AuthorizationCredential {
 			if (account == null) {
 				account = new MAuthorizationAccount(ctx, 0, get_TrxName());
 				account.setEMail(email);
-				if (preferred_username != null && ! email.toLowerCase().equals(preferred_username.toLowerCase()) && EMail.validate(preferred_username)) { // IDEMPIERE-7089-P5
+				if (preferred_username != null && ! email.toLowerCase(java.util.Locale.ROOT).equals(preferred_username.toLowerCase(java.util.Locale.ROOT)) && EMail.validate(preferred_username)) { // IDEMPIERE-7089-P5
 					account.setPreferred_UserName(preferred_username);
 				}
 				account.setAD_AuthorizationCredential_ID(getAD_AuthorizationCredential_ID());

--- a/org.adempiere.base/src/org/compiere/model/MColumn.java
+++ b/org.adempiere.base/src/org/compiere/model/MColumn.java
@@ -554,7 +554,7 @@ public class MColumn extends X_AD_Column implements ImmutablePOSupport
 		// If this is column of translation table (_trl), validate field length is >= field length of the corresponding column in base table
 		MTable table = MTable.get(getCtx(), getAD_Table_ID(), get_TrxName());
 		String tableName = table.getTableName();
-		if (tableName.toLowerCase().endsWith("_trl")) { // IDEMPIERE-7089-P3
+		if (tableName.toLowerCase(java.util.Locale.ROOT).endsWith("_trl")) { // IDEMPIERE-7089-P3
 			String parentTable = tableName.substring(0, tableName.length()-4);
 			MColumn column = MColumn.get(getCtx(), parentTable, colname, get_TrxName());
 			if (column != null && column.isTranslated()) {
@@ -820,7 +820,7 @@ public class MColumn extends X_AD_Column implements ImmutablePOSupport
         else if (columnName.equals("Description") || (!caseSensitive && columnName.equalsIgnoreCase("Description")))
             return true;
         else if (columnName.indexOf("Name") != -1
-		|| (!caseSensitive && columnName.toUpperCase().indexOf("Name".toUpperCase()) != -1) ) // IDEMPIERE-7089-P3
+		|| (!caseSensitive && columnName.toUpperCase(java.util.Locale.ROOT).indexOf("Name".toUpperCase(java.util.Locale.ROOT)) != -1) ) // IDEMPIERE-7089-P3
             return true;
         else
         	return false;
@@ -1054,11 +1054,11 @@ public class MColumn extends X_AD_Column implements ImmutablePOSupport
 					Hashtable<String, DatabaseKey> htForeignKeys = new Hashtable<String, DatabaseKey>();
 
 					if (md.storesUpperCaseIdentifiers()) {
-						referenceTableName = referenceTableName.toUpperCase(); // IDEMPIERE-7089-P3
-						tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
+						referenceTableName = referenceTableName.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
+						tableName = tableName.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 					} else if (md.storesLowerCaseIdentifiers()) {
-						referenceTableName = referenceTableName.toLowerCase(); // IDEMPIERE-7089-P3
-						tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
+						referenceTableName = referenceTableName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
+						tableName = tableName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 					}
 
 					if (!isNoTable) {
@@ -1074,7 +1074,7 @@ public class MColumn extends X_AD_Column implements ImmutablePOSupport
 								String dbFKTable = rs.getString("FKTABLE_NAME");
 								short deleteRule = rs.getShort("DELETE_RULE");
 
-								String key = dbFKName.toLowerCase(); // IDEMPIERE-7089-P3
+								String key = dbFKName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 								DatabaseKey dbForeignKey = htForeignKeys.get(key);
 								if (dbForeignKey == null)
 									dbForeignKey = new DatabaseKey(dbFKName, dbFKTable, new String[30], deleteRule);
@@ -1233,9 +1233,9 @@ public class MColumn extends X_AD_Column implements ImmutablePOSupport
 		
 		String tableName = primaryTableName;		
 		if (md.storesUpperCaseIdentifiers())
-			tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
+			tableName = tableName.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 		else if (md.storesLowerCaseIdentifiers())
-			tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
+			tableName = tableName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 		
 		ResultSet rs = null;
 		try {
@@ -1301,7 +1301,7 @@ public class MColumn extends X_AD_Column implements ImmutablePOSupport
 						if (fkConstraintName == null || fkConstraintName.trim().length() == 0)
 						{
 							String columnName = column.getColumnName();
-							if (columnName.toUpperCase().endsWith("_ID")) // IDEMPIERE-7089-P3
+							if (columnName.toUpperCase(java.util.Locale.ROOT).endsWith("_ID")) // IDEMPIERE-7089-P3
 								columnName = columnName.substring(0, columnName.length() - 3);
 							
 							StringBuilder constraintName = new StringBuilder();
@@ -1413,7 +1413,7 @@ public class MColumn extends X_AD_Column implements ImmutablePOSupport
 	public String renameDBColumn(String newColumnName) {
 		int rvalue = -1;
 		String sql;
-		if (! newColumnName.toLowerCase().equals(getColumnName().toLowerCase())) { // IDEMPIERE-7089-P3
+		if (! newColumnName.toLowerCase(java.util.Locale.ROOT).equals(getColumnName().toLowerCase(java.util.Locale.ROOT))) { // IDEMPIERE-7089-P3
 			MTable table = new MTable(getCtx(), getAD_Table_ID(), get_TrxName());
 			sql = "ALTER TABLE " + table.getTableName() + " RENAME COLUMN " + getColumnName() + " TO " + newColumnName;
 			rvalue = DB.executeUpdateEx(sql, get_TrxName());

--- a/org.adempiere.base/src/org/compiere/model/MColumn.java
+++ b/org.adempiere.base/src/org/compiere/model/MColumn.java
@@ -554,7 +554,7 @@ public class MColumn extends X_AD_Column implements ImmutablePOSupport
 		// If this is column of translation table (_trl), validate field length is >= field length of the corresponding column in base table
 		MTable table = MTable.get(getCtx(), getAD_Table_ID(), get_TrxName());
 		String tableName = table.getTableName();
-		if (tableName.toLowerCase().endsWith("_trl")) {
+		if (tableName.toLowerCase().endsWith("_trl")) { // IDEMPIERE-7089-P3
 			String parentTable = tableName.substring(0, tableName.length()-4);
 			MColumn column = MColumn.get(getCtx(), parentTable, colname, get_TrxName());
 			if (column != null && column.isTranslated()) {
@@ -820,7 +820,7 @@ public class MColumn extends X_AD_Column implements ImmutablePOSupport
         else if (columnName.equals("Description") || (!caseSensitive && columnName.equalsIgnoreCase("Description")))
             return true;
         else if (columnName.indexOf("Name") != -1
-        		|| (!caseSensitive && columnName.toUpperCase().indexOf("Name".toUpperCase()) != -1) )
+		|| (!caseSensitive && columnName.toUpperCase().indexOf("Name".toUpperCase()) != -1) ) // IDEMPIERE-7089-P3
             return true;
         else
         	return false;
@@ -1054,11 +1054,11 @@ public class MColumn extends X_AD_Column implements ImmutablePOSupport
 					Hashtable<String, DatabaseKey> htForeignKeys = new Hashtable<String, DatabaseKey>();
 
 					if (md.storesUpperCaseIdentifiers()) {
-						referenceTableName = referenceTableName.toUpperCase();
-						tableName = tableName.toUpperCase();
+						referenceTableName = referenceTableName.toUpperCase(); // IDEMPIERE-7089-P3
+						tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
 					} else if (md.storesLowerCaseIdentifiers()) {
-						referenceTableName = referenceTableName.toLowerCase();
-						tableName = tableName.toLowerCase();
+						referenceTableName = referenceTableName.toLowerCase(); // IDEMPIERE-7089-P3
+						tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
 					}
 
 					if (!isNoTable) {
@@ -1074,7 +1074,7 @@ public class MColumn extends X_AD_Column implements ImmutablePOSupport
 								String dbFKTable = rs.getString("FKTABLE_NAME");
 								short deleteRule = rs.getShort("DELETE_RULE");
 
-								String key = dbFKName.toLowerCase();
+								String key = dbFKName.toLowerCase(); // IDEMPIERE-7089-P3
 								DatabaseKey dbForeignKey = htForeignKeys.get(key);
 								if (dbForeignKey == null)
 									dbForeignKey = new DatabaseKey(dbFKName, dbFKTable, new String[30], deleteRule);
@@ -1233,9 +1233,9 @@ public class MColumn extends X_AD_Column implements ImmutablePOSupport
 		
 		String tableName = primaryTableName;		
 		if (md.storesUpperCaseIdentifiers())
-			tableName = tableName.toUpperCase();
+			tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
 		else if (md.storesLowerCaseIdentifiers())
-			tableName = tableName.toLowerCase();
+			tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
 		
 		ResultSet rs = null;
 		try {
@@ -1301,7 +1301,7 @@ public class MColumn extends X_AD_Column implements ImmutablePOSupport
 						if (fkConstraintName == null || fkConstraintName.trim().length() == 0)
 						{
 							String columnName = column.getColumnName();
-							if (columnName.toUpperCase().endsWith("_ID"))
+							if (columnName.toUpperCase().endsWith("_ID")) // IDEMPIERE-7089-P3
 								columnName = columnName.substring(0, columnName.length() - 3);
 							
 							StringBuilder constraintName = new StringBuilder();
@@ -1312,7 +1312,7 @@ public class MColumn extends X_AD_Column implements ImmutablePOSupport
 								constraintName = new StringBuilder(constraintName.substring(0, AdempiereDatabase.MAX_OBJECT_NAME_LENGTH));
 							fkConstraintName = constraintName.toString();
 							
-							int duplicateId = DB.getSQLValueEx(column.get_TrxName(), "SELECT AD_Column_ID FROM AD_Column WHERE Upper(FkConstraintName)=?", fkConstraintName.toUpperCase());
+							int duplicateId = DB.getSQLValueEx(column.get_TrxName(), "SELECT AD_Column_ID FROM AD_Column WHERE Upper(FkConstraintName)=Upper(?)", fkConstraintName); // IDEMPIERE-7089-P1
 							int loop = 0;
 							while (duplicateId > 0) 
 							{
@@ -1321,7 +1321,7 @@ public class MColumn extends X_AD_Column implements ImmutablePOSupport
 								if (fkConstraintName.length() + suffix.length() > AdempiereDatabase.MAX_OBJECT_NAME_LENGTH)
 									fkConstraintName = fkConstraintName.substring(0, fkConstraintName.length() - (fkConstraintName.length() + suffix.length() - AdempiereDatabase.MAX_OBJECT_NAME_LENGTH));
 								fkConstraintName = fkConstraintName + loop;
-								duplicateId = DB.getSQLValueEx(column.get_TrxName(), "SELECT AD_Column_ID FROM AD_Column WHERE Upper(FkConstraintName)=?", fkConstraintName.toUpperCase());
+								duplicateId = DB.getSQLValueEx(column.get_TrxName(), "SELECT AD_Column_ID FROM AD_Column WHERE Upper(FkConstraintName)=Upper(?)", fkConstraintName); // IDEMPIERE-7089-P1
 							}
 						}
 						
@@ -1413,7 +1413,7 @@ public class MColumn extends X_AD_Column implements ImmutablePOSupport
 	public String renameDBColumn(String newColumnName) {
 		int rvalue = -1;
 		String sql;
-		if (! newColumnName.toLowerCase().equals(getColumnName().toLowerCase())) {
+		if (! newColumnName.toLowerCase().equals(getColumnName().toLowerCase())) { // IDEMPIERE-7089-P3
 			MTable table = new MTable(getCtx(), getAD_Table_ID(), get_TrxName());
 			sql = "ALTER TABLE " + table.getTableName() + " RENAME COLUMN " + getColumnName() + " TO " + newColumnName;
 			rvalue = DB.executeUpdateEx(sql, get_TrxName());

--- a/org.adempiere.base/src/org/compiere/model/MIFixedAsset.java
+++ b/org.adempiere.base/src/org/compiere/model/MIFixedAsset.java
@@ -80,7 +80,7 @@ public class MIFixedAsset extends X_I_FixedAsset
 			if (key == null || key.trim().length() == 0) {
 				throw new FillMandatoryException(COLUMNNAME_ProductValue, COLUMNNAME_Name);
 			}
-			key = key.toUpperCase(); // IDEMPIERE-7089-P5
+			key = key.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P5
 			whereClause.append(DB.TO_STRING(key));
 			whereClause.append(" AND AD_Client_ID=").append(getAD_Client_ID());
 			String sql = "SELECT M_Product_ID FROM M_Product WHERE " + whereClause.toString();

--- a/org.adempiere.base/src/org/compiere/model/MIFixedAsset.java
+++ b/org.adempiere.base/src/org/compiere/model/MIFixedAsset.java
@@ -80,7 +80,7 @@ public class MIFixedAsset extends X_I_FixedAsset
 			if (key == null || key.trim().length() == 0) {
 				throw new FillMandatoryException(COLUMNNAME_ProductValue, COLUMNNAME_Name);
 			}
-			key = key.toUpperCase();
+			key = key.toUpperCase(); // IDEMPIERE-7089-P5
 			whereClause.append(DB.TO_STRING(key));
 			whereClause.append(" AND AD_Client_ID=").append(getAD_Client_ID());
 			String sql = "SELECT M_Product_ID FROM M_Product WHERE " + whereClause.toString();

--- a/org.adempiere.base/src/org/compiere/model/MMeasure.java
+++ b/org.adempiere.base/src/org/compiere/model/MMeasure.java
@@ -654,7 +654,7 @@ public class MMeasure extends X_PA_Measure implements ImmutablePOSupport
 			{
 				String cmd = st.nextToken().trim();	
 				StringBuilder retValue = new StringBuilder();
-				if (cmd.toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) {
+				if (cmd.toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) { // IDEMPIERE-7089-P2
 					
 					MRule rule = MRule.get(getCtx(), cmd.substring(MRule.SCRIPT_PREFIX.length()));
 					if (rule == null) {

--- a/org.adempiere.base/src/org/compiere/model/MMeasure.java
+++ b/org.adempiere.base/src/org/compiere/model/MMeasure.java
@@ -654,7 +654,7 @@ public class MMeasure extends X_PA_Measure implements ImmutablePOSupport
 			{
 				String cmd = st.nextToken().trim();	
 				StringBuilder retValue = new StringBuilder();
-				if (cmd.toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) { // IDEMPIERE-7089-P2
+				if (cmd.toLowerCase(java.util.Locale.ROOT).startsWith(MRule.SCRIPT_PREFIX)) { // IDEMPIERE-7089-P2
 					
 					MRule rule = MRule.get(getCtx(), cmd.substring(MRule.SCRIPT_PREFIX.length()));
 					if (rule == null) {

--- a/org.adempiere.base/src/org/compiere/model/MMeasureCalc.java
+++ b/org.adempiere.base/src/org/compiere/model/MMeasureCalc.java
@@ -263,7 +263,7 @@ public class MMeasureCalc extends X_PA_MeasureCalc implements ImmutablePOSupport
 		String selectFrom = getSelectClause();
 		int index = selectFrom.indexOf("FROM ");
 		if (index == -1)
-			index = selectFrom.toUpperCase().indexOf("FROM ");
+			index = selectFrom.toUpperCase().indexOf("FROM "); // IDEMPIERE-7089-P3
 		if (index == -1)
 			throw new IllegalArgumentException("Cannot find FROM in sql - " + selectFrom);
 		sb.append(selectFrom.substring(0, index))

--- a/org.adempiere.base/src/org/compiere/model/MMeasureCalc.java
+++ b/org.adempiere.base/src/org/compiere/model/MMeasureCalc.java
@@ -263,7 +263,7 @@ public class MMeasureCalc extends X_PA_MeasureCalc implements ImmutablePOSupport
 		String selectFrom = getSelectClause();
 		int index = selectFrom.indexOf("FROM ");
 		if (index == -1)
-			index = selectFrom.toUpperCase().indexOf("FROM "); // IDEMPIERE-7089-P3
+			index = selectFrom.toUpperCase(java.util.Locale.ROOT).indexOf("FROM "); // IDEMPIERE-7089-P3
 		if (index == -1)
 			throw new IllegalArgumentException("Cannot find FROM in sql - " + selectFrom);
 		sb.append(selectFrom.substring(0, index))

--- a/org.adempiere.base/src/org/compiere/model/MProcess.java
+++ b/org.adempiere.base/src/org/compiere/model/MProcess.java
@@ -479,7 +479,7 @@ public class MProcess extends X_AD_Process implements ImmutablePOSupport
 	{
 		if (log.isLoggable(Level.INFO)) log.info(pi.getClassName());
 
-		if (pi.getClassName().toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) {
+		if (pi.getClassName().toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) { // IDEMPIERE-7089-P2
 			return ProcessUtil.startScriptProcess(getCtx(), pi, trx);
 		} else {
 			return ProcessUtil.startJavaProcess(getCtx(), pi, trx, managedTrx);

--- a/org.adempiere.base/src/org/compiere/model/MProcess.java
+++ b/org.adempiere.base/src/org/compiere/model/MProcess.java
@@ -479,7 +479,7 @@ public class MProcess extends X_AD_Process implements ImmutablePOSupport
 	{
 		if (log.isLoggable(Level.INFO)) log.info(pi.getClassName());
 
-		if (pi.getClassName().toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) { // IDEMPIERE-7089-P2
+		if (pi.getClassName().toLowerCase(java.util.Locale.ROOT).startsWith(MRule.SCRIPT_PREFIX)) { // IDEMPIERE-7089-P2
 			return ProcessUtil.startScriptProcess(getCtx(), pi, trx);
 		} else {
 			return ProcessUtil.startJavaProcess(getCtx(), pi, trx, managedTrx);

--- a/org.adempiere.base/src/org/compiere/model/MQuery.java
+++ b/org.adempiere.base/src/org/compiere/model/MQuery.java
@@ -195,7 +195,7 @@ public class MQuery implements Serializable, Cloneable
 						if (Reference_ID == DisplayType.ChosenMultipleSelectionList)
 						{
 							String columnName = TableName + "." + ParameterName;		
-							int cnt = DB.getSQLValueEx(null, "SELECT Count(*) From AD_Column WHERE IsActive='Y' AND AD_Client_ID=0 AND Upper(ColumnName)=? AND AD_Reference_ID=?", ParameterName.toUpperCase(), DisplayType.ChosenMultipleSelectionList);
+							int cnt = DB.getSQLValueEx(null, "SELECT Count(*) From AD_Column WHERE IsActive='Y' AND AD_Client_ID=0 AND Upper(ColumnName)=Upper(?) AND AD_Reference_ID=?", ParameterName, DisplayType.ChosenMultipleSelectionList); // IDEMPIERE-7089-P1
 							if (cnt > 0)
 								query.addRestriction(DB.intersectFilterForCSV(columnName, P_String, isNotClause), isNotClause ? MQuery.NOT_EQUAL : MQuery.EQUAL, Name, Info);
 							else
@@ -2008,8 +2008,8 @@ class Restriction  implements Serializable
 					.append(ColumnName.substring(end));
 			else
 			{
-				int selectIndex = ColumnName.toLowerCase().indexOf("select ");
-				int fromIndex = ColumnName.toLowerCase().indexOf(" from ");
+				int selectIndex = ColumnName.toLowerCase().indexOf("select "); // IDEMPIERE-7089-P3
+				int fromIndex = ColumnName.toLowerCase().indexOf(" from "); // IDEMPIERE-7089-P3
 				if (selectIndex >= 0 && fromIndex > 0) 
 				{
 					sb.append(ColumnName);
@@ -2029,7 +2029,7 @@ class Restriction  implements Serializable
 		if ( ! (Operator.equals(MQuery.NULL) || Operator.equals(MQuery.NOT_NULL)))
 		{
 			if (Code instanceof String) {
-				if (ColumnName.toUpperCase().startsWith("UPPER(")) {
+				if (ColumnName.toUpperCase().startsWith("UPPER(")) { // IDEMPIERE-7089-P3
 					sb.append("UPPER("+DB.TO_STRING(Code.toString())+")");
 				} else {
 					sb.append(DB.TO_STRING(Code.toString()));
@@ -2108,8 +2108,8 @@ class Restriction  implements Serializable
 						.append(DB.getDatabase().quoteColumnName(ColumnName.substring(pos, end)))
 						.append(ColumnName.substring(end));
 			else {
-				int selectIndex = ColumnName.toLowerCase().indexOf("select ");
-				int fromIndex = ColumnName.toLowerCase().indexOf(" from ");
+				int selectIndex = ColumnName.toLowerCase().indexOf("select "); // IDEMPIERE-7089-P3
+				int fromIndex = ColumnName.toLowerCase().indexOf(" from "); // IDEMPIERE-7089-P3
 				if (selectIndex >= 0 && fromIndex > 0) {
 					sb.append(ColumnName);
 				} else {
@@ -2123,7 +2123,7 @@ class Restriction  implements Serializable
 		else
 			sb.append(Operator);
 		if (!(Operator.equals(MQuery.NULL) || Operator.equals(MQuery.NOT_NULL))) {
-			boolean useUpper = (Code instanceof String) && ColumnName.toUpperCase().startsWith("UPPER(");
+			boolean useUpper = (Code instanceof String) && ColumnName.toUpperCase().startsWith("UPPER("); // IDEMPIERE-7089-P3
 			if (useUpper)
 				sb.append("UPPER(");
 			sb.append("?");

--- a/org.adempiere.base/src/org/compiere/model/MQuery.java
+++ b/org.adempiere.base/src/org/compiere/model/MQuery.java
@@ -2008,8 +2008,8 @@ class Restriction  implements Serializable
 					.append(ColumnName.substring(end));
 			else
 			{
-				int selectIndex = ColumnName.toLowerCase().indexOf("select "); // IDEMPIERE-7089-P3
-				int fromIndex = ColumnName.toLowerCase().indexOf(" from "); // IDEMPIERE-7089-P3
+				int selectIndex = ColumnName.toLowerCase(java.util.Locale.ROOT).indexOf("select "); // IDEMPIERE-7089-P3
+				int fromIndex = ColumnName.toLowerCase(java.util.Locale.ROOT).indexOf(" from "); // IDEMPIERE-7089-P3
 				if (selectIndex >= 0 && fromIndex > 0) 
 				{
 					sb.append(ColumnName);
@@ -2029,7 +2029,7 @@ class Restriction  implements Serializable
 		if ( ! (Operator.equals(MQuery.NULL) || Operator.equals(MQuery.NOT_NULL)))
 		{
 			if (Code instanceof String) {
-				if (ColumnName.toUpperCase().startsWith("UPPER(")) { // IDEMPIERE-7089-P3
+				if (ColumnName.toUpperCase(java.util.Locale.ROOT).startsWith("UPPER(")) { // IDEMPIERE-7089-P3
 					sb.append("UPPER("+DB.TO_STRING(Code.toString())+")");
 				} else {
 					sb.append(DB.TO_STRING(Code.toString()));
@@ -2108,8 +2108,8 @@ class Restriction  implements Serializable
 						.append(DB.getDatabase().quoteColumnName(ColumnName.substring(pos, end)))
 						.append(ColumnName.substring(end));
 			else {
-				int selectIndex = ColumnName.toLowerCase().indexOf("select "); // IDEMPIERE-7089-P3
-				int fromIndex = ColumnName.toLowerCase().indexOf(" from "); // IDEMPIERE-7089-P3
+				int selectIndex = ColumnName.toLowerCase(java.util.Locale.ROOT).indexOf("select "); // IDEMPIERE-7089-P3
+				int fromIndex = ColumnName.toLowerCase(java.util.Locale.ROOT).indexOf(" from "); // IDEMPIERE-7089-P3
 				if (selectIndex >= 0 && fromIndex > 0) {
 					sb.append(ColumnName);
 				} else {
@@ -2123,7 +2123,7 @@ class Restriction  implements Serializable
 		else
 			sb.append(Operator);
 		if (!(Operator.equals(MQuery.NULL) || Operator.equals(MQuery.NOT_NULL))) {
-			boolean useUpper = (Code instanceof String) && ColumnName.toUpperCase().startsWith("UPPER("); // IDEMPIERE-7089-P3
+			boolean useUpper = (Code instanceof String) && ColumnName.toUpperCase(java.util.Locale.ROOT).startsWith("UPPER("); // IDEMPIERE-7089-P3
 			if (useUpper)
 				sb.append("UPPER(");
 			sb.append("?");

--- a/org.adempiere.base/src/org/compiere/model/MRole.java
+++ b/org.adempiere.base/src/org/compiere/model/MRole.java
@@ -2144,7 +2144,7 @@ public final class MRole extends X_AD_Role implements ImmutablePOSupport
 			String TableName = ti[i].getTableName();
 			
 			//[ 1644310 ] Rev. 1292 hangs on start
-			if (TableName.toUpperCase().endsWith("_TRL")) continue; // IDEMPIERE-7089-P3
+			if (TableName.toUpperCase(java.util.Locale.ROOT).endsWith("_TRL")) continue; // IDEMPIERE-7089-P3
 			if (isView(TableName)) continue;
 			
 			int AD_Table_ID = getAD_Table_ID (TableName);
@@ -2197,7 +2197,7 @@ public final class MRole extends X_AD_Role implements ImmutablePOSupport
 			if (columnName == null)
 				continue;	//	no key column
 			
-			if (mainSql.toUpperCase().startsWith("SELECT COUNT(*) FROM ")) { // IDEMPIERE-7089-P3
+			if (mainSql.toUpperCase(java.util.Locale.ROOT).startsWith("SELECT COUNT(*) FROM ")) { // IDEMPIERE-7089-P3
 				// globalqss - Carlos Ruiz - [ 1965744 ] Dependent entities access problem
 				// this is the count select, it doesn't have the column but needs to be filtered
 				 MTable table = MTable.get(getCtx(), tableName);

--- a/org.adempiere.base/src/org/compiere/model/MRole.java
+++ b/org.adempiere.base/src/org/compiere/model/MRole.java
@@ -2144,7 +2144,7 @@ public final class MRole extends X_AD_Role implements ImmutablePOSupport
 			String TableName = ti[i].getTableName();
 			
 			//[ 1644310 ] Rev. 1292 hangs on start
-			if (TableName.toUpperCase().endsWith("_TRL")) continue;
+			if (TableName.toUpperCase().endsWith("_TRL")) continue; // IDEMPIERE-7089-P3
 			if (isView(TableName)) continue;
 			
 			int AD_Table_ID = getAD_Table_ID (TableName);
@@ -2197,7 +2197,7 @@ public final class MRole extends X_AD_Role implements ImmutablePOSupport
 			if (columnName == null)
 				continue;	//	no key column
 			
-			if (mainSql.toUpperCase().startsWith("SELECT COUNT(*) FROM ")) {
+			if (mainSql.toUpperCase().startsWith("SELECT COUNT(*) FROM ")) { // IDEMPIERE-7089-P3
 				// globalqss - Carlos Ruiz - [ 1965744 ] Dependent entities access problem
 				// this is the count select, it doesn't have the column but needs to be filtered
 				 MTable table = MTable.get(getCtx(), tableName);

--- a/org.adempiere.base/src/org/compiere/model/MSearchDefinition.java
+++ b/org.adempiere.base/src/org/compiere/model/MSearchDefinition.java
@@ -102,9 +102,9 @@ public class MSearchDefinition extends X_AD_SearchDefinition {
 		sql = "SELECT AD_SearchDefinition_ID FROM AD_SearchDefinition WHERE IsActive = 'Y' ";
 
 		if (transactionCode != null) {
-			sql += "AND UPPER(TransactionCode) = ?";
+			sql += "AND UPPER(TransactionCode) = UPPER(?)";
 			pstmt = DB.prepareStatement(sql, null);
-			pstmt.setString(1, transactionCode.toUpperCase());
+			pstmt.setString(1, transactionCode); // IDEMPIERE-7089-P1
 		} else {
 			sql += "AND IsDefault = 'Y'";
 			pstmt = DB.prepareStatement(sql, null);
@@ -139,10 +139,10 @@ public class MSearchDefinition extends X_AD_SearchDefinition {
 			PreparedStatement pstmt = null;
 			ResultSet rs = null;
 
-			sql = "SELECT AD_SearchDefinition_ID FROM AD_SearchDefinition WHERE UPPER(TransactionCode) = ? AND IsActive = 'Y'";
+			sql = "SELECT AD_SearchDefinition_ID FROM AD_SearchDefinition WHERE UPPER(TransactionCode) = UPPER(?) AND IsActive = 'Y'";
 
 			pstmt = DB.prepareStatement(sql, null);
-			pstmt.setString(1, transactionCode.toUpperCase());
+			pstmt.setString(1, transactionCode); // IDEMPIERE-7089-P1
 
 			if (pstmt != null) {
 				rs = pstmt.executeQuery();

--- a/org.adempiere.base/src/org/compiere/model/MSequence.java
+++ b/org.adempiere.base/src/org/compiere/model/MSequence.java
@@ -878,7 +878,7 @@ public class MSequence extends X_AD_Sequence
 		try
 		{
 			pstmt = DB.prepareStatement (sql, trxName);
-			pstmt.setString(1, tableName.toUpperCase()); // IDEMPIERE-7089-P3
+			pstmt.setString(1, tableName.toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 			pstmt.setString(2, ( tableID ? "Y" : "N" ) );
 			if (! tableID)
 				pstmt.setInt (3, Env.getAD_Client_ID(Env.getCtx()));

--- a/org.adempiere.base/src/org/compiere/model/MSequence.java
+++ b/org.adempiere.base/src/org/compiere/model/MSequence.java
@@ -878,7 +878,7 @@ public class MSequence extends X_AD_Sequence
 		try
 		{
 			pstmt = DB.prepareStatement (sql, trxName);
-			pstmt.setString(1, tableName.toUpperCase());
+			pstmt.setString(1, tableName.toUpperCase()); // IDEMPIERE-7089-P3
 			pstmt.setString(2, ( tableID ? "Y" : "N" ) );
 			if (! tableID)
 				pstmt.setInt (3, Env.getAD_Client_ID(Env.getCtx()));

--- a/org.adempiere.base/src/org/compiere/model/MSession.java
+++ b/org.adempiere.base/src/org/compiere/model/MSession.java
@@ -525,7 +525,7 @@ public class MSession extends X_AD_Session implements ImmutablePOSupport
 	 * @param tableName table name, case insensitive
 	 */
 	public void addSkipChangeLogForUpdate(String tableName) {
-		skipChangeLogForUpdateSet.add(tableName.toUpperCase());
+		skipChangeLogForUpdateSet.add(tableName.toUpperCase()); // IDEMPIERE-7089-P2
 	}
 	
 	/**
@@ -534,7 +534,7 @@ public class MSession extends X_AD_Session implements ImmutablePOSupport
 	 * @param tableName table name, case insensitive
 	 */
 	public void removeSkipChangeLogForUpdate(String tableName) {
-		skipChangeLogForUpdateSet.remove(tableName.toUpperCase());
+		skipChangeLogForUpdateSet.remove(tableName.toUpperCase()); // IDEMPIERE-7089-P2
 	}
 	
 	/**
@@ -543,7 +543,7 @@ public class MSession extends X_AD_Session implements ImmutablePOSupport
 	 * @return true if it is to skip the capture of update change log for this session
 	 */
 	public boolean isSkipChangeLogForUpdate(String tableName) {
-		return skipChangeLogForUpdateSet.contains(tableName.toUpperCase());
+		return skipChangeLogForUpdateSet.contains(tableName.toUpperCase()); // IDEMPIERE-7089-P2
 	}
 }	//	MSession
 

--- a/org.adempiere.base/src/org/compiere/model/MSession.java
+++ b/org.adempiere.base/src/org/compiere/model/MSession.java
@@ -525,7 +525,7 @@ public class MSession extends X_AD_Session implements ImmutablePOSupport
 	 * @param tableName table name, case insensitive
 	 */
 	public void addSkipChangeLogForUpdate(String tableName) {
-		skipChangeLogForUpdateSet.add(tableName.toUpperCase()); // IDEMPIERE-7089-P2
+		skipChangeLogForUpdateSet.add(tableName.toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P2
 	}
 	
 	/**
@@ -534,7 +534,7 @@ public class MSession extends X_AD_Session implements ImmutablePOSupport
 	 * @param tableName table name, case insensitive
 	 */
 	public void removeSkipChangeLogForUpdate(String tableName) {
-		skipChangeLogForUpdateSet.remove(tableName.toUpperCase()); // IDEMPIERE-7089-P2
+		skipChangeLogForUpdateSet.remove(tableName.toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P2
 	}
 	
 	/**
@@ -543,7 +543,7 @@ public class MSession extends X_AD_Session implements ImmutablePOSupport
 	 * @return true if it is to skip the capture of update change log for this session
 	 */
 	public boolean isSkipChangeLogForUpdate(String tableName) {
-		return skipChangeLogForUpdateSet.contains(tableName.toUpperCase()); // IDEMPIERE-7089-P2
+		return skipChangeLogForUpdateSet.contains(tableName.toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P2
 	}
 }	//	MSession
 

--- a/org.adempiere.base/src/org/compiere/model/MSystem.java
+++ b/org.adempiere.base/src/org/compiere/model/MSystem.java
@@ -399,7 +399,7 @@ public class MSystem extends X_AD_System
 	private void setDBInfo()
 	{
 		String dbAddress = CConnection.get().getConnectionURL();
-		setDBAddress(dbAddress.toLowerCase());
+		setDBAddress(dbAddress.toLowerCase()); // IDEMPIERE-7089-P2
 		//
 		if (!Ini.isClient())
 		{
@@ -420,7 +420,7 @@ public class MSystem extends X_AD_System
 			if (rs.next())
 			{
 				dbName = rs.getString(2);
-				setDBInstance(dbName.toLowerCase());
+				setDBInstance(dbName.toLowerCase()); // IDEMPIERE-7089-P2
 			}
 		}
 		catch (SQLException e)

--- a/org.adempiere.base/src/org/compiere/model/MSystem.java
+++ b/org.adempiere.base/src/org/compiere/model/MSystem.java
@@ -399,7 +399,7 @@ public class MSystem extends X_AD_System
 	private void setDBInfo()
 	{
 		String dbAddress = CConnection.get().getConnectionURL();
-		setDBAddress(dbAddress.toLowerCase()); // IDEMPIERE-7089-P2
+		setDBAddress(dbAddress.toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P2
 		//
 		if (!Ini.isClient())
 		{
@@ -420,7 +420,7 @@ public class MSystem extends X_AD_System
 			if (rs.next())
 			{
 				dbName = rs.getString(2);
-				setDBInstance(dbName.toLowerCase()); // IDEMPIERE-7089-P2
+				setDBInstance(dbName.toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P2
 			}
 		}
 		catch (SQLException e)

--- a/org.adempiere.base/src/org/compiere/model/MTable.java
+++ b/org.adempiere.base/src/org/compiere/model/MTable.java
@@ -170,7 +170,7 @@ public class MTable extends X_AD_Table implements ImmutablePOSupport
 		try
 		{
 			pstmt = DB.prepareStatement (sql, trxName);
-			pstmt.setString(1, tableName.toUpperCase());
+			pstmt.setString(1, tableName.toUpperCase()); // IDEMPIERE-7089-P3
 			rs = pstmt.executeQuery ();
 			if (rs.next())
 				retValue = new MTable (ctx, rs, trxName);
@@ -393,7 +393,7 @@ public class MTable extends X_AD_Table implements ImmutablePOSupport
 				if (is_Immutable())
 					column.markImmutable();
 				list.add (column);
-				m_columnNameMap.put(column.getColumnName().toUpperCase(), list.size() - 1);
+				m_columnNameMap.put(column.getColumnName().toUpperCase(), list.size() - 1); // IDEMPIERE-7089-P3
 				m_columnIdMap.put(column.getAD_Column_ID(), list.size() - 1);
 			}
 		}
@@ -438,7 +438,7 @@ public class MTable extends X_AD_Table implements ImmutablePOSupport
 	{
 		if (m_columns == null)
 			getColumns(false);
-		Integer i = m_columnNameMap.get(ColumnName.toUpperCase());
+		Integer i = m_columnNameMap.get(ColumnName.toUpperCase()); // IDEMPIERE-7089-P3
 		if (i != null)
 			return i.intValue();
 		
@@ -553,7 +553,7 @@ public class MTable extends X_AD_Table implements ImmutablePOSupport
 		String uuColName = PO.getUUIDColumnName(getTableName());
 		if (m_columns == null)
 			getColumns(false);
-		return m_columnNameMap.get(uuColName.toUpperCase()) != null;
+		return m_columnNameMap.get(uuColName.toUpperCase()) != null; // IDEMPIERE-7089-P3
 	}
 
 	/**

--- a/org.adempiere.base/src/org/compiere/model/MTable.java
+++ b/org.adempiere.base/src/org/compiere/model/MTable.java
@@ -170,7 +170,7 @@ public class MTable extends X_AD_Table implements ImmutablePOSupport
 		try
 		{
 			pstmt = DB.prepareStatement (sql, trxName);
-			pstmt.setString(1, tableName.toUpperCase()); // IDEMPIERE-7089-P3
+			pstmt.setString(1, tableName.toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 			rs = pstmt.executeQuery ();
 			if (rs.next())
 				retValue = new MTable (ctx, rs, trxName);
@@ -393,7 +393,7 @@ public class MTable extends X_AD_Table implements ImmutablePOSupport
 				if (is_Immutable())
 					column.markImmutable();
 				list.add (column);
-				m_columnNameMap.put(column.getColumnName().toUpperCase(), list.size() - 1); // IDEMPIERE-7089-P3
+				m_columnNameMap.put(column.getColumnName().toUpperCase(java.util.Locale.ROOT), list.size() - 1); // IDEMPIERE-7089-P3
 				m_columnIdMap.put(column.getAD_Column_ID(), list.size() - 1);
 			}
 		}
@@ -438,7 +438,7 @@ public class MTable extends X_AD_Table implements ImmutablePOSupport
 	{
 		if (m_columns == null)
 			getColumns(false);
-		Integer i = m_columnNameMap.get(ColumnName.toUpperCase()); // IDEMPIERE-7089-P3
+		Integer i = m_columnNameMap.get(ColumnName.toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 		if (i != null)
 			return i.intValue();
 		
@@ -553,7 +553,7 @@ public class MTable extends X_AD_Table implements ImmutablePOSupport
 		String uuColName = PO.getUUIDColumnName(getTableName());
 		if (m_columns == null)
 			getColumns(false);
-		return m_columnNameMap.get(uuColName.toUpperCase()) != null; // IDEMPIERE-7089-P3
+		return m_columnNameMap.get(uuColName.toUpperCase(java.util.Locale.ROOT)) != null; // IDEMPIERE-7089-P3
 	}
 
 	/**

--- a/org.adempiere.base/src/org/compiere/model/MViewComponent.java
+++ b/org.adempiere.base/src/org/compiere/model/MViewComponent.java
@@ -175,7 +175,7 @@ public class MViewComponent extends X_AD_ViewComponent implements ImmutablePOSup
 				sb.append(", ");
 			String colSQL = vc.getColumnSQL();
 			
-			if (colSQL == null || colSQL.toUpperCase().equals("NULL")) // IDEMPIERE-7089-P3
+			if (colSQL == null || colSQL.toUpperCase(java.util.Locale.ROOT).equals("NULL")) // IDEMPIERE-7089-P3
 			{
 				String dt = vc.getDBDataType();
 				if (dt != null)

--- a/org.adempiere.base/src/org/compiere/model/MViewComponent.java
+++ b/org.adempiere.base/src/org/compiere/model/MViewComponent.java
@@ -175,7 +175,7 @@ public class MViewComponent extends X_AD_ViewComponent implements ImmutablePOSup
 				sb.append(", ");
 			String colSQL = vc.getColumnSQL();
 			
-			if (colSQL == null || colSQL.toUpperCase().equals("NULL"))
+			if (colSQL == null || colSQL.toUpperCase().equals("NULL")) // IDEMPIERE-7089-P3
 			{
 				String dt = vc.getDBDataType();
 				if (dt != null)

--- a/org.adempiere.base/src/org/compiere/model/M_Element.java
+++ b/org.adempiere.base/src/org/compiere/model/M_Element.java
@@ -96,9 +96,9 @@ public class M_Element extends X_AD_Element
 			return null;
 		//
 		// TODO: caching if trxName == null
- 	 	final String whereClause = "UPPER(ColumnName)=?";
+		final String whereClause = "UPPER(ColumnName)=UPPER(?)";
 	 	M_Element retValue = new Query(ctx, I_AD_Element.Table_Name, whereClause, trxName)
-			.setParameters(columnName.toUpperCase())
+			.setParameters(columnName) // IDEMPIERE-7089-P1
 			.firstOnly();
 		return retValue;
 	}	//	get
@@ -191,10 +191,10 @@ public class M_Element extends X_AD_Element
 			if (getColumnName().length() != columnName.length())
 				setColumnName(columnName);
 			
-			StringBuilder sql = new StringBuilder("select count(*) from AD_Element where UPPER(ColumnName)=?");
+			StringBuilder sql = new StringBuilder("select count(*) from AD_Element where UPPER(ColumnName)=UPPER(?)");
 			if (!newRecord)
 				sql.append(" AND AD_Element_ID<>").append(get_ID()); 
-			int no = DB.getSQLValue(null, sql.toString(), columnName.toUpperCase());
+			int no = DB.getSQLValue(null, sql.toString(), columnName); // IDEMPIERE-7089-P1
 			if (no > 0) {
 				log.saveError(DBException.SAVE_ERROR_NOT_UNIQUE_MSG, Msg.getElement(getCtx(), COLUMNNAME_ColumnName));
 				return false;
@@ -246,8 +246,9 @@ public class M_Element extends X_AD_Element
 					.append(", Description=").append(DB.TO_STRING(getDescription()))
 					.append(", Help=").append(DB.TO_STRING(getHelp()))
 					.append(", AD_Element_ID=").append(get_ID())
-					.append(" WHERE UPPER(ColumnName)=")
-					.append(DB.TO_STRING(getColumnName().toUpperCase()))
+					.append(" WHERE UPPER(ColumnName)=UPPER(")
+					.append(DB.TO_STRING(getColumnName())) // IDEMPIERE-7089-P1
+					.append(")")
 					.append(" AND IsCentrallyMaintained='Y' AND AD_Element_ID IS NULL");
 				no = DB.executeUpdate(sql.toString(), get_TrxName());
 				

--- a/org.adempiere.base/src/org/compiere/model/NaturalAccountMap.java
+++ b/org.adempiere.base/src/org/compiere/model/NaturalAccountMap.java
@@ -246,13 +246,13 @@ public final class NaturalAccountMap<K,V> extends CCache<K,V>
 				//  Create Account - save later
 				na = new MElementValue(m_ctx, Value, Name, Description,
 					AccountType, AccountSign,
-					IsDocControlled.toUpperCase().startsWith("Y"), 
-					IsSummary.toUpperCase().startsWith("Y"), m_trxName);
+					IsDocControlled.toUpperCase().startsWith("Y"),  // IDEMPIERE-7089-P5
+					IsSummary.toUpperCase().startsWith("Y"), m_trxName); // IDEMPIERE-7089-P5
 				m_valueMap.put(Value, na);
 			}
 			
 			//  Add to Cache
-			put((K)Default_Account.toUpperCase(), (V)na);
+			put((K)Default_Account.toUpperCase(), (V)na); // IDEMPIERE-7089-P5
 		}
 		catch (Exception e)
 		{

--- a/org.adempiere.base/src/org/compiere/model/NaturalAccountMap.java
+++ b/org.adempiere.base/src/org/compiere/model/NaturalAccountMap.java
@@ -246,13 +246,13 @@ public final class NaturalAccountMap<K,V> extends CCache<K,V>
 				//  Create Account - save later
 				na = new MElementValue(m_ctx, Value, Name, Description,
 					AccountType, AccountSign,
-					IsDocControlled.toUpperCase().startsWith("Y"),  // IDEMPIERE-7089-P5
-					IsSummary.toUpperCase().startsWith("Y"), m_trxName); // IDEMPIERE-7089-P5
+					IsDocControlled.toUpperCase(java.util.Locale.ROOT).startsWith("Y"),  // IDEMPIERE-7089-P5
+					IsSummary.toUpperCase(java.util.Locale.ROOT).startsWith("Y"), m_trxName); // IDEMPIERE-7089-P5
 				m_valueMap.put(Value, na);
 			}
 			
 			//  Add to Cache
-			put((K)Default_Account.toUpperCase(), (V)na); // IDEMPIERE-7089-P5
+			put((K)Default_Account.toUpperCase(java.util.Locale.ROOT), (V)na); // IDEMPIERE-7089-P5
 		}
 		catch (Exception e)
 		{

--- a/org.adempiere.base/src/org/compiere/model/PO.java
+++ b/org.adempiere.base/src/org/compiere/model/PO.java
@@ -911,7 +911,7 @@ public abstract class PO
 		checkImmutable();
 		
 		if (value instanceof String && ColumnName.equals("WhereClause")
-			&& value.toString().toUpperCase().indexOf("=NULL") != -1) // IDEMPIERE-7089-P3
+			&& value.toString().toUpperCase(java.util.Locale.ROOT).indexOf("=NULL") != -1) // IDEMPIERE-7089-P3
 			log.warning("Invalid Null Value - " + ColumnName + "=" + value);
 
 		int index = get_ColumnIndex(ColumnName);

--- a/org.adempiere.base/src/org/compiere/model/PO.java
+++ b/org.adempiere.base/src/org/compiere/model/PO.java
@@ -911,7 +911,7 @@ public abstract class PO
 		checkImmutable();
 		
 		if (value instanceof String && ColumnName.equals("WhereClause")
-			&& value.toString().toUpperCase().indexOf("=NULL") != -1)
+			&& value.toString().toUpperCase().indexOf("=NULL") != -1) // IDEMPIERE-7089-P3
 			log.warning("Invalid Null Value - " + ColumnName + "=" + value);
 
 		int index = get_ColumnIndex(ColumnName);

--- a/org.adempiere.base/src/org/compiere/model/POInfo.java
+++ b/org.adempiere.base/src/org/compiere/model/POInfo.java
@@ -223,7 +223,7 @@ public class POInfo implements Serializable
 					IsAllowLogging, IsAllowCopy);
 				list.add(col);
 				
-				m_columnNameMap.put(ColumnName.toUpperCase(), list.size() - 1);
+				m_columnNameMap.put(ColumnName.toUpperCase(), list.size() - 1); // IDEMPIERE-7089-P3
 				m_columnIdMap.put(AD_Column_ID, list.size() - 1);
 			}
 		}
@@ -314,7 +314,7 @@ public class POInfo implements Serializable
 	 */
 	public int getColumnIndex (String ColumnName)
 	{
-		Integer i = m_columnNameMap.get(ColumnName.toUpperCase());
+		Integer i = m_columnNameMap.get(ColumnName.toUpperCase()); // IDEMPIERE-7089-P3
 		if (i != null)
 			return i.intValue();
 		

--- a/org.adempiere.base/src/org/compiere/model/POInfo.java
+++ b/org.adempiere.base/src/org/compiere/model/POInfo.java
@@ -223,7 +223,7 @@ public class POInfo implements Serializable
 					IsAllowLogging, IsAllowCopy);
 				list.add(col);
 				
-				m_columnNameMap.put(ColumnName.toUpperCase(), list.size() - 1); // IDEMPIERE-7089-P3
+				m_columnNameMap.put(ColumnName.toUpperCase(java.util.Locale.ROOT), list.size() - 1); // IDEMPIERE-7089-P3
 				m_columnIdMap.put(AD_Column_ID, list.size() - 1);
 			}
 		}
@@ -314,7 +314,7 @@ public class POInfo implements Serializable
 	 */
 	public int getColumnIndex (String ColumnName)
 	{
-		Integer i = m_columnNameMap.get(ColumnName.toUpperCase()); // IDEMPIERE-7089-P3
+		Integer i = m_columnNameMap.get(ColumnName.toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 		if (i != null)
 			return i.intValue();
 		

--- a/org.adempiere.base/src/org/compiere/model/Query.java
+++ b/org.adempiere.base/src/org/compiere/model/Query.java
@@ -189,7 +189,7 @@ public class Query
 	public Query setOrderBy(String orderBy)
 	{
 		this.orderBy = orderBy != null ? orderBy.trim() : null;
-		if (this.orderBy != null && this.orderBy.toUpperCase().startsWith("ORDER BY")) // IDEMPIERE-7089-P3
+		if (this.orderBy != null && this.orderBy.toUpperCase(java.util.Locale.ROOT).startsWith("ORDER BY")) // IDEMPIERE-7089-P3
 		{
 			this.orderBy = this.orderBy.substring(8);
 		}

--- a/org.adempiere.base/src/org/compiere/model/Query.java
+++ b/org.adempiere.base/src/org/compiere/model/Query.java
@@ -189,7 +189,7 @@ public class Query
 	public Query setOrderBy(String orderBy)
 	{
 		this.orderBy = orderBy != null ? orderBy.trim() : null;
-		if (this.orderBy != null && this.orderBy.toUpperCase().startsWith("ORDER BY"))
+		if (this.orderBy != null && this.orderBy.toUpperCase().startsWith("ORDER BY")) // IDEMPIERE-7089-P3
 		{
 			this.orderBy = this.orderBy.substring(8);
 		}

--- a/org.adempiere.base/src/org/compiere/model/SetGetUtil.java
+++ b/org.adempiere.base/src/org/compiere/model/SetGetUtil.java
@@ -201,7 +201,7 @@ public class SetGetUtil
 		String[] columnNames = new String[no];
 		for (int i = 1; i <= no; i++)
 		{
-			columnNames[i - 1] = rsmd.getColumnName(i).toUpperCase();
+			columnNames[i - 1] = rsmd.getColumnName(i).toUpperCase(); // IDEMPIERE-7089-P3
 		}
 		//
 		return columnNames;

--- a/org.adempiere.base/src/org/compiere/model/SetGetUtil.java
+++ b/org.adempiere.base/src/org/compiere/model/SetGetUtil.java
@@ -201,7 +201,7 @@ public class SetGetUtil
 		String[] columnNames = new String[no];
 		for (int i = 1; i <= no; i++)
 		{
-			columnNames[i - 1] = rsmd.getColumnName(i).toUpperCase(); // IDEMPIERE-7089-P3
+			columnNames[i - 1] = rsmd.getColumnName(i).toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 		}
 		//
 		return columnNames;

--- a/org.adempiere.base/src/org/compiere/print/DataEngine.java
+++ b/org.adempiere.base/src/org/compiere/print/DataEngine.java
@@ -236,7 +236,7 @@ public class DataEngine
 			log.log(Level.SEVERE, "Not found Format=" + format);
 			return null;
 		}
-		if (format.isTranslationView() && tableName.toLowerCase().endsWith("_v"))	//	_vt not just _v
+		if (format.isTranslationView() && tableName.toLowerCase().endsWith("_v"))	//	_vt not just _v // IDEMPIERE-7089-P3
 		{
 			boolean hasVT = DB.isTableOrViewExists(tableName+"t");
 			if (hasVT)
@@ -337,7 +337,7 @@ public class DataEngine
 			// init regular object to replace table name in virtual column
 			String orgTable = null;
 			Pattern regTranslateTable = null; 
-			if (tableName.toLowerCase().endsWith("_vt")){
+			if (tableName.toLowerCase().endsWith("_vt")){ // IDEMPIERE-7089-P3
 				orgTable = MTable.getTableName(ctx, format.getAD_Table_ID());
 				regTranslateTable =  Pattern.compile("\\b" + orgTable + "\\b", Pattern.CASE_INSENSITIVE);
 			}
@@ -359,7 +359,7 @@ public class DataEngine
 					ColumnSQL = "";
 				else{
 					// replace table with translate table IDEMPIERE-2234
-					if (tableName.toLowerCase().endsWith("_vt")){
+					if (tableName.toLowerCase().endsWith("_vt")){ // IDEMPIERE-7089-P3
 						ColumnSQL = regTranslateTable.matcher(ColumnSQL).replaceAll(tableName);
 					}
 				}

--- a/org.adempiere.base/src/org/compiere/print/DataEngine.java
+++ b/org.adempiere.base/src/org/compiere/print/DataEngine.java
@@ -236,7 +236,7 @@ public class DataEngine
 			log.log(Level.SEVERE, "Not found Format=" + format);
 			return null;
 		}
-		if (format.isTranslationView() && tableName.toLowerCase().endsWith("_v"))	//	_vt not just _v // IDEMPIERE-7089-P3
+		if (format.isTranslationView() && tableName.toLowerCase(java.util.Locale.ROOT).endsWith("_v"))	//	_vt not just _v // IDEMPIERE-7089-P3
 		{
 			boolean hasVT = DB.isTableOrViewExists(tableName+"t");
 			if (hasVT)
@@ -337,7 +337,7 @@ public class DataEngine
 			// init regular object to replace table name in virtual column
 			String orgTable = null;
 			Pattern regTranslateTable = null; 
-			if (tableName.toLowerCase().endsWith("_vt")){ // IDEMPIERE-7089-P3
+			if (tableName.toLowerCase(java.util.Locale.ROOT).endsWith("_vt")){ // IDEMPIERE-7089-P3
 				orgTable = MTable.getTableName(ctx, format.getAD_Table_ID());
 				regTranslateTable =  Pattern.compile("\\b" + orgTable + "\\b", Pattern.CASE_INSENSITIVE);
 			}
@@ -359,7 +359,7 @@ public class DataEngine
 					ColumnSQL = "";
 				else{
 					// replace table with translate table IDEMPIERE-2234
-					if (tableName.toLowerCase().endsWith("_vt")){ // IDEMPIERE-7089-P3
+					if (tableName.toLowerCase(java.util.Locale.ROOT).endsWith("_vt")){ // IDEMPIERE-7089-P3
 						ColumnSQL = regTranslateTable.matcher(ColumnSQL).replaceAll(tableName);
 					}
 				}

--- a/org.adempiere.base/src/org/compiere/print/MPrintFormat.java
+++ b/org.adempiere.base/src/org/compiere/print/MPrintFormat.java
@@ -476,7 +476,7 @@ public class MPrintFormat extends X_AD_PrintFormat implements ImmutablePOSupport
 	public void setTranslationViewQuery (MQuery query)
 	{
 		//	Set Table Name and add add restriction, if a view and language set
-		if (m_translationViewLanguage != null && query != null && query.getTableName().toUpperCase().endsWith("_V")) // IDEMPIERE-7089-P3
+		if (m_translationViewLanguage != null && query != null && query.getTableName().toUpperCase(java.util.Locale.ROOT).endsWith("_V")) // IDEMPIERE-7089-P3
 		{
 			query.setTableName(query.getTableName() + "t");
 			query.addRestriction("AD_Language", MQuery.EQUAL, m_translationViewLanguage);

--- a/org.adempiere.base/src/org/compiere/print/MPrintFormat.java
+++ b/org.adempiere.base/src/org/compiere/print/MPrintFormat.java
@@ -476,7 +476,7 @@ public class MPrintFormat extends X_AD_PrintFormat implements ImmutablePOSupport
 	public void setTranslationViewQuery (MQuery query)
 	{
 		//	Set Table Name and add add restriction, if a view and language set
-		if (m_translationViewLanguage != null && query != null && query.getTableName().toUpperCase().endsWith("_V"))
+		if (m_translationViewLanguage != null && query != null && query.getTableName().toUpperCase().endsWith("_V")) // IDEMPIERE-7089-P3
 		{
 			query.setTableName(query.getTableName() + "t");
 			query.addRestriction("AD_Language", MQuery.EQUAL, m_translationViewLanguage);

--- a/org.adempiere.base/src/org/compiere/print/MPrintPaper.java
+++ b/org.adempiere.base/src/org/compiere/print/MPrintPaper.java
@@ -267,7 +267,7 @@ public class MPrintPaper extends X_AD_PrintPaper implements ImmutablePOSupport
 	public CPaper getCPaper()
 	{
 		CPaper retValue;
-		if (getCode().toLowerCase().startsWith("custom")) // IDEMPIERE-7089-P2
+		if (getCode().toLowerCase(java.util.Locale.ROOT).startsWith("custom")) // IDEMPIERE-7089-P2
 		{
 			retValue = new CPaper (getSizeX().doubleValue(), getSizeY().doubleValue(), getUnitsInt(),
 					isLandscape(),

--- a/org.adempiere.base/src/org/compiere/print/MPrintPaper.java
+++ b/org.adempiere.base/src/org/compiere/print/MPrintPaper.java
@@ -267,7 +267,7 @@ public class MPrintPaper extends X_AD_PrintPaper implements ImmutablePOSupport
 	public CPaper getCPaper()
 	{
 		CPaper retValue;
-		if (getCode().toLowerCase().startsWith("custom"))
+		if (getCode().toLowerCase().startsWith("custom")) // IDEMPIERE-7089-P2
 		{
 			retValue = new CPaper (getSizeX().doubleValue(), getSizeY().doubleValue(), getUnitsInt(),
 					isLandscape(),

--- a/org.adempiere.base/src/org/compiere/process/CreateForeignKey.java
+++ b/org.adempiere.base/src/org/compiere/process/CreateForeignKey.java
@@ -147,9 +147,9 @@ public class CreateForeignKey extends SvrProcess {
 		
 		String tableName = table.getTableName();		
 		if (md.storesUpperCaseIdentifiers())
-			tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
+			tableName = tableName.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 		else if (md.storesLowerCaseIdentifiers())
-			tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
+			tableName = tableName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 		
 		ResultSet rs = null;
 		try {
@@ -163,7 +163,7 @@ public class CreateForeignKey extends SvrProcess {
 				String dbFKTable = rs.getString("FKTABLE_NAME");
 				short deleteRule = rs.getShort("DELETE_RULE");
 
-				String key = dbFKName.toLowerCase(); // IDEMPIERE-7089-P3
+				String key = dbFKName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 				DatabaseKey dbForeignKey = htForeignKeys.get(key);
 				if (dbForeignKey == null)
 					dbForeignKey = new DatabaseKey(dbFKName, dbFKTable, new String[30], deleteRule);
@@ -201,7 +201,7 @@ public class CreateForeignKey extends SvrProcess {
 					if (columnName == null)
 						continue;
 					
-					int AD_Column_ID = DB.getSQLValue(null, getColumnIDSql, table.getAD_Table_ID(), columnName.toLowerCase()); // IDEMPIERE-7089-P3
+					int AD_Column_ID = DB.getSQLValue(null, getColumnIDSql, table.getAD_Table_ID(), columnName.toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 					if (AD_Column_ID > 0)
 					{
 						column = MColumn.getCopy(getCtx(), AD_Column_ID, get_TrxName());

--- a/org.adempiere.base/src/org/compiere/process/CreateForeignKey.java
+++ b/org.adempiere.base/src/org/compiere/process/CreateForeignKey.java
@@ -147,9 +147,9 @@ public class CreateForeignKey extends SvrProcess {
 		
 		String tableName = table.getTableName();		
 		if (md.storesUpperCaseIdentifiers())
-			tableName = tableName.toUpperCase();
+			tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
 		else if (md.storesLowerCaseIdentifiers())
-			tableName = tableName.toLowerCase();
+			tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
 		
 		ResultSet rs = null;
 		try {
@@ -163,7 +163,7 @@ public class CreateForeignKey extends SvrProcess {
 				String dbFKTable = rs.getString("FKTABLE_NAME");
 				short deleteRule = rs.getShort("DELETE_RULE");
 
-				String key = dbFKName.toLowerCase();
+				String key = dbFKName.toLowerCase(); // IDEMPIERE-7089-P3
 				DatabaseKey dbForeignKey = htForeignKeys.get(key);
 				if (dbForeignKey == null)
 					dbForeignKey = new DatabaseKey(dbFKName, dbFKTable, new String[30], deleteRule);
@@ -201,7 +201,7 @@ public class CreateForeignKey extends SvrProcess {
 					if (columnName == null)
 						continue;
 					
-					int AD_Column_ID = DB.getSQLValue(null, getColumnIDSql, table.getAD_Table_ID(), columnName.toLowerCase());
+					int AD_Column_ID = DB.getSQLValue(null, getColumnIDSql, table.getAD_Table_ID(), columnName.toLowerCase()); // IDEMPIERE-7089-P3
 					if (AD_Column_ID > 0)
 					{
 						column = MColumn.getCopy(getCtx(), AD_Column_ID, get_TrxName());

--- a/org.adempiere.base/src/org/compiere/process/CreateTableIndex.java
+++ b/org.adempiere.base/src/org/compiere/process/CreateTableIndex.java
@@ -122,9 +122,9 @@ public class CreateTableIndex extends SvrProcess {
 		
 		String tableName = table.getTableName();		
 		if (md.storesUpperCaseIdentifiers())
-			tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
+			tableName = tableName.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 		else if (md.storesLowerCaseIdentifiers())
-			tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
+			tableName = tableName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 		
 		addLog(Msg.getMsg(getCtx(), "CreateTableIndexProcessTable") + tableName);
 		addLog(table.getAD_Table_ID(), null, null, table.toString(), table.get_Table_ID(), table.getAD_Table_ID());
@@ -137,7 +137,7 @@ public class CreateTableIndex extends SvrProcess {
 			if (dbIndexName == null)
 				continue;
 
-			String key = dbIndexName.toLowerCase(); // IDEMPIERE-7089-P3
+			String key = dbIndexName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 			DatabaseTableIndex dbTableIndex = htIndexes.get(key);
 			if (dbTableIndex == null)
 				dbTableIndex = new DatabaseTableIndex(dbIndexName, new String[30], true, null);
@@ -173,15 +173,15 @@ public class CreateTableIndex extends SvrProcess {
 		
 		String tableName = table.getTableName();		
 		if (md.storesUpperCaseIdentifiers())
-			tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
+			tableName = tableName.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 		else if (md.storesLowerCaseIdentifiers())
-			tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
+			tableName = tableName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 		
 		ResultSet rs = md.getPrimaryKeys(catalog, schema, tableName);
 		while (rs.next())
 		{
 			String primaryKeyName = rs.getString("PK_NAME");
-			String key = primaryKeyName.toLowerCase(); // IDEMPIERE-7089-P3
+			String key = primaryKeyName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 			DatabaseTableIndex dbTableIndex = htIndexes.get(key);
 			if (dbTableIndex != null)
 				htIndexes.remove(key);
@@ -196,7 +196,7 @@ public class CreateTableIndex extends SvrProcess {
 		MTableIndex[] tableIndexes = MTableIndex.get(table);
 		for (MTableIndex tableIndex : tableIndexes)
 		{
-			String key = tableIndex.getName().toLowerCase(); // IDEMPIERE-7089-P3
+			String key = tableIndex.getName().toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 			DatabaseTableIndex dbTableIndex = htIndexes.get(key);
 			tableIndexesToValidate.add(tableIndex);
 			if (dbTableIndex != null)
@@ -225,7 +225,7 @@ public class CreateTableIndex extends SvrProcess {
 					String dbIndexColumn = dbTableIndex.columns[i];
 					if (dbIndexColumn == null)
 						break;
-					int AD_Column_ID = DB.getSQLValue(null, getColumnIDSql, table.getAD_Table_ID(), dbIndexColumn.toLowerCase()); // IDEMPIERE-7089-P3
+					int AD_Column_ID = DB.getSQLValue(null, getColumnIDSql, table.getAD_Table_ID(), dbIndexColumn.toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 					String columnName = dbIndexColumn;
 					
 					if (AD_Column_ID > 0)

--- a/org.adempiere.base/src/org/compiere/process/CreateTableIndex.java
+++ b/org.adempiere.base/src/org/compiere/process/CreateTableIndex.java
@@ -122,9 +122,9 @@ public class CreateTableIndex extends SvrProcess {
 		
 		String tableName = table.getTableName();		
 		if (md.storesUpperCaseIdentifiers())
-			tableName = tableName.toUpperCase();
+			tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
 		else if (md.storesLowerCaseIdentifiers())
-			tableName = tableName.toLowerCase();
+			tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
 		
 		addLog(Msg.getMsg(getCtx(), "CreateTableIndexProcessTable") + tableName);
 		addLog(table.getAD_Table_ID(), null, null, table.toString(), table.get_Table_ID(), table.getAD_Table_ID());
@@ -137,7 +137,7 @@ public class CreateTableIndex extends SvrProcess {
 			if (dbIndexName == null)
 				continue;
 
-			String key = dbIndexName.toLowerCase();
+			String key = dbIndexName.toLowerCase(); // IDEMPIERE-7089-P3
 			DatabaseTableIndex dbTableIndex = htIndexes.get(key);
 			if (dbTableIndex == null)
 				dbTableIndex = new DatabaseTableIndex(dbIndexName, new String[30], true, null);
@@ -173,15 +173,15 @@ public class CreateTableIndex extends SvrProcess {
 		
 		String tableName = table.getTableName();		
 		if (md.storesUpperCaseIdentifiers())
-			tableName = tableName.toUpperCase();
+			tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
 		else if (md.storesLowerCaseIdentifiers())
-			tableName = tableName.toLowerCase();
+			tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
 		
 		ResultSet rs = md.getPrimaryKeys(catalog, schema, tableName);
 		while (rs.next())
 		{
 			String primaryKeyName = rs.getString("PK_NAME");
-			String key = primaryKeyName.toLowerCase();
+			String key = primaryKeyName.toLowerCase(); // IDEMPIERE-7089-P3
 			DatabaseTableIndex dbTableIndex = htIndexes.get(key);
 			if (dbTableIndex != null)
 				htIndexes.remove(key);
@@ -196,7 +196,7 @@ public class CreateTableIndex extends SvrProcess {
 		MTableIndex[] tableIndexes = MTableIndex.get(table);
 		for (MTableIndex tableIndex : tableIndexes)
 		{
-			String key = tableIndex.getName().toLowerCase();
+			String key = tableIndex.getName().toLowerCase(); // IDEMPIERE-7089-P3
 			DatabaseTableIndex dbTableIndex = htIndexes.get(key);
 			tableIndexesToValidate.add(tableIndex);
 			if (dbTableIndex != null)
@@ -225,7 +225,7 @@ public class CreateTableIndex extends SvrProcess {
 					String dbIndexColumn = dbTableIndex.columns[i];
 					if (dbIndexColumn == null)
 						break;
-					int AD_Column_ID = DB.getSQLValue(null, getColumnIDSql, table.getAD_Table_ID(), dbIndexColumn.toLowerCase());
+					int AD_Column_ID = DB.getSQLValue(null, getColumnIDSql, table.getAD_Table_ID(), dbIndexColumn.toLowerCase()); // IDEMPIERE-7089-P3
 					String columnName = dbIndexColumn;
 					
 					if (AD_Column_ID > 0)

--- a/org.adempiere.base/src/org/compiere/process/DatabaseElementColumnRename.java
+++ b/org.adempiere.base/src/org/compiere/process/DatabaseElementColumnRename.java
@@ -61,7 +61,7 @@ public class DatabaseElementColumnRename extends SvrProcess {
 		M_Element element = new M_Element(getCtx(), p_AD_Element_ID, get_TrxName());
 		if (log.isLoggable(Level.INFO)) log.info(element.toString());
 		if (Util.isEmpty(p_NewColumnName, true)
-			|| p_NewColumnName.toLowerCase().equals(element.getColumnName().toLowerCase())) { // IDEMPIERE-7089-P3
+			|| p_NewColumnName.toLowerCase(java.util.Locale.ROOT).equals(element.getColumnName().toLowerCase(java.util.Locale.ROOT))) { // IDEMPIERE-7089-P3
 			throw new AdempiereException(Util.cleanAmp(Msg.parseTranslation(getCtx(), "@NotValid@: @NewColumnName@")));
 		}
 		// Validate there is not another element with new column name

--- a/org.adempiere.base/src/org/compiere/process/DatabaseElementColumnRename.java
+++ b/org.adempiere.base/src/org/compiere/process/DatabaseElementColumnRename.java
@@ -61,7 +61,7 @@ public class DatabaseElementColumnRename extends SvrProcess {
 		M_Element element = new M_Element(getCtx(), p_AD_Element_ID, get_TrxName());
 		if (log.isLoggable(Level.INFO)) log.info(element.toString());
 		if (Util.isEmpty(p_NewColumnName, true)
-			|| p_NewColumnName.toLowerCase().equals(element.getColumnName().toLowerCase())) {
+			|| p_NewColumnName.toLowerCase().equals(element.getColumnName().toLowerCase())) { // IDEMPIERE-7089-P3
 			throw new AdempiereException(Util.cleanAmp(Msg.parseTranslation(getCtx(), "@NotValid@: @NewColumnName@")));
 		}
 		// Validate there is not another element with new column name

--- a/org.adempiere.base/src/org/compiere/process/DatabaseTableRename.java
+++ b/org.adempiere.base/src/org/compiere/process/DatabaseTableRename.java
@@ -74,12 +74,12 @@ public class DatabaseTableRename extends SvrProcess {
 		String oldTableName = table.getTableName();
 		if (log.isLoggable(Level.INFO)) log.info(table.toString());
 		if (   Util.isEmpty(p_NewTableName, true)
-			|| p_NewTableName.toLowerCase().equals(oldTableName.toLowerCase())) {
+			|| p_NewTableName.toLowerCase().equals(oldTableName.toLowerCase())) { // IDEMPIERE-7089-P3
 			throw new AdempiereException(Util.cleanAmp(Msg.parseTranslation(getCtx(), "@NotValid@: @NewTableName@")));
 		}
 		int cnt = DB.getSQLValueEx(get_TrxName(),
 				"SELECT COUNT(*) FROM AD_Table WHERE LOWER(TableName)=?",
-				p_NewTableName.toLowerCase());
+				p_NewTableName.toLowerCase()); // IDEMPIERE-7089-P3
 		if (cnt > 0) {
 			throw new AdempiereException(Util.cleanAmp(Msg.parseTranslation(getCtx(), "@AlreadyExists@: @TableName@ = " + p_NewTableName)));
 		}
@@ -160,14 +160,14 @@ public class DatabaseTableRename extends SvrProcess {
 			}
 		}
 		
-		String colPrefix = oldTableName.toLowerCase();
+		String colPrefix = oldTableName.toLowerCase(); // IDEMPIERE-7089-P3
 		List<M_Element> elements = new Query(getCtx(), M_Element.Table_Name, "LOWER(ColumnName) IN (?, ?)", get_TrxName())
 				.setParameters(colPrefix+"_id", colPrefix+"_uu")
 				.setOrderBy("AD_Element_ID")
 				.list();
 		for (M_Element element : elements) {
 			String newColumnName;
-			if (element.getColumnName().toLowerCase().endsWith("_id")) {
+			if (element.getColumnName().toLowerCase().endsWith("_id")) { // IDEMPIERE-7089-P3
 				newColumnName = p_NewTableName + "_ID";
 			} else {
 				newColumnName = p_NewTableName + "_UU";

--- a/org.adempiere.base/src/org/compiere/process/DatabaseTableRename.java
+++ b/org.adempiere.base/src/org/compiere/process/DatabaseTableRename.java
@@ -74,12 +74,12 @@ public class DatabaseTableRename extends SvrProcess {
 		String oldTableName = table.getTableName();
 		if (log.isLoggable(Level.INFO)) log.info(table.toString());
 		if (   Util.isEmpty(p_NewTableName, true)
-			|| p_NewTableName.toLowerCase().equals(oldTableName.toLowerCase())) { // IDEMPIERE-7089-P3
+			|| p_NewTableName.toLowerCase(java.util.Locale.ROOT).equals(oldTableName.toLowerCase(java.util.Locale.ROOT))) { // IDEMPIERE-7089-P3
 			throw new AdempiereException(Util.cleanAmp(Msg.parseTranslation(getCtx(), "@NotValid@: @NewTableName@")));
 		}
 		int cnt = DB.getSQLValueEx(get_TrxName(),
 				"SELECT COUNT(*) FROM AD_Table WHERE LOWER(TableName)=?",
-				p_NewTableName.toLowerCase()); // IDEMPIERE-7089-P3
+				p_NewTableName.toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 		if (cnt > 0) {
 			throw new AdempiereException(Util.cleanAmp(Msg.parseTranslation(getCtx(), "@AlreadyExists@: @TableName@ = " + p_NewTableName)));
 		}
@@ -160,14 +160,14 @@ public class DatabaseTableRename extends SvrProcess {
 			}
 		}
 		
-		String colPrefix = oldTableName.toLowerCase(); // IDEMPIERE-7089-P3
+		String colPrefix = oldTableName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 		List<M_Element> elements = new Query(getCtx(), M_Element.Table_Name, "LOWER(ColumnName) IN (?, ?)", get_TrxName())
 				.setParameters(colPrefix+"_id", colPrefix+"_uu")
 				.setOrderBy("AD_Element_ID")
 				.list();
 		for (M_Element element : elements) {
 			String newColumnName;
-			if (element.getColumnName().toLowerCase().endsWith("_id")) { // IDEMPIERE-7089-P3
+			if (element.getColumnName().toLowerCase(java.util.Locale.ROOT).endsWith("_id")) { // IDEMPIERE-7089-P3
 				newColumnName = p_NewTableName + "_ID";
 			} else {
 				newColumnName = p_NewTableName + "_UU";

--- a/org.adempiere.base/src/org/compiere/process/DatabaseViewValidate.java
+++ b/org.adempiere.base/src/org/compiere/process/DatabaseViewValidate.java
@@ -70,9 +70,9 @@ public class DatabaseViewValidate extends SvrProcess {
 		DatabaseMetaData md = trx.getConnection().getMetaData();
 		String tableName = table.getTableName();
 		if (md.storesUpperCaseIdentifiers())
-			tableName = tableName.toUpperCase();
+			tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
 		else if (md.storesLowerCaseIdentifiers())
-			tableName = tableName.toLowerCase();
+			tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
 		
 		String catalog = null;
 		String schema = null;

--- a/org.adempiere.base/src/org/compiere/process/DatabaseViewValidate.java
+++ b/org.adempiere.base/src/org/compiere/process/DatabaseViewValidate.java
@@ -70,9 +70,9 @@ public class DatabaseViewValidate extends SvrProcess {
 		DatabaseMetaData md = trx.getConnection().getMetaData();
 		String tableName = table.getTableName();
 		if (md.storesUpperCaseIdentifiers())
-			tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
+			tableName = tableName.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 		else if (md.storesLowerCaseIdentifiers())
-			tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
+			tableName = tableName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 		
 		String catalog = null;
 		String schema = null;

--- a/org.adempiere.base/src/org/compiere/process/ServerProcessCtl.java
+++ b/org.adempiere.base/src/org/compiere/process/ServerProcessCtl.java
@@ -334,7 +334,7 @@ public class ServerProcessCtl implements Runnable {
 	protected boolean startProcess ()
 	{
 		if (log.isLoggable(Level.FINE)) log.fine(m_pi.toString());
-		if (m_pi.getClassName().toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) { // IDEMPIERE-7089-P2
+		if (m_pi.getClassName().toLowerCase(java.util.Locale.ROOT).startsWith(MRule.SCRIPT_PREFIX)) { // IDEMPIERE-7089-P2
 			return ProcessUtil.startScriptProcess(Env.getCtx(), m_pi, m_trx);
 		} else {
 			return ProcessUtil.startJavaProcess(Env.getCtx(), m_pi, m_trx, managedTrxForJavaProcess);

--- a/org.adempiere.base/src/org/compiere/process/ServerProcessCtl.java
+++ b/org.adempiere.base/src/org/compiere/process/ServerProcessCtl.java
@@ -334,7 +334,7 @@ public class ServerProcessCtl implements Runnable {
 	protected boolean startProcess ()
 	{
 		if (log.isLoggable(Level.FINE)) log.fine(m_pi.toString());
-		if (m_pi.getClassName().toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) {
+		if (m_pi.getClassName().toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) { // IDEMPIERE-7089-P2
 			return ProcessUtil.startScriptProcess(Env.getCtx(), m_pi, m_trx);
 		} else {
 			return ProcessUtil.startJavaProcess(Env.getCtx(), m_pi, m_trx, managedTrxForJavaProcess);

--- a/org.adempiere.base/src/org/compiere/process/SvrProcess.java
+++ b/org.adempiere.base/src/org/compiere/process/SvrProcess.java
@@ -830,7 +830,7 @@ public abstract class SvrProcess implements ProcessCall
 		        if(map.containsValue(field))
 		        	continue;
 		        String name = pa.name().isEmpty() ? field.getName() : pa.name();
-		        map.put(name.toLowerCase(), field); // IDEMPIERE-7089-P2
+		        map.put(name.toLowerCase(java.util.Locale.ROOT), field); // IDEMPIERE-7089-P2
 		    }
 	    	target = target.getSuperclass();
 	    }
@@ -839,7 +839,7 @@ public abstract class SvrProcess implements ProcessCall
 	        return;
 
         for(ProcessInfoParameter parameter : getParameter()){
-            String name = parameter.getParameterName().trim().toLowerCase(); // IDEMPIERE-7089-P2
+            String name = parameter.getParameterName().trim().toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P2
             Field field = map.get(name);
             Field toField = map.containsKey(name + "_to") ? map.get(name + "_to") : null;
             Field notField = map.containsKey(name + "_not") ? map.get(name + "_not") : null;

--- a/org.adempiere.base/src/org/compiere/process/SvrProcess.java
+++ b/org.adempiere.base/src/org/compiere/process/SvrProcess.java
@@ -830,7 +830,7 @@ public abstract class SvrProcess implements ProcessCall
 		        if(map.containsValue(field))
 		        	continue;
 		        String name = pa.name().isEmpty() ? field.getName() : pa.name();
-		        map.put(name.toLowerCase(), field);
+		        map.put(name.toLowerCase(), field); // IDEMPIERE-7089-P2
 		    }
 	    	target = target.getSuperclass();
 	    }
@@ -839,7 +839,7 @@ public abstract class SvrProcess implements ProcessCall
 	        return;
 
         for(ProcessInfoParameter parameter : getParameter()){
-            String name = parameter.getParameterName().trim().toLowerCase();
+            String name = parameter.getParameterName().trim().toLowerCase(); // IDEMPIERE-7089-P2
             Field field = map.get(name);
             Field toField = map.containsKey(name + "_to") ? map.get(name + "_to") : null;
             Field notField = map.containsKey(name + "_not") ? map.get(name + "_not") : null;

--- a/org.adempiere.base/src/org/compiere/process/TableIndexValidate.java
+++ b/org.adempiere.base/src/org/compiere/process/TableIndexValidate.java
@@ -67,9 +67,9 @@ public class TableIndexValidate extends SvrProcess {
 		
 		String tableName = index.getTableName();
 		if (md.storesUpperCaseIdentifiers())
-			tableName = tableName.toUpperCase();
+			tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
 		else if (md.storesLowerCaseIdentifiers())
-			tableName = tableName.toLowerCase();
+			tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
 
 		String catalog = DB.getDatabase().getCatalog();
 		String schema = DB.getDatabase().getSchema();

--- a/org.adempiere.base/src/org/compiere/process/TableIndexValidate.java
+++ b/org.adempiere.base/src/org/compiere/process/TableIndexValidate.java
@@ -67,9 +67,9 @@ public class TableIndexValidate extends SvrProcess {
 		
 		String tableName = index.getTableName();
 		if (md.storesUpperCaseIdentifiers())
-			tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
+			tableName = tableName.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 		else if (md.storesLowerCaseIdentifiers())
-			tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
+			tableName = tableName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 
 		String catalog = DB.getDatabase().getCatalog();
 		String schema = DB.getDatabase().getSchema();

--- a/org.adempiere.base/src/org/compiere/util/DB.java
+++ b/org.adempiere.base/src/org/compiere/util/DB.java
@@ -2486,9 +2486,9 @@ public final class DB
 			DatabaseMetaData metadata = conn.getMetaData();
 			String tblName;
 			if (metadata.storesUpperCaseIdentifiers())
-				tblName = tableName.toUpperCase();
+				tblName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
 			else if (metadata.storesLowerCaseIdentifiers())
-				tblName = tableName.toLowerCase();
+				tblName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
 			else
 				tblName = tableName;
 			rs = metadata.getTables(null, null, tblName, null);
@@ -2897,7 +2897,7 @@ public final class DB
 		String removeComments = "/\\*(?:.|[\\n\\r])*?\\*/";
 		String removeQuotedStrings = "'(?:.|[\\n\\r])*?'";
 		String removeLeadingSpaces = "^\\s+";
-		String cleanSql = sql.toLowerCase().replaceAll(removeComments, "").replaceAll(removeQuotedStrings, "").replaceFirst(removeLeadingSpaces, "");
+		String cleanSql = sql.toLowerCase().replaceAll(removeComments, "").replaceAll(removeQuotedStrings, "").replaceFirst(removeLeadingSpaces, ""); // IDEMPIERE-7089-P3
 		if(cleanSql.matches("^select\\s.*$") && !cleanSql.contains(";"))
 			return true;
 		else

--- a/org.adempiere.base/src/org/compiere/util/DB.java
+++ b/org.adempiere.base/src/org/compiere/util/DB.java
@@ -2486,9 +2486,9 @@ public final class DB
 			DatabaseMetaData metadata = conn.getMetaData();
 			String tblName;
 			if (metadata.storesUpperCaseIdentifiers())
-				tblName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
+				tblName = tableName.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 			else if (metadata.storesLowerCaseIdentifiers())
-				tblName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
+				tblName = tableName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 			else
 				tblName = tableName;
 			rs = metadata.getTables(null, null, tblName, null);
@@ -2897,7 +2897,7 @@ public final class DB
 		String removeComments = "/\\*(?:.|[\\n\\r])*?\\*/";
 		String removeQuotedStrings = "'(?:.|[\\n\\r])*?'";
 		String removeLeadingSpaces = "^\\s+";
-		String cleanSql = sql.toLowerCase().replaceAll(removeComments, "").replaceAll(removeQuotedStrings, "").replaceFirst(removeLeadingSpaces, ""); // IDEMPIERE-7089-P3
+		String cleanSql = sql.toLowerCase(java.util.Locale.ROOT).replaceAll(removeComments, "").replaceAll(removeQuotedStrings, "").replaceFirst(removeLeadingSpaces, ""); // IDEMPIERE-7089-P3
 		if(cleanSql.matches("^select\\s.*$") && !cleanSql.contains(";"))
 			return true;
 		else

--- a/org.adempiere.base/src/org/compiere/util/EmailSrv.java
+++ b/org.adempiere.base/src/org/compiere/util/EmailSrv.java
@@ -90,7 +90,7 @@ public class EmailSrv {
 		if(isSSL != null) {
 			this.isSSL = isSSL;
 		} else {
-			this.isSSL = this.imapHost.toLowerCase().startsWith ("imap.gmail.com");
+			this.isSSL = this.imapHost.toLowerCase().startsWith ("imap.gmail.com"); // IDEMPIERE-7089-P2
 			if(!this.isSSL && imapPort == 993)
 				this.isSSL = true;	// Port is 993 set to SSL IMAPS
 			if (this.isSSL && imapPort != 993){
@@ -110,7 +110,7 @@ public class EmailSrv {
 	 */
 	@Deprecated (since="13", forRemoval=true)
 	public EmailSrv (String imapHost, String  imapUser, String  imapPass){
-		this (imapHost, imapUser, imapPass, (imapHost != null && imapHost.toLowerCase().startsWith ("imap.gmail.com"))? 993 : 143, (imapHost != null && imapHost.toLowerCase().startsWith ("imap.gmail.com"))? true : false);
+		this (imapHost, imapUser, imapPass, (imapHost != null && imapHost.toLowerCase().startsWith ("imap.gmail.com"))? 993 : 143, (imapHost != null && imapHost.toLowerCase().startsWith ("imap.gmail.com"))? true : false); // IDEMPIERE-7089-P2
 	}
 	
 	/**

--- a/org.adempiere.base/src/org/compiere/util/EmailSrv.java
+++ b/org.adempiere.base/src/org/compiere/util/EmailSrv.java
@@ -90,7 +90,7 @@ public class EmailSrv {
 		if(isSSL != null) {
 			this.isSSL = isSSL;
 		} else {
-			this.isSSL = this.imapHost.toLowerCase().startsWith ("imap.gmail.com"); // IDEMPIERE-7089-P2
+			this.isSSL = this.imapHost.toLowerCase(java.util.Locale.ROOT).startsWith ("imap.gmail.com"); // IDEMPIERE-7089-P2
 			if(!this.isSSL && imapPort == 993)
 				this.isSSL = true;	// Port is 993 set to SSL IMAPS
 			if (this.isSSL && imapPort != 993){
@@ -110,7 +110,7 @@ public class EmailSrv {
 	 */
 	@Deprecated (since="13", forRemoval=true)
 	public EmailSrv (String imapHost, String  imapUser, String  imapPass){
-		this (imapHost, imapUser, imapPass, (imapHost != null && imapHost.toLowerCase().startsWith ("imap.gmail.com"))? 993 : 143, (imapHost != null && imapHost.toLowerCase().startsWith ("imap.gmail.com"))? true : false); // IDEMPIERE-7089-P2
+		this (imapHost, imapUser, imapPass, (imapHost != null && imapHost.toLowerCase(java.util.Locale.ROOT).startsWith ("imap.gmail.com"))? 993 : 143, (imapHost != null && imapHost.toLowerCase(java.util.Locale.ROOT).startsWith ("imap.gmail.com"))? true : false); // IDEMPIERE-7089-P2
 	}
 	
 	/**

--- a/org.adempiere.base/src/org/compiere/util/Env.java
+++ b/org.adempiere.base/src/org/compiere/util/Env.java
@@ -2282,7 +2282,7 @@ public final class Env
 	public static boolean isMac()
    	{
    		String osName = System.getProperty ("os.name");
-   		osName = osName.toLowerCase();
+		osName = osName.toLowerCase(); // IDEMPIERE-7089-P2
    		return osName.indexOf ("mac") != -1;
    	}	//	isMac
 
@@ -2293,7 +2293,7 @@ public final class Env
    	public static boolean isWindows()
    	{
    		String osName = System.getProperty ("os.name");
-   		osName = osName.toLowerCase();
+		osName = osName.toLowerCase(); // IDEMPIERE-7089-P2
    		return osName.indexOf ("windows") != -1;
    	}	//	isWindows
 

--- a/org.adempiere.base/src/org/compiere/util/Env.java
+++ b/org.adempiere.base/src/org/compiere/util/Env.java
@@ -2282,7 +2282,7 @@ public final class Env
 	public static boolean isMac()
    	{
    		String osName = System.getProperty ("os.name");
-		osName = osName.toLowerCase(); // IDEMPIERE-7089-P2
+		osName = osName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P2
    		return osName.indexOf ("mac") != -1;
    	}	//	isMac
 
@@ -2293,7 +2293,7 @@ public final class Env
    	public static boolean isWindows()
    	{
    		String osName = System.getProperty ("os.name");
-		osName = osName.toLowerCase(); // IDEMPIERE-7089-P2
+		osName = osName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P2
    		return osName.indexOf ("windows") != -1;
    	}	//	isWindows
 

--- a/org.adempiere.base/src/org/compiere/util/IBAN.java
+++ b/org.adempiere.base/src/org/compiere/util/IBAN.java
@@ -28,7 +28,7 @@ public class IBAN {
 	{
 		if (iban!=null)
 		{
-			return iban.trim().replace(" ", "").toUpperCase() ; // IDEMPIERE-7089-P5
+			return iban.trim().replace(" ", "").toUpperCase(java.util.Locale.ROOT) ; // IDEMPIERE-7089-P5
 		}
 		return null ;
 	}

--- a/org.adempiere.base/src/org/compiere/util/IBAN.java
+++ b/org.adempiere.base/src/org/compiere/util/IBAN.java
@@ -28,7 +28,7 @@ public class IBAN {
 	{
 		if (iban!=null)
 		{
-			return iban.trim().replace(" ", "").toUpperCase() ;
+			return iban.trim().replace(" ", "").toUpperCase() ; // IDEMPIERE-7089-P5
 		}
 		return null ;
 	}

--- a/org.adempiere.base/src/org/compiere/util/Msg.java
+++ b/org.adempiere.base/src/org/compiere/util/Msg.java
@@ -492,7 +492,7 @@ public final class Msg
 		String className = "org.compiere.util.AmtInWords_";
 		try
 		{
-			className += language.getLanguageCode().toUpperCase();
+			className += language.getLanguageCode().toUpperCase(); // IDEMPIERE-7089-P2
 			Class<?> clazz = Class.forName(className);
 			AmtInWords aiw = (AmtInWords)clazz.getDeclaredConstructor().newInstance();
 			return aiw.getAmtInWords(amount);
@@ -576,7 +576,7 @@ public final class Msg
 			if (AD_Language == null || AD_Language.length() == 0 || Env.isBaseLanguage(AD_Language, "AD_Element")) {
 				StringBuilder sql = new StringBuilder("SELECT")
 						.append(isPrintName ? " PrintName, PO_PrintName" : " Name, PO_Name")
-						.append(" FROM AD_Element WHERE UPPER(ColumnName)=?");
+						.append(" FROM AD_Element WHERE UPPER(ColumnName)=UPPER(?)");
 				pstmt = DB.prepareStatement(sql.toString(), null);
 			}
 			else
@@ -584,13 +584,13 @@ public final class Msg
 				StringBuilder sql = new StringBuilder("SELECT")
 						.append(isPrintName ? " t.PrintName, t.PO_PrintName" : " t.Name, t.PO_Name")
 						.append(" FROM AD_Element_Trl t, AD_Element e")
-						.append(" WHERE t.AD_Element_ID=e.AD_Element_ID AND UPPER(e.ColumnName)=?")
+						.append(" WHERE t.AD_Element_ID=e.AD_Element_ID AND UPPER(e.ColumnName)=UPPER(?)")
 						.append(" AND t.AD_Language=?");
 				pstmt = DB.prepareStatement(sql.toString(), null);
 				pstmt.setString(2, AD_Language);
 			}
 
-			pstmt.setString(1, ColumnName.toUpperCase());
+			pstmt.setString(1, ColumnName); // IDEMPIERE-7089-P1
 			rs = pstmt.executeQuery();
 			if (rs.next())
 			{

--- a/org.adempiere.base/src/org/compiere/util/Msg.java
+++ b/org.adempiere.base/src/org/compiere/util/Msg.java
@@ -492,7 +492,7 @@ public final class Msg
 		String className = "org.compiere.util.AmtInWords_";
 		try
 		{
-			className += language.getLanguageCode().toUpperCase(); // IDEMPIERE-7089-P2
+			className += language.getLanguageCode().toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P2
 			Class<?> clazz = Class.forName(className);
 			AmtInWords aiw = (AmtInWords)clazz.getDeclaredConstructor().newInstance();
 			return aiw.getAmtInWords(amount);

--- a/org.adempiere.base/src/org/idempiere/fa/feature/UseLifeImpl.java
+++ b/org.adempiere.base/src/org/idempiere/fa/feature/UseLifeImpl.java
@@ -327,7 +327,7 @@ public class UseLifeImpl
 				ivalue = ((Integer)value).intValue();
 			}
 			
-			String columnName = mField.getColumnName().toUpperCase();
+			String columnName = mField.getColumnName().toUpperCase(); // IDEMPIERE-7089-P3
 			if (columnName.endsWith(FIELD_FiscalPostfix)) {
 				sufix = FIELD_FiscalPostfix;
 				columnName = columnName.substring(0, columnName.length() - FIELD_FiscalPostfix.length());

--- a/org.adempiere.base/src/org/idempiere/fa/feature/UseLifeImpl.java
+++ b/org.adempiere.base/src/org/idempiere/fa/feature/UseLifeImpl.java
@@ -327,7 +327,7 @@ public class UseLifeImpl
 				ivalue = ((Integer)value).intValue();
 			}
 			
-			String columnName = mField.getColumnName().toUpperCase(); // IDEMPIERE-7089-P3
+			String columnName = mField.getColumnName().toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 			if (columnName.endsWith(FIELD_FiscalPostfix)) {
 				sufix = FIELD_FiscalPostfix;
 				columnName = columnName.substring(0, columnName.length() - FIELD_FiscalPostfix.length());

--- a/org.adempiere.base/src/org/idempiere/process/MoveClient.java
+++ b/org.adempiere.base/src/org/idempiere/process/MoveClient.java
@@ -220,13 +220,13 @@ public class MoveClient extends SvrProcess {
 			p_excludeTablesWhere.append(" AND UPPER(TableName) NOT IN (");
 			boolean addComma = false;
 			for (String tableName : p_TablesToExclude.split(",")) {
-				p_tablesToExcludeList.add(tableName.toUpperCase());
+				p_tablesToExcludeList.add(tableName.toUpperCase()); // IDEMPIERE-7089-P3
 				if (addComma) {
 					p_excludeTablesWhere.append(",");
 				} else {
 					addComma = true;
 				}
-				p_excludeTablesWhere.append(DB.TO_STRING(tableName.toUpperCase()));
+				p_excludeTablesWhere.append(DB.TO_STRING(tableName.toUpperCase())); // IDEMPIERE-7089-P3
 			}
 			p_excludeTablesWhere.append("))");
 		}
@@ -271,7 +271,7 @@ public class MoveClient extends SvrProcess {
 			} else {
 				p_isPreserveAll = false;
 				for (String tableName : p_TablesToPreserveIDs.split(",")) {
-					p_tablesToPreserveIDsList.add(tableName.toUpperCase());
+					p_tablesToPreserveIDsList.add(tableName.toUpperCase()); // IDEMPIERE-7089-P3
 				}
 			}
 		}
@@ -330,9 +330,9 @@ public class MoveClient extends SvrProcess {
 			int cntCV = DB.getSQLValueEx(get_TrxName(), "SELECT COUNT(*) FROM AD_Client WHERE Value=?", p_ClientValue);
 			if (cntCV > 0)
 				throw new AdempiereUserError("Tenant with search key " + p_ClientValue + " already exists in database");
-			int cntCW = DB.getSQLValueEx(get_TrxName(), "SELECT COUNT(*) FROM W_Store WHERE WebContext=?", p_ClientValue.toLowerCase());
+			int cntCW = DB.getSQLValueEx(get_TrxName(), "SELECT COUNT(*) FROM W_Store WHERE WebContext=?", p_ClientValue.toLowerCase()); // IDEMPIERE-7089-P5
 			if (cntCW > 0)
-				throw new AdempiereUserError("WebStore with context " + p_ClientValue.toLowerCase() + " already exists in database");
+				throw new AdempiereUserError("WebStore with context " + p_ClientValue.toLowerCase() + " already exists in database"); // IDEMPIERE-7089-P5
 		}
 		
 		// validate there are clients to move, and doesn't exist in target
@@ -527,14 +527,14 @@ public class MoveClient extends SvrProcess {
 		ResultSet rsRC = null;
 		try {
 			stmtRC = externalConn.prepareStatement(sqlRemoteColumns, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
-			stmtRC.setString(1, tableName.toUpperCase());
+			stmtRC.setString(1, tableName.toUpperCase()); // IDEMPIERE-7089-P3
 			rsRC = stmtRC.executeQuery();
 			while (rsRC.next()) {
 				String columnName = rsRC.getString(1);
 				int refID = rsRC.getInt(2);
 				int length = rsRC.getInt(3);
 				if (columnName.equalsIgnoreCase("AD_Client_ID")) {
-					p_columnsVerifiedList.add(tableName.toUpperCase() + "." + columnName.toUpperCase());
+					p_columnsVerifiedList.add(tableName.toUpperCase() + "." + columnName.toUpperCase()); // IDEMPIERE-7089-P3
 				} else {
 					validateExternalColumn(tableName, columnName, refID, length);
 				}
@@ -544,7 +544,7 @@ public class MoveClient extends SvrProcess {
 		} finally {
 			DB.close(rsRC, stmtRC);
 		}
-		p_tablesVerifiedList.add(tableName.toUpperCase());
+		p_tablesVerifiedList.add(tableName.toUpperCase()); // IDEMPIERE-7089-P3
 	}
 
 	/**
@@ -619,8 +619,8 @@ public class MoveClient extends SvrProcess {
 				sqlForeignClientSB.append(" AND AD_Ref_List.AD_Reference_ID=")
 				.append(" (SELECT AD_Column.AD_Reference_Value_ID FROM AD_Column")
 				.append(" JOIN AD_Table ON (AD_Column.AD_Table_ID=AD_Table.AD_Table_ID)")
-				.append(" WHERE UPPER(AD_Table.TableName)='").append(tableName.toUpperCase())
-				.append("' AND UPPER(AD_Column.ColumnName)='").append(columnName.toUpperCase()).append("'))")
+				.append(" WHERE UPPER(AD_Table.TableName)='").append(tableName.toUpperCase()) // IDEMPIERE-7089-P3
+				.append("' AND UPPER(AD_Column.ColumnName)='").append(columnName.toUpperCase()).append("'))") // IDEMPIERE-7089-P3
 				.append(" WHERE ").append(p_whereClient)
 				.append(" AND ").append(foreignTableName).append(".AD_Client_ID!=").append(tableName).append(".AD_Client_ID")
 				.append(" ORDER BY 2");
@@ -674,7 +674,7 @@ public class MoveClient extends SvrProcess {
 						continue;
 					}
 					if (foreignID != null) {
-						if (! p_idSystemConversionList.contains(foreignTableName.toUpperCase() + "." + foreignID)) {
+						if (! p_idSystemConversionList.contains(foreignTableName.toUpperCase() + "." + foreignID)) { // IDEMPIERE-7089-P3
 							Object localID = getFromUUID(foreignTableName, uuidCol, tableName, columnName, foreignUU, foreignID);
 							if (localID == null || (localID instanceof Number && ((Number)localID).intValue() < 0)) {
 								continue;
@@ -689,7 +689,7 @@ public class MoveClient extends SvrProcess {
 			}
 		}
 		// add to the list of verified columns
-		p_columnsVerifiedList.add(tableName.toUpperCase() + "." + columnName.toUpperCase());
+		p_columnsVerifiedList.add(tableName.toUpperCase() + "." + columnName.toUpperCase()); // IDEMPIERE-7089-P3
 	}
 
 	/**
@@ -718,8 +718,8 @@ public class MoveClient extends SvrProcess {
 						.append("FROM   AD_Table t ")
 						.append("       JOIN AD_Column c ")
 						.append("         ON ( c.AD_Table_ID = t.AD_Table_ID ) ")
-						.append("WHERE  UPPER(t.TableName)=").append(DB.TO_STRING(tableName.toUpperCase()))
-						.append("       AND UPPER(c.ColumnName)=").append(DB.TO_STRING(columnName.toUpperCase()))
+						.append("WHERE  UPPER(t.TableName)=").append(DB.TO_STRING(tableName.toUpperCase())) // IDEMPIERE-7089-P3
+						.append("       AND UPPER(c.ColumnName)=").append(DB.TO_STRING(columnName.toUpperCase())) // IDEMPIERE-7089-P3
 						.append("       AND ( c.FKConstraintType IS NULL OR c.FKConstraintType=").append(DB.TO_STRING(MColumn.FKCONSTRAINTTYPE_DoNotCreate_Ignore)).append(")");
 				int cntFk = countInExternal(sqlVerifFKSB.toString());
 				if (cntFk > 0) {
@@ -801,16 +801,16 @@ public class MoveClient extends SvrProcess {
 		// create/verify the ID conversions
 		for (MTable table : tables) {
 			String tableName = table.getTableName();
-			if (! p_tablesVerifiedList.contains(tableName.toUpperCase())) {
+			if (! p_tablesVerifiedList.contains(tableName.toUpperCase())) { // IDEMPIERE-7089-P3
 				continue;
 			}
 			String uuidCol = PO.getUUIDColumnName(tableName);
 			String keyCol;
 			if (table.isUUIDKeyTable())
-				keyCol = uuidCol.toUpperCase();
+				keyCol = uuidCol.toUpperCase(); // IDEMPIERE-7089-P3
 			else
-				keyCol = tableName.toUpperCase() + "_ID";
-			if (! p_columnsVerifiedList.contains(tableName.toUpperCase() + "." + keyCol))
+				keyCol = tableName.toUpperCase() + "_ID"; // IDEMPIERE-7089-P3
+			if (! p_columnsVerifiedList.contains(tableName.toUpperCase() + "." + keyCol)) // IDEMPIERE-7089-P3
 				continue;
 			
 			statusUpdate("Converting IDs for table " + tableName);
@@ -833,7 +833,7 @@ public class MoveClient extends SvrProcess {
 				while (rsGI.next()) {
 					Object source_Key = rsGI.getObject(1);
 					Object target_Key = null;
-					if (p_isPreserveAll || p_tablesToPreserveIDsList.contains(tableName.toUpperCase())) {
+					if (p_isPreserveAll || p_tablesToPreserveIDsList.contains(tableName.toUpperCase())) { // IDEMPIERE-7089-P3
 						List<Object> list = DB.getSQLValueObjectsEx(get_TrxName(), selectVerifyIdSB.toString(), source_Key);
 						Object localID = null;
 						if (list != null && list.size() == 1)
@@ -866,7 +866,7 @@ public class MoveClient extends SvrProcess {
 					if (target_Key != null || (target_Key instanceof Number && ((Number)target_Key).intValue() >= 0)) {
 						if (p_IsCopyClient) {
 							stmtInsertConv.setInt(1, getAD_PInstance_ID());
-							stmtInsertConv.setString(2, tableName.toUpperCase());
+							stmtInsertConv.setString(2, tableName.toUpperCase()); // IDEMPIERE-7089-P3
 							stmtInsertConv.setString(3, source_Key.toString());
 							stmtInsertConv.setString(4, target_Key.toString());
 							stmtInsertConv.setString(5, null);
@@ -880,7 +880,7 @@ public class MoveClient extends SvrProcess {
 							}
 						} else {
 							DB.executeUpdateEx(insertConversionId,
-									new Object[] {getAD_PInstance_ID(), tableName.toUpperCase(), source_Key.toString(), target_Key.toString(), null},
+									new Object[] {getAD_PInstance_ID(), tableName.toUpperCase(), source_Key.toString(), target_Key.toString(), null}, // IDEMPIERE-7089-P3
 									get_TrxName());
 						}
 					}
@@ -927,7 +927,7 @@ public class MoveClient extends SvrProcess {
 		// get the source data and insert into target converting the IDs
 		for (MTable table : tables) {
 			String tableName = table.getTableName();
-			if (! p_tablesVerifiedList.contains(tableName.toUpperCase())) {
+			if (! p_tablesVerifiedList.contains(tableName.toUpperCase())) { // IDEMPIERE-7089-P3
 				continue;
 			}
 			statusUpdate("Inserting data for table " + tableName);
@@ -941,7 +941,7 @@ public class MoveClient extends SvrProcess {
 					continue;
 				}
 				String columnName = column.getColumnName();
-				if (! p_columnsVerifiedList.contains(tableName.toUpperCase() + "." + columnName.toUpperCase())) {
+				if (! p_columnsVerifiedList.contains(tableName.toUpperCase() + "." + columnName.toUpperCase())) { // IDEMPIERE-7089-P3
 					continue;
 				}
 				if (columnsSB.length() > 0) {
@@ -1061,7 +1061,7 @@ public class MoveClient extends SvrProcess {
 						} else if ("AD_Preference".equalsIgnoreCase(tableName) && "Value".equalsIgnoreCase(columnName)) {
 							// Special case for AD_Preference.Value
 							String att = rsGD.getString("Attribute");
-							if (att.toUpperCase().endsWith("_ID")) {
+							if (att.toUpperCase().endsWith("_ID")) { // IDEMPIERE-7089-P3
 								convertTable = att.substring(0, att.length()-3);
 								if ("C_DocTypeTarget".equals(convertTable)) {
 									convertTable = "C_DocType";
@@ -1148,7 +1148,7 @@ public class MoveClient extends SvrProcess {
 								if (columnName.equals(uuidCol)) {
 									String oldUUID = parameters[i] == null ? null : parameters[i].toString();
 									// it is possible that the UUID has been resolved before because of a foreign key Record_UU, so search in T_MoveClient first
-									String newUUID = DB.getSQLValueStringEx(get_TrxName(), queryT_MoveClient, getAD_PInstance_ID(), tableName.toUpperCase(), oldUUID);
+									String newUUID = DB.getSQLValueStringEx(get_TrxName(), queryT_MoveClient, getAD_PInstance_ID(), tableName.toUpperCase(), oldUUID); // IDEMPIERE-7089-P3
 									if (newUUID == null) {
 										newUUID = Util.generateUUIDv7().toString();
 									}
@@ -1169,7 +1169,7 @@ public class MoveClient extends SvrProcess {
 										   ("W_Store".equalsIgnoreCase(tableName) && "WebContext".equalsIgnoreCase(columnName))
 										|| ("AD_User".equalsIgnoreCase(tableName) && "Value".equalsIgnoreCase(columnName))
 										) {
-									parameters[i] = p_ClientValue.toLowerCase();
+									parameters[i] = p_ClientValue.toLowerCase(); // IDEMPIERE-7089-P5
 								} else if (
 										   ("AD_User".equalsIgnoreCase(tableName) && "Password".equalsIgnoreCase(columnName))
 										|| ("AD_User".equalsIgnoreCase(tableName) && "Salt".equalsIgnoreCase(columnName))
@@ -1269,7 +1269,7 @@ public class MoveClient extends SvrProcess {
 								|| "AD_TreeNodeU4".equalsIgnoreCase(tableName)
 								|| "AD_Tree_Favorite_Node".equalsIgnoreCase(tableName)
 								|| "AD_TreeBar".equalsIgnoreCase(tableName)))) {
-			if (p_tablesToExcludeList.contains(convertTable.toUpperCase())) {
+			if (p_tablesToExcludeList.contains(convertTable.toUpperCase())) { // IDEMPIERE-7089-P3
 				// record is pointing to a table that is not included, ignore it
 				return true;
 			}
@@ -1295,7 +1295,7 @@ public class MoveClient extends SvrProcess {
 		Object convertedId = null;
 		try {
 			List<Object> list = DB.getSQLValueObjectsEx(get_TrxName(), queryT_MoveClient,
-					getAD_PInstance_ID(), convertTable.toUpperCase(), String.valueOf(key));
+					getAD_PInstance_ID(), convertTable.toUpperCase(), String.valueOf(key)); // IDEMPIERE-7089-P3
 			if (list != null && list.size() == 1)
 				convertedId = list.get(0);
 		} catch (Exception e) {
@@ -1311,7 +1311,7 @@ public class MoveClient extends SvrProcess {
 			if ((key instanceof String || key instanceof UUID) && ! cTable.isUUIDKeyTable() && columnName.equals("Record_UU")) {
 				convertedId = Util.generateUUIDv7().toString();
 				DB.executeUpdateEx(insertConversionId,
-						new Object[] {getAD_PInstance_ID(), convertTable.toUpperCase(), key.toString(), convertedId.toString(), null},
+						new Object[] {getAD_PInstance_ID(), convertTable.toUpperCase(), key.toString(), convertedId.toString(), null}, // IDEMPIERE-7089-P3
 						get_TrxName());
 			} else {
 				// not found in the T_MoveClient table - try to get it again - could be missed in first pass
@@ -1535,9 +1535,9 @@ public class MoveClient extends SvrProcess {
 			}
 		}
 		DB.executeUpdateEx(insertConversionId,
-				new Object[] {getAD_PInstance_ID(), foreignTableName.toUpperCase(), foreign_Key, local_Key, identifier},
+				new Object[] {getAD_PInstance_ID(), foreignTableName.toUpperCase(), foreign_Key, local_Key, identifier}, // IDEMPIERE-7089-P3
 				get_TrxName());
-		p_idSystemConversionList.add(foreignTableName.toUpperCase() + "." + foreign_Key);
+		p_idSystemConversionList.add(foreignTableName.toUpperCase() + "." + foreign_Key); // IDEMPIERE-7089-P3
 		return local_Key;
 	}
 

--- a/org.adempiere.base/src/org/idempiere/process/MoveClient.java
+++ b/org.adempiere.base/src/org/idempiere/process/MoveClient.java
@@ -220,13 +220,13 @@ public class MoveClient extends SvrProcess {
 			p_excludeTablesWhere.append(" AND UPPER(TableName) NOT IN (");
 			boolean addComma = false;
 			for (String tableName : p_TablesToExclude.split(",")) {
-				p_tablesToExcludeList.add(tableName.toUpperCase()); // IDEMPIERE-7089-P3
+				p_tablesToExcludeList.add(tableName.toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 				if (addComma) {
 					p_excludeTablesWhere.append(",");
 				} else {
 					addComma = true;
 				}
-				p_excludeTablesWhere.append(DB.TO_STRING(tableName.toUpperCase())); // IDEMPIERE-7089-P3
+				p_excludeTablesWhere.append(DB.TO_STRING(tableName.toUpperCase(java.util.Locale.ROOT))); // IDEMPIERE-7089-P3
 			}
 			p_excludeTablesWhere.append("))");
 		}
@@ -271,7 +271,7 @@ public class MoveClient extends SvrProcess {
 			} else {
 				p_isPreserveAll = false;
 				for (String tableName : p_TablesToPreserveIDs.split(",")) {
-					p_tablesToPreserveIDsList.add(tableName.toUpperCase()); // IDEMPIERE-7089-P3
+					p_tablesToPreserveIDsList.add(tableName.toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 				}
 			}
 		}
@@ -330,9 +330,9 @@ public class MoveClient extends SvrProcess {
 			int cntCV = DB.getSQLValueEx(get_TrxName(), "SELECT COUNT(*) FROM AD_Client WHERE Value=?", p_ClientValue);
 			if (cntCV > 0)
 				throw new AdempiereUserError("Tenant with search key " + p_ClientValue + " already exists in database");
-			int cntCW = DB.getSQLValueEx(get_TrxName(), "SELECT COUNT(*) FROM W_Store WHERE WebContext=?", p_ClientValue.toLowerCase()); // IDEMPIERE-7089-P5
+			int cntCW = DB.getSQLValueEx(get_TrxName(), "SELECT COUNT(*) FROM W_Store WHERE WebContext=?", p_ClientValue.toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P5
 			if (cntCW > 0)
-				throw new AdempiereUserError("WebStore with context " + p_ClientValue.toLowerCase() + " already exists in database"); // IDEMPIERE-7089-P5
+				throw new AdempiereUserError("WebStore with context " + p_ClientValue.toLowerCase(java.util.Locale.ROOT) + " already exists in database"); // IDEMPIERE-7089-P5
 		}
 		
 		// validate there are clients to move, and doesn't exist in target
@@ -527,14 +527,14 @@ public class MoveClient extends SvrProcess {
 		ResultSet rsRC = null;
 		try {
 			stmtRC = externalConn.prepareStatement(sqlRemoteColumns, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
-			stmtRC.setString(1, tableName.toUpperCase()); // IDEMPIERE-7089-P3
+			stmtRC.setString(1, tableName.toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 			rsRC = stmtRC.executeQuery();
 			while (rsRC.next()) {
 				String columnName = rsRC.getString(1);
 				int refID = rsRC.getInt(2);
 				int length = rsRC.getInt(3);
 				if (columnName.equalsIgnoreCase("AD_Client_ID")) {
-					p_columnsVerifiedList.add(tableName.toUpperCase() + "." + columnName.toUpperCase()); // IDEMPIERE-7089-P3
+					p_columnsVerifiedList.add(tableName.toUpperCase(java.util.Locale.ROOT) + "." + columnName.toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 				} else {
 					validateExternalColumn(tableName, columnName, refID, length);
 				}
@@ -544,7 +544,7 @@ public class MoveClient extends SvrProcess {
 		} finally {
 			DB.close(rsRC, stmtRC);
 		}
-		p_tablesVerifiedList.add(tableName.toUpperCase()); // IDEMPIERE-7089-P3
+		p_tablesVerifiedList.add(tableName.toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 	}
 
 	/**
@@ -619,8 +619,8 @@ public class MoveClient extends SvrProcess {
 				sqlForeignClientSB.append(" AND AD_Ref_List.AD_Reference_ID=")
 				.append(" (SELECT AD_Column.AD_Reference_Value_ID FROM AD_Column")
 				.append(" JOIN AD_Table ON (AD_Column.AD_Table_ID=AD_Table.AD_Table_ID)")
-				.append(" WHERE UPPER(AD_Table.TableName)='").append(tableName.toUpperCase()) // IDEMPIERE-7089-P3
-				.append("' AND UPPER(AD_Column.ColumnName)='").append(columnName.toUpperCase()).append("'))") // IDEMPIERE-7089-P3
+				.append(" WHERE UPPER(AD_Table.TableName)='").append(tableName.toUpperCase(java.util.Locale.ROOT)) // IDEMPIERE-7089-P3
+				.append("' AND UPPER(AD_Column.ColumnName)='").append(columnName.toUpperCase(java.util.Locale.ROOT)).append("'))") // IDEMPIERE-7089-P3
 				.append(" WHERE ").append(p_whereClient)
 				.append(" AND ").append(foreignTableName).append(".AD_Client_ID!=").append(tableName).append(".AD_Client_ID")
 				.append(" ORDER BY 2");
@@ -674,7 +674,7 @@ public class MoveClient extends SvrProcess {
 						continue;
 					}
 					if (foreignID != null) {
-						if (! p_idSystemConversionList.contains(foreignTableName.toUpperCase() + "." + foreignID)) { // IDEMPIERE-7089-P3
+						if (! p_idSystemConversionList.contains(foreignTableName.toUpperCase(java.util.Locale.ROOT) + "." + foreignID)) { // IDEMPIERE-7089-P3
 							Object localID = getFromUUID(foreignTableName, uuidCol, tableName, columnName, foreignUU, foreignID);
 							if (localID == null || (localID instanceof Number && ((Number)localID).intValue() < 0)) {
 								continue;
@@ -689,7 +689,7 @@ public class MoveClient extends SvrProcess {
 			}
 		}
 		// add to the list of verified columns
-		p_columnsVerifiedList.add(tableName.toUpperCase() + "." + columnName.toUpperCase()); // IDEMPIERE-7089-P3
+		p_columnsVerifiedList.add(tableName.toUpperCase(java.util.Locale.ROOT) + "." + columnName.toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 	}
 
 	/**
@@ -718,8 +718,8 @@ public class MoveClient extends SvrProcess {
 						.append("FROM   AD_Table t ")
 						.append("       JOIN AD_Column c ")
 						.append("         ON ( c.AD_Table_ID = t.AD_Table_ID ) ")
-						.append("WHERE  UPPER(t.TableName)=").append(DB.TO_STRING(tableName.toUpperCase())) // IDEMPIERE-7089-P3
-						.append("       AND UPPER(c.ColumnName)=").append(DB.TO_STRING(columnName.toUpperCase())) // IDEMPIERE-7089-P3
+						.append("WHERE  UPPER(t.TableName)=").append(DB.TO_STRING(tableName.toUpperCase(java.util.Locale.ROOT))) // IDEMPIERE-7089-P3
+						.append("       AND UPPER(c.ColumnName)=").append(DB.TO_STRING(columnName.toUpperCase(java.util.Locale.ROOT))) // IDEMPIERE-7089-P3
 						.append("       AND ( c.FKConstraintType IS NULL OR c.FKConstraintType=").append(DB.TO_STRING(MColumn.FKCONSTRAINTTYPE_DoNotCreate_Ignore)).append(")");
 				int cntFk = countInExternal(sqlVerifFKSB.toString());
 				if (cntFk > 0) {
@@ -801,16 +801,16 @@ public class MoveClient extends SvrProcess {
 		// create/verify the ID conversions
 		for (MTable table : tables) {
 			String tableName = table.getTableName();
-			if (! p_tablesVerifiedList.contains(tableName.toUpperCase())) { // IDEMPIERE-7089-P3
+			if (! p_tablesVerifiedList.contains(tableName.toUpperCase(java.util.Locale.ROOT))) { // IDEMPIERE-7089-P3
 				continue;
 			}
 			String uuidCol = PO.getUUIDColumnName(tableName);
 			String keyCol;
 			if (table.isUUIDKeyTable())
-				keyCol = uuidCol.toUpperCase(); // IDEMPIERE-7089-P3
+				keyCol = uuidCol.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 			else
-				keyCol = tableName.toUpperCase() + "_ID"; // IDEMPIERE-7089-P3
-			if (! p_columnsVerifiedList.contains(tableName.toUpperCase() + "." + keyCol)) // IDEMPIERE-7089-P3
+				keyCol = tableName.toUpperCase(java.util.Locale.ROOT) + "_ID"; // IDEMPIERE-7089-P3
+			if (! p_columnsVerifiedList.contains(tableName.toUpperCase(java.util.Locale.ROOT) + "." + keyCol)) // IDEMPIERE-7089-P3
 				continue;
 			
 			statusUpdate("Converting IDs for table " + tableName);
@@ -833,7 +833,7 @@ public class MoveClient extends SvrProcess {
 				while (rsGI.next()) {
 					Object source_Key = rsGI.getObject(1);
 					Object target_Key = null;
-					if (p_isPreserveAll || p_tablesToPreserveIDsList.contains(tableName.toUpperCase())) { // IDEMPIERE-7089-P3
+					if (p_isPreserveAll || p_tablesToPreserveIDsList.contains(tableName.toUpperCase(java.util.Locale.ROOT))) { // IDEMPIERE-7089-P3
 						List<Object> list = DB.getSQLValueObjectsEx(get_TrxName(), selectVerifyIdSB.toString(), source_Key);
 						Object localID = null;
 						if (list != null && list.size() == 1)
@@ -866,7 +866,7 @@ public class MoveClient extends SvrProcess {
 					if (target_Key != null || (target_Key instanceof Number && ((Number)target_Key).intValue() >= 0)) {
 						if (p_IsCopyClient) {
 							stmtInsertConv.setInt(1, getAD_PInstance_ID());
-							stmtInsertConv.setString(2, tableName.toUpperCase()); // IDEMPIERE-7089-P3
+							stmtInsertConv.setString(2, tableName.toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 							stmtInsertConv.setString(3, source_Key.toString());
 							stmtInsertConv.setString(4, target_Key.toString());
 							stmtInsertConv.setString(5, null);
@@ -880,7 +880,7 @@ public class MoveClient extends SvrProcess {
 							}
 						} else {
 							DB.executeUpdateEx(insertConversionId,
-									new Object[] {getAD_PInstance_ID(), tableName.toUpperCase(), source_Key.toString(), target_Key.toString(), null}, // IDEMPIERE-7089-P3
+									new Object[] {getAD_PInstance_ID(), tableName.toUpperCase(java.util.Locale.ROOT), source_Key.toString(), target_Key.toString(), null}, // IDEMPIERE-7089-P3
 									get_TrxName());
 						}
 					}
@@ -927,7 +927,7 @@ public class MoveClient extends SvrProcess {
 		// get the source data and insert into target converting the IDs
 		for (MTable table : tables) {
 			String tableName = table.getTableName();
-			if (! p_tablesVerifiedList.contains(tableName.toUpperCase())) { // IDEMPIERE-7089-P3
+			if (! p_tablesVerifiedList.contains(tableName.toUpperCase(java.util.Locale.ROOT))) { // IDEMPIERE-7089-P3
 				continue;
 			}
 			statusUpdate("Inserting data for table " + tableName);
@@ -941,7 +941,7 @@ public class MoveClient extends SvrProcess {
 					continue;
 				}
 				String columnName = column.getColumnName();
-				if (! p_columnsVerifiedList.contains(tableName.toUpperCase() + "." + columnName.toUpperCase())) { // IDEMPIERE-7089-P3
+				if (! p_columnsVerifiedList.contains(tableName.toUpperCase(java.util.Locale.ROOT) + "." + columnName.toUpperCase(java.util.Locale.ROOT))) { // IDEMPIERE-7089-P3
 					continue;
 				}
 				if (columnsSB.length() > 0) {
@@ -1061,7 +1061,7 @@ public class MoveClient extends SvrProcess {
 						} else if ("AD_Preference".equalsIgnoreCase(tableName) && "Value".equalsIgnoreCase(columnName)) {
 							// Special case for AD_Preference.Value
 							String att = rsGD.getString("Attribute");
-							if (att.toUpperCase().endsWith("_ID")) { // IDEMPIERE-7089-P3
+							if (att.toUpperCase(java.util.Locale.ROOT).endsWith("_ID")) { // IDEMPIERE-7089-P3
 								convertTable = att.substring(0, att.length()-3);
 								if ("C_DocTypeTarget".equals(convertTable)) {
 									convertTable = "C_DocType";
@@ -1148,7 +1148,7 @@ public class MoveClient extends SvrProcess {
 								if (columnName.equals(uuidCol)) {
 									String oldUUID = parameters[i] == null ? null : parameters[i].toString();
 									// it is possible that the UUID has been resolved before because of a foreign key Record_UU, so search in T_MoveClient first
-									String newUUID = DB.getSQLValueStringEx(get_TrxName(), queryT_MoveClient, getAD_PInstance_ID(), tableName.toUpperCase(), oldUUID); // IDEMPIERE-7089-P3
+									String newUUID = DB.getSQLValueStringEx(get_TrxName(), queryT_MoveClient, getAD_PInstance_ID(), tableName.toUpperCase(java.util.Locale.ROOT), oldUUID); // IDEMPIERE-7089-P3
 									if (newUUID == null) {
 										newUUID = Util.generateUUIDv7().toString();
 									}
@@ -1169,7 +1169,7 @@ public class MoveClient extends SvrProcess {
 										   ("W_Store".equalsIgnoreCase(tableName) && "WebContext".equalsIgnoreCase(columnName))
 										|| ("AD_User".equalsIgnoreCase(tableName) && "Value".equalsIgnoreCase(columnName))
 										) {
-									parameters[i] = p_ClientValue.toLowerCase(); // IDEMPIERE-7089-P5
+									parameters[i] = p_ClientValue.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P5
 								} else if (
 										   ("AD_User".equalsIgnoreCase(tableName) && "Password".equalsIgnoreCase(columnName))
 										|| ("AD_User".equalsIgnoreCase(tableName) && "Salt".equalsIgnoreCase(columnName))
@@ -1269,7 +1269,7 @@ public class MoveClient extends SvrProcess {
 								|| "AD_TreeNodeU4".equalsIgnoreCase(tableName)
 								|| "AD_Tree_Favorite_Node".equalsIgnoreCase(tableName)
 								|| "AD_TreeBar".equalsIgnoreCase(tableName)))) {
-			if (p_tablesToExcludeList.contains(convertTable.toUpperCase())) { // IDEMPIERE-7089-P3
+			if (p_tablesToExcludeList.contains(convertTable.toUpperCase(java.util.Locale.ROOT))) { // IDEMPIERE-7089-P3
 				// record is pointing to a table that is not included, ignore it
 				return true;
 			}
@@ -1295,7 +1295,7 @@ public class MoveClient extends SvrProcess {
 		Object convertedId = null;
 		try {
 			List<Object> list = DB.getSQLValueObjectsEx(get_TrxName(), queryT_MoveClient,
-					getAD_PInstance_ID(), convertTable.toUpperCase(), String.valueOf(key)); // IDEMPIERE-7089-P3
+					getAD_PInstance_ID(), convertTable.toUpperCase(java.util.Locale.ROOT), String.valueOf(key)); // IDEMPIERE-7089-P3
 			if (list != null && list.size() == 1)
 				convertedId = list.get(0);
 		} catch (Exception e) {
@@ -1311,7 +1311,7 @@ public class MoveClient extends SvrProcess {
 			if ((key instanceof String || key instanceof UUID) && ! cTable.isUUIDKeyTable() && columnName.equals("Record_UU")) {
 				convertedId = Util.generateUUIDv7().toString();
 				DB.executeUpdateEx(insertConversionId,
-						new Object[] {getAD_PInstance_ID(), convertTable.toUpperCase(), key.toString(), convertedId.toString(), null}, // IDEMPIERE-7089-P3
+						new Object[] {getAD_PInstance_ID(), convertTable.toUpperCase(java.util.Locale.ROOT), key.toString(), convertedId.toString(), null}, // IDEMPIERE-7089-P3
 						get_TrxName());
 			} else {
 				// not found in the T_MoveClient table - try to get it again - could be missed in first pass
@@ -1535,9 +1535,9 @@ public class MoveClient extends SvrProcess {
 			}
 		}
 		DB.executeUpdateEx(insertConversionId,
-				new Object[] {getAD_PInstance_ID(), foreignTableName.toUpperCase(), foreign_Key, local_Key, identifier}, // IDEMPIERE-7089-P3
+				new Object[] {getAD_PInstance_ID(), foreignTableName.toUpperCase(java.util.Locale.ROOT), foreign_Key, local_Key, identifier}, // IDEMPIERE-7089-P3
 				get_TrxName());
-		p_idSystemConversionList.add(foreignTableName.toUpperCase() + "." + foreign_Key); // IDEMPIERE-7089-P3
+		p_idSystemConversionList.add(foreignTableName.toUpperCase(java.util.Locale.ROOT) + "." + foreign_Key); // IDEMPIERE-7089-P3
 		return local_Key;
 	}
 

--- a/org.adempiere.base/src/org/idempiere/process/TranslationImpExp.java
+++ b/org.adempiere.base/src/org/idempiere/process/TranslationImpExp.java
@@ -123,7 +123,7 @@ public class TranslationImpExp extends SvrProcess {
 						fos.close();
 					}
 				} else {
-					if (! p_FileName.toLowerCase().endsWith(".zip")) { // IDEMPIERE-7089-P2
+					if (! p_FileName.toLowerCase(java.util.Locale.ROOT).endsWith(".zip")) { // IDEMPIERE-7089-P2
 						throw new AdempiereSystemError("@FileMustBeZIP@");
 					}
 				}

--- a/org.adempiere.base/src/org/idempiere/process/TranslationImpExp.java
+++ b/org.adempiere.base/src/org/idempiere/process/TranslationImpExp.java
@@ -123,7 +123,7 @@ public class TranslationImpExp extends SvrProcess {
 						fos.close();
 					}
 				} else {
-					if (! p_FileName.toLowerCase().endsWith(".zip")) {
+					if (! p_FileName.toLowerCase().endsWith(".zip")) { // IDEMPIERE-7089-P2
 						throw new AdempiereSystemError("@FileMustBeZIP@");
 					}
 				}

--- a/org.adempiere.base/src/org/idempiere/process/VerifyMigration.java
+++ b/org.adempiere.base/src/org/idempiere/process/VerifyMigration.java
@@ -209,8 +209,8 @@ public class VerifyMigration extends SvrProcess {
 				String columnName = vcol.getColumnName();
 				if (columnName.startsWith("\"") && columnName.endsWith("\""))
 					columnName = columnName.substring(1, columnName.length()-1);
-				listDict.add(columnName.toUpperCase());
-				mapDict.put(columnName.toUpperCase(), vcol);
+				listDict.add(columnName.toUpperCase()); // IDEMPIERE-7089-P3
+				mapDict.put(columnName.toUpperCase(), vcol); // IDEMPIERE-7089-P3
 			}
 
 			if (listDict.size() == 0) { // ignore, view not defined in dictionary
@@ -229,13 +229,13 @@ public class VerifyMigration extends SvrProcess {
 				String schema = DB.getDatabase().getSchema();
 				String tableName = table.getTableName();
 				if (md.storesUpperCaseIdentifiers())
-					tableName = tableName.toUpperCase();
+					tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
 				else if (md.storesLowerCaseIdentifiers())
-					tableName = tableName.toLowerCase();
+					tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
 				rs = md.getColumns(catalog, schema, tableName, null);
 				while (rs.next()) {
 					String columnName = rs.getString ("COLUMN_NAME");
-					listDB.add(columnName.toUpperCase());
+					listDB.add(columnName.toUpperCase()); // IDEMPIERE-7089-P3
 				}
 			} finally {
 				DB.close(rs);

--- a/org.adempiere.base/src/org/idempiere/process/VerifyMigration.java
+++ b/org.adempiere.base/src/org/idempiere/process/VerifyMigration.java
@@ -209,8 +209,8 @@ public class VerifyMigration extends SvrProcess {
 				String columnName = vcol.getColumnName();
 				if (columnName.startsWith("\"") && columnName.endsWith("\""))
 					columnName = columnName.substring(1, columnName.length()-1);
-				listDict.add(columnName.toUpperCase()); // IDEMPIERE-7089-P3
-				mapDict.put(columnName.toUpperCase(), vcol); // IDEMPIERE-7089-P3
+				listDict.add(columnName.toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
+				mapDict.put(columnName.toUpperCase(java.util.Locale.ROOT), vcol); // IDEMPIERE-7089-P3
 			}
 
 			if (listDict.size() == 0) { // ignore, view not defined in dictionary
@@ -229,13 +229,13 @@ public class VerifyMigration extends SvrProcess {
 				String schema = DB.getDatabase().getSchema();
 				String tableName = table.getTableName();
 				if (md.storesUpperCaseIdentifiers())
-					tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
+					tableName = tableName.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 				else if (md.storesLowerCaseIdentifiers())
-					tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
+					tableName = tableName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 				rs = md.getColumns(catalog, schema, tableName, null);
 				while (rs.next()) {
 					String columnName = rs.getString ("COLUMN_NAME");
-					listDB.add(columnName.toUpperCase()); // IDEMPIERE-7089-P3
+					listDB.add(columnName.toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 				}
 			} finally {
 				DB.close(rs);

--- a/org.adempiere.install/src/org/compiere/install/util/AppsAction.java
+++ b/org.adempiere.install/src/org/compiere/install/util/AppsAction.java
@@ -98,7 +98,7 @@ public final class AppsAction extends AbstractAction
 		int pos = toolTipText.indexOf('&');
 		if (pos != -1  && toolTipText.length() > pos)	//	We have a nemonic - creates ALT-_
 		{
-			Character ch = Character.valueOf(toolTipText.toUpperCase().charAt(pos+1));
+			Character ch = Character.valueOf(toolTipText.toUpperCase().charAt(pos+1)); // IDEMPIERE-7089-P4
 			if (ch != ' ')
 			{
 				toolTipText = toolTipText.substring(0, pos) + toolTipText.substring(pos+1);

--- a/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/AttributeElementHandler.java
+++ b/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/AttributeElementHandler.java
@@ -71,16 +71,16 @@ public class AttributeElementHandler extends GenericPOElementHandler
 						{
 							throw new Exception("SQL Statement must include AD_Client_ID and AD_Org_ID");
 						}
-						if (!excludes.contains(column.getColumnName().toLowerCase()))
+						if (!excludes.contains(column.getColumnName().toLowerCase())) // IDEMPIERE-7089-P3
 						{
-							excludes.add(column.getColumnName().toLowerCase());
+							excludes.add(column.getColumnName().toLowerCase()); // IDEMPIERE-7089-P3
 						}
 					}
 				}
 
 				for (String keycol : attribute.get_KeyColumns())
 				{
-					if (excludes.contains(keycol.toLowerCase()))
+					if (excludes.contains(keycol.toLowerCase())) // IDEMPIERE-7089-P3
 					{
 						throw new Exception("SQL Statement must include key columns");
 					}

--- a/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/AttributeElementHandler.java
+++ b/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/AttributeElementHandler.java
@@ -71,16 +71,16 @@ public class AttributeElementHandler extends GenericPOElementHandler
 						{
 							throw new Exception("SQL Statement must include AD_Client_ID and AD_Org_ID");
 						}
-						if (!excludes.contains(column.getColumnName().toLowerCase())) // IDEMPIERE-7089-P3
+						if (!excludes.contains(column.getColumnName().toLowerCase(java.util.Locale.ROOT))) // IDEMPIERE-7089-P3
 						{
-							excludes.add(column.getColumnName().toLowerCase()); // IDEMPIERE-7089-P3
+							excludes.add(column.getColumnName().toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 						}
 					}
 				}
 
 				for (String keycol : attribute.get_KeyColumns())
 				{
-					if (excludes.contains(keycol.toLowerCase())) // IDEMPIERE-7089-P3
+					if (excludes.contains(keycol.toLowerCase(java.util.Locale.ROOT))) // IDEMPIERE-7089-P3
 					{
 						throw new Exception("SQL Statement must include key columns");
 					}

--- a/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/AttributeUseElementHandler.java
+++ b/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/AttributeUseElementHandler.java
@@ -75,16 +75,16 @@ public class AttributeUseElementHandler extends GenericPOElementHandler
 						{
 							throw new Exception("SQL Statement must include AD_Client_ID and AD_Org_ID");
 						}
-						if (!excludes.contains(column.getColumnName().toLowerCase())) // IDEMPIERE-7089-P3
+						if (!excludes.contains(column.getColumnName().toLowerCase(java.util.Locale.ROOT))) // IDEMPIERE-7089-P3
 						{
-							excludes.add(column.getColumnName().toLowerCase()); // IDEMPIERE-7089-P3
+							excludes.add(column.getColumnName().toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 						}
 					}
 				}
 
 				for (String keycol : mAttributeUse.get_KeyColumns())
 				{
-					if (excludes.contains(keycol.toLowerCase())) // IDEMPIERE-7089-P3
+					if (excludes.contains(keycol.toLowerCase(java.util.Locale.ROOT))) // IDEMPIERE-7089-P3
 					{
 						throw new Exception("SQL Statement must include key columns");
 					}

--- a/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/AttributeUseElementHandler.java
+++ b/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/AttributeUseElementHandler.java
@@ -75,16 +75,16 @@ public class AttributeUseElementHandler extends GenericPOElementHandler
 						{
 							throw new Exception("SQL Statement must include AD_Client_ID and AD_Org_ID");
 						}
-						if (!excludes.contains(column.getColumnName().toLowerCase()))
+						if (!excludes.contains(column.getColumnName().toLowerCase())) // IDEMPIERE-7089-P3
 						{
-							excludes.add(column.getColumnName().toLowerCase());
+							excludes.add(column.getColumnName().toLowerCase()); // IDEMPIERE-7089-P3
 						}
 					}
 				}
 
 				for (String keycol : mAttributeUse.get_KeyColumns())
 				{
-					if (excludes.contains(keycol.toLowerCase()))
+					if (excludes.contains(keycol.toLowerCase())) // IDEMPIERE-7089-P3
 					{
 						throw new Exception("SQL Statement must include key columns");
 					}

--- a/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/ColumnElementHandler.java
+++ b/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/ColumnElementHandler.java
@@ -247,11 +247,11 @@ public class ColumnElementHandler extends AbstractElementHandler {
 			String tableName = table.getTableName();
 			String columnName = column.getColumnName();
 			if (md.storesUpperCaseIdentifiers()) {
-				tableName = tableName.toUpperCase();
-				columnName = columnName.toUpperCase();
+				tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
+				columnName = columnName.toUpperCase(); // IDEMPIERE-7089-P3
 			} else if (md.storesLowerCaseIdentifiers()) {
-				tableName = tableName.toLowerCase();
-				columnName = columnName.toLowerCase();
+				tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
+				columnName = columnName.toLowerCase(); // IDEMPIERE-7089-P3
 			}
 
 			rst = md.getTables(catalog, schema, tableName,

--- a/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/ColumnElementHandler.java
+++ b/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/ColumnElementHandler.java
@@ -247,11 +247,11 @@ public class ColumnElementHandler extends AbstractElementHandler {
 			String tableName = table.getTableName();
 			String columnName = column.getColumnName();
 			if (md.storesUpperCaseIdentifiers()) {
-				tableName = tableName.toUpperCase(); // IDEMPIERE-7089-P3
-				columnName = columnName.toUpperCase(); // IDEMPIERE-7089-P3
+				tableName = tableName.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
+				columnName = columnName.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 			} else if (md.storesLowerCaseIdentifiers()) {
-				tableName = tableName.toLowerCase(); // IDEMPIERE-7089-P3
-				columnName = columnName.toLowerCase(); // IDEMPIERE-7089-P3
+				tableName = tableName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
+				columnName = columnName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 			}
 
 			rst = md.getTables(catalog, schema, tableName,

--- a/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/GenericPOElementHandler.java
+++ b/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/GenericPOElementHandler.java
@@ -142,7 +142,7 @@ public class GenericPOElementHandler extends AbstractElementHandler {
 		int tableId = Env.getContextAsInt(ctx.ctx, DataElementParameters.AD_TABLE_ID);
 		String tableName = MTable.getTableName(ctx.ctx, tableId);
 		List<String> excludes = defaultExcludeList(tableName);
-		boolean checkExcluded = ! sql.toLowerCase().startsWith("select *");				
+		boolean checkExcluded = ! sql.toLowerCase().startsWith("select *");				 // IDEMPIERE-7089-P3
 		try (Statement stmt = DB.createStatement();) {
 			sql = MRole.getDefault().addAccessSQL(sql, tableName, true, true);			
 			ResultSet rs = stmt.executeQuery(sql);
@@ -163,17 +163,17 @@ public class GenericPOElementHandler extends AbstractElementHandler {
 							if (column.getColumnName().equals("AD_Client_ID") || column.getColumnName().equals("AD_Org_ID")) {
 								throw new Exception("SQL Statement must include AD_Client_ID and AD_Org_ID");
 							}
-							if (!excludes.contains(column.getColumnName().toLowerCase())) {
-								excludes.add(column.getColumnName().toLowerCase());
+							if (!excludes.contains(column.getColumnName().toLowerCase())) { // IDEMPIERE-7089-P3
+								excludes.add(column.getColumnName().toLowerCase()); // IDEMPIERE-7089-P3
 							}
 						}
 					}
 					for (String keycol : po.get_KeyColumns()) {
-						if (excludes.contains(keycol.toLowerCase())) {
+						if (excludes.contains(keycol.toLowerCase())) { // IDEMPIERE-7089-P3
 							throw new Exception("SQL Statement must include key columns");
 						}
 					}
-					if (excludes.contains(po.getUUIDColumnName().toLowerCase())) {
+					if (excludes.contains(po.getUUIDColumnName().toLowerCase())) { // IDEMPIERE-7089-P3
 						throw new Exception("SQL Statement must include UUID column");
 					}
 					checkExcluded = false;

--- a/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/GenericPOElementHandler.java
+++ b/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/GenericPOElementHandler.java
@@ -142,7 +142,7 @@ public class GenericPOElementHandler extends AbstractElementHandler {
 		int tableId = Env.getContextAsInt(ctx.ctx, DataElementParameters.AD_TABLE_ID);
 		String tableName = MTable.getTableName(ctx.ctx, tableId);
 		List<String> excludes = defaultExcludeList(tableName);
-		boolean checkExcluded = ! sql.toLowerCase().startsWith("select *");				 // IDEMPIERE-7089-P3
+		boolean checkExcluded = ! sql.toLowerCase(java.util.Locale.ROOT).startsWith("select *");				 // IDEMPIERE-7089-P3
 		try (Statement stmt = DB.createStatement();) {
 			sql = MRole.getDefault().addAccessSQL(sql, tableName, true, true);			
 			ResultSet rs = stmt.executeQuery(sql);
@@ -163,17 +163,17 @@ public class GenericPOElementHandler extends AbstractElementHandler {
 							if (column.getColumnName().equals("AD_Client_ID") || column.getColumnName().equals("AD_Org_ID")) {
 								throw new Exception("SQL Statement must include AD_Client_ID and AD_Org_ID");
 							}
-							if (!excludes.contains(column.getColumnName().toLowerCase())) { // IDEMPIERE-7089-P3
-								excludes.add(column.getColumnName().toLowerCase()); // IDEMPIERE-7089-P3
+							if (!excludes.contains(column.getColumnName().toLowerCase(java.util.Locale.ROOT))) { // IDEMPIERE-7089-P3
+								excludes.add(column.getColumnName().toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 							}
 						}
 					}
 					for (String keycol : po.get_KeyColumns()) {
-						if (excludes.contains(keycol.toLowerCase())) { // IDEMPIERE-7089-P3
+						if (excludes.contains(keycol.toLowerCase(java.util.Locale.ROOT))) { // IDEMPIERE-7089-P3
 							throw new Exception("SQL Statement must include key columns");
 						}
 					}
-					if (excludes.contains(po.getUUIDColumnName().toLowerCase())) { // IDEMPIERE-7089-P3
+					if (excludes.contains(po.getUUIDColumnName().toLowerCase(java.util.Locale.ROOT))) { // IDEMPIERE-7089-P3
 						throw new Exception("SQL Statement must include UUID column");
 					}
 					checkExcluded = false;

--- a/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/MenuElementHandler.java
+++ b/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/MenuElementHandler.java
@@ -136,7 +136,7 @@ public class MenuElementHandler extends AbstractElementHandler {
 	
 						for (int q = 1; q <= columns; q++) {
 	
-							String colName = meta.getColumnName(q).toUpperCase();
+							String colName = meta.getColumnName(q).toUpperCase(); // IDEMPIERE-7089-P3
 							final String sql3 = "SELECT AD_Column_ID FROM AD_column WHERE Upper(ColumnName) = ? AND AD_Table_ID = ?";
 							int columnID = DB.getSQLValueEx(getTrxName(ctx), sql3, colName, tableID);
 							final String sql4 = "SELECT AD_Reference_ID FROM AD_COLUMN WHERE AD_Column_ID = ?";

--- a/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/MenuElementHandler.java
+++ b/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/MenuElementHandler.java
@@ -136,7 +136,7 @@ public class MenuElementHandler extends AbstractElementHandler {
 	
 						for (int q = 1; q <= columns; q++) {
 	
-							String colName = meta.getColumnName(q).toUpperCase(); // IDEMPIERE-7089-P3
+							String colName = meta.getColumnName(q).toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 							final String sql3 = "SELECT AD_Column_ID FROM AD_column WHERE Upper(ColumnName) = ? AND AD_Table_ID = ?";
 							int columnID = DB.getSQLValueEx(getTrxName(ctx), sql3, colName, tableID);
 							final String sql4 = "SELECT AD_Reference_ID FROM AD_COLUMN WHERE AD_Column_ID = ?";

--- a/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/SQLMandatoryElementHandler.java
+++ b/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/SQLMandatoryElementHandler.java
@@ -56,7 +56,7 @@ public class SQLMandatoryElementHandler extends AbstractElementHandler {
 		log.info(elementValue);
 		String DBType = getStringValue(element, "DBType");
 		String sql = getStringValue(element, "statement");
-		if (sql.endsWith(";") && !(sql.toLowerCase().endsWith("end;"))) // IDEMPIERE-7089-P3
+		if (sql.endsWith(";") && !(sql.toLowerCase(java.util.Locale.ROOT).endsWith("end;"))) // IDEMPIERE-7089-P3
 			sql = sql.substring(0, sql.length() - 1);
 		sql = Env.parseContext(Env.getCtx(), 0, sql, false);
 		int count = 0;
@@ -93,10 +93,10 @@ public class SQLMandatoryElementHandler extends AbstractElementHandler {
 			logImportDetail (ctx, impDetail, 1, "SQLMandatory",count,"Execute", sql, String.valueOf(count));
 			ctx.packIn.getNotifier().addSuccessLine("-> " + sql);
 			// Cache Reset when deleting records via SQL
-			if (sql.toLowerCase().startsWith("delete from ")) { // IDEMPIERE-7089-P3
+			if (sql.toLowerCase(java.util.Locale.ROOT).startsWith("delete from ")) { // IDEMPIERE-7089-P3
 				String[] words = sql.split("[ \r\n]");
 				String table = words[2];
-				String tableName = DB.getSQLValueString(null, "SELECT TableName FROM AD_Table WHERE LOWER(TableName)=?", table.toLowerCase()); // IDEMPIERE-7089-P3
+				String tableName = DB.getSQLValueString(null, "SELECT TableName FROM AD_Table WHERE LOWER(TableName)=?", table.toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 				if (! Util.isEmpty(tableName)) {
 					CacheMgt.get().reset(tableName);
 				}

--- a/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/SQLMandatoryElementHandler.java
+++ b/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/SQLMandatoryElementHandler.java
@@ -56,7 +56,7 @@ public class SQLMandatoryElementHandler extends AbstractElementHandler {
 		log.info(elementValue);
 		String DBType = getStringValue(element, "DBType");
 		String sql = getStringValue(element, "statement");
-		if (sql.endsWith(";") && !(sql.toLowerCase().endsWith("end;")))
+		if (sql.endsWith(";") && !(sql.toLowerCase().endsWith("end;"))) // IDEMPIERE-7089-P3
 			sql = sql.substring(0, sql.length() - 1);
 		sql = Env.parseContext(Env.getCtx(), 0, sql, false);
 		int count = 0;
@@ -93,10 +93,10 @@ public class SQLMandatoryElementHandler extends AbstractElementHandler {
 			logImportDetail (ctx, impDetail, 1, "SQLMandatory",count,"Execute", sql, String.valueOf(count));
 			ctx.packIn.getNotifier().addSuccessLine("-> " + sql);
 			// Cache Reset when deleting records via SQL
-			if (sql.toLowerCase().startsWith("delete from ")) {
+			if (sql.toLowerCase().startsWith("delete from ")) { // IDEMPIERE-7089-P3
 				String[] words = sql.split("[ \r\n]");
 				String table = words[2];
-				String tableName = DB.getSQLValueString(null, "SELECT TableName FROM AD_Table WHERE LOWER(TableName)=?", table.toLowerCase());
+				String tableName = DB.getSQLValueString(null, "SELECT TableName FROM AD_Table WHERE LOWER(TableName)=?", table.toLowerCase()); // IDEMPIERE-7089-P3
 				if (! Util.isEmpty(tableName)) {
 					CacheMgt.get().reset(tableName);
 				}

--- a/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/SQLStatementElementHandler.java
+++ b/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/SQLStatementElementHandler.java
@@ -48,7 +48,7 @@ public class SQLStatementElementHandler extends AbstractElementHandler {
 		log.info(elementValue);
 		String DBType = getStringValue(element, "DBType");
 		String sql = getStringValue(element, "statement");
-		if (sql.endsWith(";") && !(sql.toLowerCase().endsWith("end;"))) // IDEMPIERE-7089-P3
+		if (sql.endsWith(";") && !(sql.toLowerCase(java.util.Locale.ROOT).endsWith("end;"))) // IDEMPIERE-7089-P3
 			sql = sql.substring(0, sql.length() - 1);
 		sql=Env.parseContext(Env.getCtx(), 0, sql, false);  // tbayen IDEMPIERE-2140
 		Savepoint savepoint = null;
@@ -94,10 +94,10 @@ public class SQLStatementElementHandler extends AbstractElementHandler {
 			logImportDetail (ctx, impDetail, 1, "SQLStatement",count,"Execute", sql, String.valueOf(count));
 			ctx.packIn.getNotifier().addSuccessLine("-> " + sql);
 			// Cache Reset when deleting records via SQL
-			if (sql.toLowerCase().startsWith("delete from ")) { // IDEMPIERE-7089-P3
+			if (sql.toLowerCase(java.util.Locale.ROOT).startsWith("delete from ")) { // IDEMPIERE-7089-P3
 				String[] words = sql.split("[ \r\n]");
 				String table = words[2];
-				String tableName = DB.getSQLValueString(null, "SELECT TableName FROM AD_Table WHERE LOWER(TableName)=?", table.toLowerCase()); // IDEMPIERE-7089-P3
+				String tableName = DB.getSQLValueString(null, "SELECT TableName FROM AD_Table WHERE LOWER(TableName)=?", table.toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 				if (! Util.isEmpty(tableName)) {
 					CacheMgt.get().reset(tableName);
 				}

--- a/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/SQLStatementElementHandler.java
+++ b/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/SQLStatementElementHandler.java
@@ -48,7 +48,7 @@ public class SQLStatementElementHandler extends AbstractElementHandler {
 		log.info(elementValue);
 		String DBType = getStringValue(element, "DBType");
 		String sql = getStringValue(element, "statement");
-		if (sql.endsWith(";") && !(sql.toLowerCase().endsWith("end;")))
+		if (sql.endsWith(";") && !(sql.toLowerCase().endsWith("end;"))) // IDEMPIERE-7089-P3
 			sql = sql.substring(0, sql.length() - 1);
 		sql=Env.parseContext(Env.getCtx(), 0, sql, false);  // tbayen IDEMPIERE-2140
 		Savepoint savepoint = null;
@@ -94,10 +94,10 @@ public class SQLStatementElementHandler extends AbstractElementHandler {
 			logImportDetail (ctx, impDetail, 1, "SQLStatement",count,"Execute", sql, String.valueOf(count));
 			ctx.packIn.getNotifier().addSuccessLine("-> " + sql);
 			// Cache Reset when deleting records via SQL
-			if (sql.toLowerCase().startsWith("delete from ")) {
+			if (sql.toLowerCase().startsWith("delete from ")) { // IDEMPIERE-7089-P3
 				String[] words = sql.split("[ \r\n]");
 				String table = words[2];
-				String tableName = DB.getSQLValueString(null, "SELECT TableName FROM AD_Table WHERE LOWER(TableName)=?", table.toLowerCase());
+				String tableName = DB.getSQLValueString(null, "SELECT TableName FROM AD_Table WHERE LOWER(TableName)=?", table.toLowerCase()); // IDEMPIERE-7089-P3
 				if (! Util.isEmpty(tableName)) {
 					CacheMgt.get().reset(tableName);
 				}

--- a/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/TableAttributeElementHandler.java
+++ b/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/TableAttributeElementHandler.java
@@ -81,16 +81,16 @@ public class TableAttributeElementHandler extends GenericPOElementHandler
 						{
 							throw new Exception("SQL Statement must include AD_Client_ID and AD_Org_ID");
 						}
-						if (!excludes.contains(column.getColumnName().toLowerCase()))
+						if (!excludes.contains(column.getColumnName().toLowerCase())) // IDEMPIERE-7089-P3
 						{
-							excludes.add(column.getColumnName().toLowerCase());
+							excludes.add(column.getColumnName().toLowerCase()); // IDEMPIERE-7089-P3
 						}
 					}
 				}
 
 				for (String keycol : mTableAttribute.get_KeyColumns())
 				{
-					if (excludes.contains(keycol.toLowerCase()))
+					if (excludes.contains(keycol.toLowerCase())) // IDEMPIERE-7089-P3
 					{
 						throw new Exception("SQL Statement must include key columns");
 					}

--- a/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/TableAttributeElementHandler.java
+++ b/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/TableAttributeElementHandler.java
@@ -81,16 +81,16 @@ public class TableAttributeElementHandler extends GenericPOElementHandler
 						{
 							throw new Exception("SQL Statement must include AD_Client_ID and AD_Org_ID");
 						}
-						if (!excludes.contains(column.getColumnName().toLowerCase())) // IDEMPIERE-7089-P3
+						if (!excludes.contains(column.getColumnName().toLowerCase(java.util.Locale.ROOT))) // IDEMPIERE-7089-P3
 						{
-							excludes.add(column.getColumnName().toLowerCase()); // IDEMPIERE-7089-P3
+							excludes.add(column.getColumnName().toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 						}
 					}
 				}
 
 				for (String keycol : mTableAttribute.get_KeyColumns())
 				{
-					if (excludes.contains(keycol.toLowerCase())) // IDEMPIERE-7089-P3
+					if (excludes.contains(keycol.toLowerCase(java.util.Locale.ROOT))) // IDEMPIERE-7089-P3
 					{
 						throw new Exception("SQL Statement must include key columns");
 					}

--- a/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/TableAttributeSetElementHandler.java
+++ b/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/TableAttributeSetElementHandler.java
@@ -74,16 +74,16 @@ public class TableAttributeSetElementHandler extends GenericPOElementHandler {
 						{
 							throw new Exception("SQL Statement must include AD_Client_ID and AD_Org_ID");
 						}
-						if (!excludes.contains(column.getColumnName().toLowerCase()))
+						if (!excludes.contains(column.getColumnName().toLowerCase())) // IDEMPIERE-7089-P3
 						{
-							excludes.add(column.getColumnName().toLowerCase());
+							excludes.add(column.getColumnName().toLowerCase()); // IDEMPIERE-7089-P3
 						}
 					}
 				}
 
 				for (String keycol : mTableAttributeSet.get_KeyColumns())
 				{
-					if (excludes.contains(keycol.toLowerCase()))
+					if (excludes.contains(keycol.toLowerCase())) // IDEMPIERE-7089-P3
 					{
 						throw new Exception("SQL Statement must include key columns");
 					}

--- a/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/TableAttributeSetElementHandler.java
+++ b/org.adempiere.pipo.handlers/src/org/adempiere/pipo2/handler/TableAttributeSetElementHandler.java
@@ -74,16 +74,16 @@ public class TableAttributeSetElementHandler extends GenericPOElementHandler {
 						{
 							throw new Exception("SQL Statement must include AD_Client_ID and AD_Org_ID");
 						}
-						if (!excludes.contains(column.getColumnName().toLowerCase())) // IDEMPIERE-7089-P3
+						if (!excludes.contains(column.getColumnName().toLowerCase(java.util.Locale.ROOT))) // IDEMPIERE-7089-P3
 						{
-							excludes.add(column.getColumnName().toLowerCase()); // IDEMPIERE-7089-P3
+							excludes.add(column.getColumnName().toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 						}
 					}
 				}
 
 				for (String keycol : mTableAttributeSet.get_KeyColumns())
 				{
-					if (excludes.contains(keycol.toLowerCase())) // IDEMPIERE-7089-P3
+					if (excludes.contains(keycol.toLowerCase(java.util.Locale.ROOT))) // IDEMPIERE-7089-P3
 					{
 						throw new Exception("SQL Statement must include key columns");
 					}

--- a/org.adempiere.pipo/src/org/adempiere/pipo2/GridTab2PackExporter.java
+++ b/org.adempiere.pipo/src/org/adempiere/pipo2/GridTab2PackExporter.java
@@ -71,7 +71,7 @@ public class GridTab2PackExporter implements IGridTabExporter {
 				sql.append("))");
 			}
 			for(GridTab child : childs) {
-				if (child.getTableName().toLowerCase().endsWith("_trl")) // ignore trl tabs as they are exported as translation // IDEMPIERE-7089-P3
+				if (child.getTableName().toLowerCase(java.util.Locale.ROOT).endsWith("_trl")) // ignore trl tabs as they are exported as translation // IDEMPIERE-7089-P3
 					continue;
 				if (child.getTabLevel() > gridTab.getTabLevel()+1) {
 					int level = child.getTabLevel() - gridTab.getTabLevel() - 1;
@@ -183,7 +183,7 @@ public class GridTab2PackExporter implements IGridTabExporter {
 	 */
 	@Override
 	public boolean isExportableTab(GridTab gridTab) {
-		if (gridTab.getTableName().toLowerCase().endsWith("_trl")) // IDEMPIERE-7089-P3
+		if (gridTab.getTableName().toLowerCase(java.util.Locale.ROOT).endsWith("_trl")) // IDEMPIERE-7089-P3
 			return false;
 		return true;
 	}

--- a/org.adempiere.pipo/src/org/adempiere/pipo2/GridTab2PackExporter.java
+++ b/org.adempiere.pipo/src/org/adempiere/pipo2/GridTab2PackExporter.java
@@ -71,7 +71,7 @@ public class GridTab2PackExporter implements IGridTabExporter {
 				sql.append("))");
 			}
 			for(GridTab child : childs) {
-				if (child.getTableName().toLowerCase().endsWith("_trl")) // ignore trl tabs as they are exported as translation
+				if (child.getTableName().toLowerCase().endsWith("_trl")) // ignore trl tabs as they are exported as translation // IDEMPIERE-7089-P3
 					continue;
 				if (child.getTabLevel() > gridTab.getTabLevel()+1) {
 					int level = child.getTabLevel() - gridTab.getTabLevel() - 1;
@@ -183,7 +183,7 @@ public class GridTab2PackExporter implements IGridTabExporter {
 	 */
 	@Override
 	public boolean isExportableTab(GridTab gridTab) {
-		if (gridTab.getTableName().toLowerCase().endsWith("_trl"))
+		if (gridTab.getTableName().toLowerCase().endsWith("_trl")) // IDEMPIERE-7089-P3
 			return false;
 		return true;
 	}

--- a/org.adempiere.pipo/src/org/adempiere/pipo2/IDFinder.java
+++ b/org.adempiere.pipo/src/org/adempiere/pipo2/IDFinder.java
@@ -102,7 +102,7 @@ public class IDFinder {
 				if (i > 0)
 					sqlB.append(" AND ");
 				if (ignorecase) {
-					sqlB.append("UPPER(").append(columns[i]).append(")=? ");
+					sqlB.append("UPPER(").append(columns[i]).append(")=UPPER(?) ");
 				} else {
 					sqlB.append(columns[i]).append("=? ");
 				}
@@ -110,7 +110,7 @@ public class IDFinder {
 					byte[] bytes = Hex.decodeHex(values[i].toCharArray());
 					String s = new String(bytes, "UTF-8");
 					if (ignorecase) {
-						paramList.add(s.toUpperCase());
+						paramList.add(s); // IDEMPIERE-7089-P1
 					} else {
 						paramList.add(s);
 					}
@@ -123,8 +123,8 @@ public class IDFinder {
 			params = paramList.toArray();
 		} else {
 			if (ignorecase && value != null && value instanceof String) {
-				sqlB.append("UPPER(").append(columnName).append(") =? ");
-				params = new Object[]{ ((String)value).toUpperCase()};
+				sqlB.append("UPPER(").append(columnName).append(") =UPPER(?) ");
+				params = new Object[]{value}; // IDEMPIERE-7089-P1
 			} else {
 				sqlB.append(columnName).append(" =? ");
 				params = new Object[]{value};
@@ -325,7 +325,7 @@ public class IDFinder {
 		if (ignoreCase) {
 			sqlB.append("UPPER(")
 				.append(columnName)
-				.append(") = ? AND ");
+				.append(") = UPPER(?) AND ");
 		} else {
 			sqlB.append(columnName)
 				.append(" = ? AND ");
@@ -341,7 +341,7 @@ public class IDFinder {
 
 			pstmt = DB.prepareStatement(sqlB.toString(), trxName);
 			if (ignoreCase) {
-				pstmt.setString(1, name.toUpperCase());
+				pstmt.setString(1, name); // IDEMPIERE-7089-P1
 			} else {
 				pstmt.setString(1, name);
 			}

--- a/org.adempiere.pipo/src/org/adempiere/pipo2/PackInHandler.java
+++ b/org.adempiere.pipo/src/org/adempiere/pipo2/PackInHandler.java
@@ -456,7 +456,7 @@ public class PackInHandler extends DefaultHandler {
 
         		String fkConstraintSql = MColumn.getForeignKeyConstraintSql(md, catalog, schema, tableName, table, column, false);
         		if (! Util.isEmpty(fkConstraintSql)) {
-			if (fkConstraintSql.toLowerCase().contains(" ad_sequence(ad_sequence_id)")) // IDEMPIERE-7089-P3
+			if (fkConstraintSql.toLowerCase(java.util.Locale.ROOT).contains(" ad_sequence(ad_sequence_id)")) // IDEMPIERE-7089-P3
         				fkConstraintSql = fkConstraintSql + "; COMMIT";
         			if (fkConstraintSql.indexOf(DB.SQLSTATEMENT_SEPARATOR) == -1) {
         				DB.executeUpdate(fkConstraintSql, false, m_ctx.trx.getTrxName());

--- a/org.adempiere.pipo/src/org/adempiere/pipo2/PackInHandler.java
+++ b/org.adempiere.pipo/src/org/adempiere/pipo2/PackInHandler.java
@@ -456,7 +456,7 @@ public class PackInHandler extends DefaultHandler {
 
         		String fkConstraintSql = MColumn.getForeignKeyConstraintSql(md, catalog, schema, tableName, table, column, false);
         		if (! Util.isEmpty(fkConstraintSql)) {
-        			if (fkConstraintSql.toLowerCase().contains(" ad_sequence(ad_sequence_id)"))
+			if (fkConstraintSql.toLowerCase().contains(" ad_sequence(ad_sequence_id)")) // IDEMPIERE-7089-P3
         				fkConstraintSql = fkConstraintSql + "; COMMIT";
         			if (fkConstraintSql.indexOf(DB.SQLSTATEMENT_SEPARATOR) == -1) {
         				DB.executeUpdate(fkConstraintSql, false, m_ctx.trx.getTrxName());

--- a/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/PackInApplicationActivator.java
+++ b/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/PackInApplicationActivator.java
@@ -292,7 +292,7 @@ public class PackInApplicationActivator extends AbstractActivator{
 	
 	private void processFilePath(File toProcess) {
 		if (toProcess.isFile() && toProcess.canRead()) {
-			if (toProcess.getName().toLowerCase().endsWith(".zip"))
+			if (toProcess.getName().toLowerCase().endsWith(".zip")) // IDEMPIERE-7089-P2
 				filesToProcess.add(toProcess);
 			else {
 				logger.log(Level.WARNING, toProcess.getName() + " is not a valid .zip file");
@@ -301,7 +301,7 @@ public class PackInApplicationActivator extends AbstractActivator{
 		} else if (toProcess.isDirectory() && toProcess.canRead()) {
 			FileFilter filter = new FileFilter() {
 				public boolean accept(File file) {
-					if (file.getName().toUpperCase().endsWith(".ZIP") || file.isDirectory())
+					if (file.getName().toUpperCase().endsWith(".ZIP") || file.isDirectory()) // IDEMPIERE-7089-P2
 						return true;
 					else
 						return false;

--- a/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/PackInApplicationActivator.java
+++ b/org.adempiere.plugin.utils/src/org/adempiere/plugin/utils/PackInApplicationActivator.java
@@ -292,7 +292,7 @@ public class PackInApplicationActivator extends AbstractActivator{
 	
 	private void processFilePath(File toProcess) {
 		if (toProcess.isFile() && toProcess.canRead()) {
-			if (toProcess.getName().toLowerCase().endsWith(".zip")) // IDEMPIERE-7089-P2
+			if (toProcess.getName().toLowerCase(java.util.Locale.ROOT).endsWith(".zip")) // IDEMPIERE-7089-P2
 				filesToProcess.add(toProcess);
 			else {
 				logger.log(Level.WARNING, toProcess.getName() + " is not a valid .zip file");
@@ -301,7 +301,7 @@ public class PackInApplicationActivator extends AbstractActivator{
 		} else if (toProcess.isDirectory() && toProcess.canRead()) {
 			FileFilter filter = new FileFilter() {
 				public boolean accept(File file) {
-					if (file.getName().toUpperCase().endsWith(".ZIP") || file.isDirectory()) // IDEMPIERE-7089-P2
+					if (file.getName().toUpperCase(java.util.Locale.ROOT).endsWith(".ZIP") || file.isDirectory()) // IDEMPIERE-7089-P2
 						return true;
 					else
 						return false;

--- a/org.adempiere.report.jasper/src/org/adempiere/report/jasper/AttachmentResourceLoader.java
+++ b/org.adempiere.report.jasper/src/org/adempiere/report/jasper/AttachmentResourceLoader.java
@@ -177,8 +177,8 @@ public class AttachmentResourceLoader {
 			if (!entries[i].getName().equals(name)) {
 				File reportFile = getAttachmentEntryFile(entries[i]);
 				if (reportFile != null) {
-					if (entries[i].getName().toLowerCase().endsWith(".jrxml") // IDEMPIERE-7089-P2
-							|| entries[i].getName().toLowerCase().endsWith(".jasper")) { // IDEMPIERE-7089-P2
+					if (entries[i].getName().toLowerCase(java.util.Locale.ROOT).endsWith(".jrxml") // IDEMPIERE-7089-P2
+							|| entries[i].getName().toLowerCase(java.util.Locale.ROOT).endsWith(".jasper")) { // IDEMPIERE-7089-P2
 						subreports.add(reportFile);
 					}
 				}

--- a/org.adempiere.report.jasper/src/org/adempiere/report/jasper/AttachmentResourceLoader.java
+++ b/org.adempiere.report.jasper/src/org/adempiere/report/jasper/AttachmentResourceLoader.java
@@ -177,8 +177,8 @@ public class AttachmentResourceLoader {
 			if (!entries[i].getName().equals(name)) {
 				File reportFile = getAttachmentEntryFile(entries[i]);
 				if (reportFile != null) {
-					if (entries[i].getName().toLowerCase().endsWith(".jrxml")
-							|| entries[i].getName().toLowerCase().endsWith(".jasper")) {
+					if (entries[i].getName().toLowerCase().endsWith(".jrxml") // IDEMPIERE-7089-P2
+							|| entries[i].getName().toLowerCase().endsWith(".jasper")) { // IDEMPIERE-7089-P2
 						subreports.add(reportFile);
 					}
 				}

--- a/org.adempiere.report.jasper/src/org/adempiere/report/jasper/ColumnLookup.java
+++ b/org.adempiere.report.jasper/src/org/adempiere/report/jasper/ColumnLookup.java
@@ -127,7 +127,7 @@ public class ColumnLookup implements BiFunction<String, Object, Object> {
 				return getImage(((Number)key).intValue());				
 			} else if (t.equalsIgnoreCase("YesNo") && (key instanceof String)) {
 				return getYesNoText((String) key);
-			} else if (t.toLowerCase().startsWith("chart/") && (key instanceof Number)) { // IDEMPIERE-7089-P2
+			} else if (t.toLowerCase(java.util.Locale.ROOT).startsWith("chart/") && (key instanceof Number)) { // IDEMPIERE-7089-P2
 				//expression syntax - chart/width/height
 				parts = t.split("[/]");
 				if (parts.length == 3) {
@@ -142,7 +142,7 @@ public class ColumnLookup implements BiFunction<String, Object, Object> {
 					}
 				}
 				return null;
-			} else if (t.toLowerCase().startsWith("attachment/")) { // IDEMPIERE-7089-P2
+			} else if (t.toLowerCase(java.util.Locale.ROOT).startsWith("attachment/")) { // IDEMPIERE-7089-P2
 				return getAttachmentData(t, key);
 			}
 		}

--- a/org.adempiere.report.jasper/src/org/adempiere/report/jasper/ColumnLookup.java
+++ b/org.adempiere.report.jasper/src/org/adempiere/report/jasper/ColumnLookup.java
@@ -127,7 +127,7 @@ public class ColumnLookup implements BiFunction<String, Object, Object> {
 				return getImage(((Number)key).intValue());				
 			} else if (t.equalsIgnoreCase("YesNo") && (key instanceof String)) {
 				return getYesNoText((String) key);
-			} else if (t.toLowerCase().startsWith("chart/") && (key instanceof Number)) {
+			} else if (t.toLowerCase().startsWith("chart/") && (key instanceof Number)) { // IDEMPIERE-7089-P2
 				//expression syntax - chart/width/height
 				parts = t.split("[/]");
 				if (parts.length == 3) {
@@ -142,7 +142,7 @@ public class ColumnLookup implements BiFunction<String, Object, Object> {
 					}
 				}
 				return null;
-			} else if (t.toLowerCase().startsWith("attachment/")) {
+			} else if (t.toLowerCase().startsWith("attachment/")) { // IDEMPIERE-7089-P2
 				return getAttachmentData(t, key);
 			}
 		}

--- a/org.adempiere.report.jasper/src/org/adempiere/report/jasper/FileResourceLoader.java
+++ b/org.adempiere.report.jasper/src/org/adempiere/report/jasper/FileResourceLoader.java
@@ -125,7 +125,7 @@ public class FileResourceLoader {
 		public boolean accept(File file, String name) {
 			if (file.equals(directory)) {
 				if (!name.equals(reportFile.getName())) {
-					String lower = name.toLowerCase();
+					String lower = name.toLowerCase(); // IDEMPIERE-7089-P2
 					if (lower.endsWith(".jasper") || lower.endsWith(".jrxml"))
 						return true;
 				}

--- a/org.adempiere.report.jasper/src/org/adempiere/report/jasper/FileResourceLoader.java
+++ b/org.adempiere.report.jasper/src/org/adempiere/report/jasper/FileResourceLoader.java
@@ -125,7 +125,7 @@ public class FileResourceLoader {
 		public boolean accept(File file, String name) {
 			if (file.equals(directory)) {
 				if (!name.equals(reportFile.getName())) {
-					String lower = name.toLowerCase(); // IDEMPIERE-7089-P2
+					String lower = name.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P2
 					if (lower.endsWith(".jasper") || lower.endsWith(".jrxml"))
 						return true;
 				}

--- a/org.adempiere.report.jasper/src/org/adempiere/report/jasper/JasperReportContentRendererFactory.java
+++ b/org.adempiere.report.jasper/src/org/adempiere/report/jasper/JasperReportContentRendererFactory.java
@@ -126,7 +126,7 @@ public class JasperReportContentRendererFactory implements IReportContentRendere
 			instance.saveEx();
 			pi.setAD_PInstance_ID(instance.getAD_PInstance_ID());
 			Trx trx = pi.getTransactionName() != null ? Trx.get(pi.getTransactionName(), false) : null;
-			boolean ok = process.getClassname().toLowerCase().startsWith(MRule.SCRIPT_PREFIX) // IDEMPIERE-7089-P2
+			boolean ok = process.getClassname().toLowerCase(java.util.Locale.ROOT).startsWith(MRule.SCRIPT_PREFIX) // IDEMPIERE-7089-P2
 					? ProcessUtil.startScriptProcess(request.reportEngine().getCtx(), pi, trx)
 					: ProcessUtil.startJavaProcess(request.reportEngine().getCtx(), pi, trx, true);
 			if (!ok || pi.isError())

--- a/org.adempiere.report.jasper/src/org/adempiere/report/jasper/JasperReportContentRendererFactory.java
+++ b/org.adempiere.report.jasper/src/org/adempiere/report/jasper/JasperReportContentRendererFactory.java
@@ -126,7 +126,7 @@ public class JasperReportContentRendererFactory implements IReportContentRendere
 			instance.saveEx();
 			pi.setAD_PInstance_ID(instance.getAD_PInstance_ID());
 			Trx trx = pi.getTransactionName() != null ? Trx.get(pi.getTransactionName(), false) : null;
-			boolean ok = process.getClassname().toLowerCase().startsWith(MRule.SCRIPT_PREFIX)
+			boolean ok = process.getClassname().toLowerCase().startsWith(MRule.SCRIPT_PREFIX) // IDEMPIERE-7089-P2
 					? ProcessUtil.startScriptProcess(request.reportEngine().getCtx(), pi, trx)
 					: ProcessUtil.startJavaProcess(request.reportEngine().getCtx(), pi, trx, true);
 			if (!ok || pi.isError())

--- a/org.adempiere.report.jasper/src/org/adempiere/report/jasper/ReportStarter.java
+++ b/org.adempiere.report.jasper/src/org/adempiere/report/jasper/ReportStarter.java
@@ -333,8 +333,8 @@ public class ReportStarter implements ProcessCall, ClientProcess
 			//doesn't work for web, class resource and bundle resource
             for( int i=0; i<subreports.length; i++) {
             	// @Trifon - begin
-	if (subreports[i].getName().toLowerCase().endsWith(".jasper") // IDEMPIERE-7089-P3
-		|| subreports[i].getName().toLowerCase().endsWith(".jrxml")) // IDEMPIERE-7089-P3
+	if (subreports[i].getName().toLowerCase(java.util.Locale.ROOT).endsWith(".jasper") // IDEMPIERE-7089-P3
+		|| subreports[i].getName().toLowerCase(java.util.Locale.ROOT).endsWith(".jrxml")) // IDEMPIERE-7089-P3
             	{
                     JasperInfo subInfo = getJasperInfo( subreports[i] );
                     if (subInfo.getJasperReport()!=null) {
@@ -635,8 +635,8 @@ public class ReportStarter implements ProcessCall, ClientProcess
 				{
 					MTable table = new MTable(ctx, pi.getTable_ID(), trxName);
 					String tableName = table.getTableName();
-					String originalQueryTemp = originalQueryText.toUpperCase(); // IDEMPIERE-7089-P3
-					int index1 = originalQueryTemp.indexOf(" " + tableName.toUpperCase()); // IDEMPIERE-7089-P3
+					String originalQueryTemp = originalQueryText.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
+					int index1 = originalQueryTemp.indexOf(" " + tableName.toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 		    		if (index1 != -1)
 		    		{
 		    			int index2 = originalQueryTemp.substring(index1).indexOf(",");

--- a/org.adempiere.report.jasper/src/org/adempiere/report/jasper/ReportStarter.java
+++ b/org.adempiere.report.jasper/src/org/adempiere/report/jasper/ReportStarter.java
@@ -333,8 +333,8 @@ public class ReportStarter implements ProcessCall, ClientProcess
 			//doesn't work for web, class resource and bundle resource
             for( int i=0; i<subreports.length; i++) {
             	// @Trifon - begin
-            	if (subreports[i].getName().toLowerCase().endsWith(".jasper")
-            		|| subreports[i].getName().toLowerCase().endsWith(".jrxml"))
+	if (subreports[i].getName().toLowerCase().endsWith(".jasper") // IDEMPIERE-7089-P3
+		|| subreports[i].getName().toLowerCase().endsWith(".jrxml")) // IDEMPIERE-7089-P3
             	{
                     JasperInfo subInfo = getJasperInfo( subreports[i] );
                     if (subInfo.getJasperReport()!=null) {
@@ -635,8 +635,8 @@ public class ReportStarter implements ProcessCall, ClientProcess
 				{
 					MTable table = new MTable(ctx, pi.getTable_ID(), trxName);
 					String tableName = table.getTableName();
-		    		String originalQueryTemp = originalQueryText.toUpperCase();
-		    		int index1 = originalQueryTemp.indexOf(" " + tableName.toUpperCase());
+					String originalQueryTemp = originalQueryText.toUpperCase(); // IDEMPIERE-7089-P3
+					int index1 = originalQueryTemp.indexOf(" " + tableName.toUpperCase()); // IDEMPIERE-7089-P3
 		    		if (index1 != -1)
 		    		{
 		    			int index2 = originalQueryTemp.substring(index1).indexOf(",");

--- a/org.adempiere.server/src/main/server/org/compiere/server/EMailProcessor.java
+++ b/org.adempiere.server/src/main/server/org/compiere/server/EMailProcessor.java
@@ -684,7 +684,7 @@ public class EMailProcessor
 			printOut("Plain text ---------------------------");
 			System.out.println((String)p.getContent());
 		}
-		else if (p.getContentType().toUpperCase().startsWith("TEXT"))
+		else if (p.getContentType().toUpperCase().startsWith("TEXT")) // IDEMPIERE-7089-P2
 		{
 			printOut("Other text ---------------------------");
 			System.out.println((String)p.getContent());

--- a/org.adempiere.server/src/main/server/org/compiere/server/EMailProcessor.java
+++ b/org.adempiere.server/src/main/server/org/compiere/server/EMailProcessor.java
@@ -684,7 +684,7 @@ public class EMailProcessor
 			printOut("Plain text ---------------------------");
 			System.out.println((String)p.getContent());
 		}
-		else if (p.getContentType().toUpperCase().startsWith("TEXT")) // IDEMPIERE-7089-P2
+		else if (p.getContentType().toUpperCase(java.util.Locale.ROOT).startsWith("TEXT")) // IDEMPIERE-7089-P2
 		{
 			printOut("Other text ---------------------------");
 			System.out.println((String)p.getContent());

--- a/org.adempiere.server/src/main/server/org/compiere/server/RequestProcessor.java
+++ b/org.adempiere.server/src/main/server/org/compiere/server/RequestProcessor.java
@@ -623,7 +623,7 @@ public class RequestProcessor extends AdempiereServer
 		if (QText == null)
 			QText = "";
 		else
-			QText = QText.toUpperCase();
+			QText = QText.toUpperCase(); // IDEMPIERE-7089-P4
 		//
 		MRequestProcessorRoute[] routes = m_model.getRoutes(false);
 		for (int i = 0; i < routes.length; i++)
@@ -639,7 +639,7 @@ public class RequestProcessor extends AdempiereServer
 			String keyword = route.getKeyword();
 			if (keyword != null)
 			{
-				StringTokenizer st = new StringTokenizer(keyword.toUpperCase(), " ,;\t\n\r\f");
+				StringTokenizer st = new StringTokenizer(keyword.toUpperCase(), " ,;\t\n\r\f"); // IDEMPIERE-7089-P4
 				while (st.hasMoreElements())
 				{
 					if (QText.indexOf(st.nextToken()) != -1)

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/AdempiereIdGenerator.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/AdempiereIdGenerator.java
@@ -101,7 +101,7 @@ public class AdempiereIdGenerator implements IdGenerator {
 
 	private static String getWidgetName(String widgetClass) {
 		String name = widgetClass.substring(widgetClass.lastIndexOf(".")+1);
-		return name.toLowerCase(); // IDEMPIERE-7089-P2
+		return name.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P2
 	}
 
 	/**

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/AdempiereIdGenerator.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/AdempiereIdGenerator.java
@@ -101,7 +101,7 @@ public class AdempiereIdGenerator implements IdGenerator {
 
 	private static String getWidgetName(String widgetClass) {
 		String name = widgetClass.substring(widgetClass.lastIndexOf(".")+1);
-		return name.toLowerCase();
+		return name.toLowerCase(); // IDEMPIERE-7089-P2
 	}
 
 	/**

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/AdempiereWebUI.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/AdempiereWebUI.java
@@ -664,7 +664,7 @@ public class AdempiereWebUI extends Window implements EventListener<Event>, IWeb
 			clientInfo.timeZone = TimeZone.getTimeZone(c.getZoneId());			
 			String ua = Servlets.getUserAgent((ServletRequest) Executions.getCurrent().getNativeRequest());
 			clientInfo.userAgent = ua;
-			ua = ua.toLowerCase();
+			ua = ua.toLowerCase(); // IDEMPIERE-7089-P2
 			clientInfo.tablet = false;
 			if (Executions.getCurrent().getBrowser("mobile") !=null) {
 				clientInfo.tablet = true;

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/AdempiereWebUI.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/AdempiereWebUI.java
@@ -664,7 +664,7 @@ public class AdempiereWebUI extends Window implements EventListener<Event>, IWeb
 			clientInfo.timeZone = TimeZone.getTimeZone(c.getZoneId());			
 			String ua = Servlets.getUserAgent((ServletRequest) Executions.getCurrent().getNativeRequest());
 			clientInfo.userAgent = ua;
-			ua = ua.toLowerCase(); // IDEMPIERE-7089-P2
+			ua = ua.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P2
 			clientInfo.tablet = false;
 			if (Executions.getCurrent().getBrowser("mobile") !=null) {
 				clientInfo.tablet = true;

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/WLogin.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/WLogin.java
@@ -77,7 +77,7 @@ public class WLogin extends AbstractUIPart
 			mobile = true;
 		} else {
 			String ua = Servlets.getUserAgent((ServletRequest) Executions.getCurrent().getNativeRequest());
-			ua = ua.toLowerCase(); // IDEMPIERE-7089-P2
+			ua = ua.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P2
 			if (ua.contains("ipad") || ua.contains("iphone") || ua.contains("android"))
 				mobile = true;
 		}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/WLogin.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/WLogin.java
@@ -77,7 +77,7 @@ public class WLogin extends AbstractUIPart
 			mobile = true;
 		} else {
 			String ua = Servlets.getUserAgent((ServletRequest) Executions.getCurrent().getNativeRequest());
-			ua = ua.toLowerCase();
+			ua = ua.toLowerCase(); // IDEMPIERE-7089-P2
 			if (ua.contains("ipad") || ua.contains("iphone") || ua.contains("android"))
 				mobile = true;
 		}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/DocumentSearchController.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/DocumentSearchController.java
@@ -187,10 +187,10 @@ public class DocumentSearchController implements EventListener<Event> {
 				}
 			});
 
-			String matchString = searchString.toLowerCase();
+			String matchString = searchString.toLowerCase(); // IDEMPIERE-7089-P4
 			if (searchString != null && searchString.startsWith("/") && searchString.indexOf(" ") > 1) {
 				// "/TransactionCode Search Text"
-				matchString = searchString.substring(searchString.indexOf(" ") + 1).toLowerCase();
+				matchString = searchString.substring(searchString.indexOf(" ") + 1).toLowerCase(); // IDEMPIERE-7089-P4
 			}
 
 			String windowName = null;
@@ -420,7 +420,7 @@ public class DocumentSearchController implements EventListener<Event> {
 	 * @return true if added highlight span
 	 */
 	private boolean addHighlightSpan(String matchString, String inputString, StringBuilder sb) {
-		int match = inputString.toLowerCase().indexOf(matchString);
+		int match = inputString.toLowerCase().indexOf(matchString); // IDEMPIERE-7089-P4
 		boolean hasMatch = false;
 		while (match >= 0) {
 			hasMatch = true;
@@ -436,7 +436,7 @@ public class DocumentSearchController implements EventListener<Event> {
 				sb.append("</span>");
 				inputString = inputString.substring(matchString.length());
 			}
-			match = inputString.toLowerCase().indexOf(matchString);
+			match = inputString.toLowerCase().indexOf(matchString); // IDEMPIERE-7089-P4
 		}
 		if (inputString.length() > 0)
 			sb.append(inputString);
@@ -632,7 +632,7 @@ public class DocumentSearchController implements EventListener<Event> {
 		a.addEventListener(Events.ON_CLICK, this);
 		String label = result.getLabel();
 		if (!Util.isEmpty(matchString, true)) {
-			int match = label.toLowerCase().indexOf(matchString);
+			int match = label.toLowerCase().indexOf(matchString); // IDEMPIERE-7089-P4
 			while (match >= 0) {
 				if (match > 0) {
 					a.appendChild(new Label(label.substring(0, match)));
@@ -646,7 +646,7 @@ public class DocumentSearchController implements EventListener<Event> {
 					a.appendChild(l);
 					label = label.substring(matchString.length());
 				}
-				match = label.toLowerCase().indexOf(matchString);
+				match = label.toLowerCase().indexOf(matchString); // IDEMPIERE-7089-P4
 			}
 		}
 		if (label.length() > 0)
@@ -670,7 +670,7 @@ public class DocumentSearchController implements EventListener<Event> {
 			// "/TransactionCode Search Text"
 			transactionCode = searchString.substring(1, searchString.indexOf(" "));
 			searchString = searchString.substring(searchString.indexOf(" ") + 1);
-			whereClause.append("Upper(TransactionCode) = ?");
+			whereClause.append("Upper(TransactionCode) = Upper(?)");
 		} else {
 			// Search with definition that doesn't use transaction code
 			whereClause.append("TransactionCode IS NULL");
@@ -678,7 +678,7 @@ public class DocumentSearchController implements EventListener<Event> {
 
 		Query query = new Query(Env.getCtx(), I_AD_SearchDefinition.Table_Name, whereClause.toString(), null);
 		if (transactionCode != null)
-			query.setParameters(transactionCode.toUpperCase());
+			query.setParameters(transactionCode); // IDEMPIERE-7089-P1
 		List<MSearchDefinition> definitions = query.setOnlyActiveRecords(true).list();
 
 		List<ISearchProvider> providers = Core.getSearchProviders();
@@ -735,7 +735,7 @@ public class DocumentSearchController implements EventListener<Event> {
 		String text = textbox.getText();
 		if (Util.isEmpty(text))
 			return false;
-		text = text.toLowerCase();
+		text = text.toLowerCase(); // IDEMPIERE-7089-P4
 		int size = layout.getChildren().size();
 		A firstStart = null;
 		A exact = null;
@@ -750,7 +750,7 @@ public class DocumentSearchController implements EventListener<Event> {
 			} else if (text.equalsIgnoreCase(result.getName())) {
 				exact = a;
 				break;
-			} else if (firstStart == null && result.getLabel().toLowerCase().startsWith(text) && text.length() >= 3) {
+			} else if (firstStart == null && result.getLabel().toLowerCase().startsWith(text) && text.length() >= 3) { // IDEMPIERE-7089-P4
 				firstStart = a;
 			}
 		}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/LabelsSearchController.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/LabelsSearchController.java
@@ -194,7 +194,7 @@ public class LabelsSearchController implements EventListener<Event>{
 					LabelItem i = new LabelItem(rs.getInt(1), rs.getString(2), rs.getInt(3), rs.getBoolean(4));
 					newModel.add(i);
 					
-					if (rs.getString(2).toUpperCase().equals(value.toUpperCase())) {
+					if (rs.getString(2).toUpperCase().equals(value.toUpperCase())) { // IDEMPIERE-7089-P4
 						found = true;
 						foundIndex = currentIndex;
 					}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/MenuSearchController.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/MenuSearchController.java
@@ -587,10 +587,10 @@ public class MenuSearchController implements EventListener<Event>{
 				return -1;
 			
 			String label2 = o2.getLabel();
-			label2 = Util.deleteAccents(label2.toLowerCase());
+			label2 = Util.deleteAccents(label2.toLowerCase()); // IDEMPIERE-7089-P4
 			
 			String compare = o1.getLabel();			
-			compare = Util.deleteAccents(compare.toLowerCase());
+			compare = Util.deleteAccents(compare.toLowerCase()); // IDEMPIERE-7089-P4
 			
 			boolean match = false;
 			if (compare.length() < 3)
@@ -659,7 +659,7 @@ public class MenuSearchController implements EventListener<Event>{
 		String text = textbox.getText();
 		if (Util.isEmpty(text))
 			return false;
-		text = text.toLowerCase();
+		text = text.toLowerCase(); // IDEMPIERE-7089-P4
 		ListItem exact = null;
 		ListItem firstStart = null;
 		int count = listbox.getItemCount();
@@ -672,7 +672,7 @@ public class MenuSearchController implements EventListener<Event>{
 			if (label.equalsIgnoreCase(text)) {
 				exact = item;
 				break;
-			} else if (firstStart == null && label.toLowerCase().startsWith(text) && text.length() >= 3) {
+			} else if (firstStart == null && label.toLowerCase().startsWith(text) && text.length() >= 3) { // IDEMPIERE-7089-P4
 				firstStart = item;
 			}
 		}
@@ -730,13 +730,13 @@ public class MenuSearchController implements EventListener<Event>{
 			}
 			
 			// Highlight search text
-			if (!Util.isEmpty(highlightText, true) && Util.deleteAccents(data.getLabel()).toLowerCase().contains(Util.deleteAccents(highlightText).toLowerCase())) {
+			if (!Util.isEmpty(highlightText, true) && Util.deleteAccents(data.getLabel()).toLowerCase().contains(Util.deleteAccents(highlightText).toLowerCase())) { // IDEMPIERE-7089-P4
 				// Space to maintain proper gap between icon and label
 				cell.setLabel(" ");
 				String label = data.getLabel();
 				String unaccentedLabel = Util.deleteAccents(label);
-				String matchString = Util.deleteAccents(highlightText.toLowerCase());
-				int match = unaccentedLabel.toLowerCase().indexOf(matchString);
+				String matchString = Util.deleteAccents(highlightText.toLowerCase()); // IDEMPIERE-7089-P4
+				int match = unaccentedLabel.toLowerCase().indexOf(matchString); // IDEMPIERE-7089-P4
     			while (match >= 0) {
     				if (match > 0) {
     					cell.appendChild(new Label(label.substring(0, match)));
@@ -752,7 +752,7 @@ public class MenuSearchController implements EventListener<Event>{
     					unaccentedLabel = unaccentedLabel.substring(matchString.length());
     					label = label.substring(matchString.length());
     				}
-    				match = unaccentedLabel.toLowerCase().indexOf(matchString);
+				match = unaccentedLabel.toLowerCase().indexOf(matchString); // IDEMPIERE-7089-P4
     			}
     			if (label.length() > 0)
     				cell.appendChild(new Label(label));

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WArchiveViewer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WArchiveViewer.java
@@ -158,7 +158,7 @@ public class WArchiveViewer extends Archive implements IFormController, EventLis
 				try {
 					dynInit();
 					zkInit();
-					if (   media != null && iframe.getSrc() == null && media.getName().toLowerCase().endsWith(".pdf") // IDEMPIERE-7089-P2
+					if (   media != null && iframe.getSrc() == null && media.getName().toLowerCase(java.util.Locale.ROOT).endsWith(".pdf") // IDEMPIERE-7089-P2
 						&& (ClientInfo.isMobile() || MSysConfig.getBooleanValue(MSysConfig.ZK_USE_PDF_JS_VIEWER, false, Env.getAD_Client_ID(Env.getCtx())))) {
 						String url = Utils.getDynamicMediaURI(form, mediaVersion, media.getName(), media.getFormat());
 						String pdfJsUrl = AEnv.toPdfJsUrl(url);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WArchiveViewer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WArchiveViewer.java
@@ -158,7 +158,7 @@ public class WArchiveViewer extends Archive implements IFormController, EventLis
 				try {
 					dynInit();
 					zkInit();
-					if (   media != null && iframe.getSrc() == null && media.getName().toLowerCase().endsWith(".pdf")
+					if (   media != null && iframe.getSrc() == null && media.getName().toLowerCase().endsWith(".pdf") // IDEMPIERE-7089-P2
 						&& (ClientInfo.isMobile() || MSysConfig.getBooleanValue(MSysConfig.ZK_USE_PDF_JS_VIEWER, false, Env.getAD_Client_ID(Env.getCtx())))) {
 						String url = Utils.getDynamicMediaURI(form, mediaVersion, media.getName(), media.getFormat());
 						String pdfJsUrl = AEnv.toPdfJsUrl(url);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WPluginManager.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WPluginManager.java
@@ -295,7 +295,7 @@ public class WPluginManager extends ADForm implements EventListener<Event> {
 		BundleContext bundleCtx = WebUIActivator.getBundleContext();
 		for (Bundle bundle : bundleCtx.getBundles()) {
 
-			if (!Util.isEmpty(fFilter.getValue()) && !bundle.getSymbolicName().toUpperCase().contains(fFilter.getValue().toUpperCase())) // IDEMPIERE-7089-P2
+			if (!Util.isEmpty(fFilter.getValue()) && !bundle.getSymbolicName().toUpperCase(java.util.Locale.ROOT).contains(fFilter.getValue().toUpperCase(java.util.Locale.ROOT))) // IDEMPIERE-7089-P2
 				continue;
 
 			Vector<Object> line = new Vector<Object>();

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WPluginManager.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WPluginManager.java
@@ -295,7 +295,7 @@ public class WPluginManager extends ADForm implements EventListener<Event> {
 		BundleContext bundleCtx = WebUIActivator.getBundleContext();
 		for (Bundle bundle : bundleCtx.getBundles()) {
 
-			if (!Util.isEmpty(fFilter.getValue()) && !bundle.getSymbolicName().toUpperCase().contains(fFilter.getValue().toUpperCase()))
+			if (!Util.isEmpty(fFilter.getValue()) && !bundle.getSymbolicName().toUpperCase().contains(fFilter.getValue().toUpperCase())) // IDEMPIERE-7089-P2
 				continue;
 
 			Vector<Object> line = new Vector<Object>();

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WSQLProcess.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WSQLProcess.java
@@ -226,7 +226,7 @@ public class WSQLProcess extends ADForm implements EventListener<Event>
 		StringBuilder result = new StringBuilder("SQL> ")
 				.append(sql)
 				.append(Env.NL);
-		String SQL = sql.toUpperCase(); // IDEMPIERE-7089-P3
+		String SQL = sql.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 		String cleanSQL = SQL
 				.replaceAll(REGEX_REMOVE_COMMENTS, "")
 				.replaceAll(REGEX_REMOVE_QUOTED_STRINGS, "")

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WSQLProcess.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WSQLProcess.java
@@ -226,7 +226,7 @@ public class WSQLProcess extends ADForm implements EventListener<Event>
 		StringBuilder result = new StringBuilder("SQL> ")
 				.append(sql)
 				.append(Env.NL);
-		String SQL = sql.toUpperCase();
+		String SQL = sql.toUpperCase(); // IDEMPIERE-7089-P3
 		String cleanSQL = SQL
 				.replaceAll(REGEX_REMOVE_COMMENTS, "")
 				.replaceAll(REGEX_REMOVE_QUOTED_STRINGS, "")

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WSQLQuery.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WSQLQuery.java
@@ -206,7 +206,7 @@ public class WSQLQuery extends ADForm implements EventListener<Event>
 			return "";
 		//
 		StringBuilder result = new StringBuilder();
-		String SQL = sql.toUpperCase();
+		String SQL = sql.toUpperCase(); // IDEMPIERE-7089-P3
 		String cleanSQL = SQL
 				.replaceAll(REGEX_REMOVE_COMMENTS, "")
 				.replaceAll(REGEX_REMOVE_QUOTED_STRINGS, "")
@@ -270,7 +270,7 @@ public class WSQLQuery extends ADForm implements EventListener<Event>
 				List<Object> row = new ArrayList<Object>();
 				row.add(++count);
 				for (int col = 1; col <= meta.getColumnCount(); col++) {
-					String colName = header.get(col).toLowerCase();
+					String colName = header.get(col).toLowerCase(); // IDEMPIERE-7089-P3
 					if (rs.getObject(col) instanceof BigDecimal
 						&& (colName.endsWith("_id") || colName.equals("createdby") || colName.equals("updatedby")))
 						row.add(rs.getInt(col));

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WSQLQuery.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WSQLQuery.java
@@ -206,7 +206,7 @@ public class WSQLQuery extends ADForm implements EventListener<Event>
 			return "";
 		//
 		StringBuilder result = new StringBuilder();
-		String SQL = sql.toUpperCase(); // IDEMPIERE-7089-P3
+		String SQL = sql.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 		String cleanSQL = SQL
 				.replaceAll(REGEX_REMOVE_COMMENTS, "")
 				.replaceAll(REGEX_REMOVE_QUOTED_STRINGS, "")
@@ -270,7 +270,7 @@ public class WSQLQuery extends ADForm implements EventListener<Event>
 				List<Object> row = new ArrayList<Object>();
 				row.add(++count);
 				for (int col = 1; col <= meta.getColumnCount(); col++) {
-					String colName = header.get(col).toLowerCase(); // IDEMPIERE-7089-P3
+					String colName = header.get(col).toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 					if (rs.getObject(col) instanceof BigDecimal
 						&& (colName.endsWith("_id") || colName.equals("createdby") || colName.equals("updatedby")))
 						row.add(rs.getInt(col));

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WTreeMaintenance.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/form/WTreeMaintenance.java
@@ -322,7 +322,7 @@ public class WTreeMaintenance extends TreeMaintenance implements IFormController
 	 */
 	private void searchElement() {
 		String filter = searchBox.getText() == null ? "" : searchBox.getText();
-		filter = Util.deleteAccents(filter.trim().toUpperCase());
+		filter = Util.deleteAccents(filter.trim().toUpperCase()); // IDEMPIERE-7089-P4
 		action_loadTree(filter);
 	}
 
@@ -363,7 +363,7 @@ public class WTreeMaintenance extends TreeMaintenance implements IFormController
 			if (Util.isEmpty(filter)) {
 				model.addElement(item);
 			} else {
-				String valueItem = item.toString() == null ? "" : Util.deleteAccents(item.toString().toUpperCase());
+				String valueItem = item.toString() == null ? "" : Util.deleteAccents(item.toString().toUpperCase()); // IDEMPIERE-7089-P4
 				if (valueItem.contains(filter)) {
 					model.addElement(item);
 				}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/AutoComplete.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/AutoComplete.java
@@ -172,7 +172,7 @@ public class AutoComplete extends Combobox
 			return;
 		}
 		
-		String compare = val.toLowerCase().trim();
+		String compare = val.toLowerCase().trim(); // IDEMPIERE-7089-P4
 		
 		Iterator<?> it = getItems().iterator();
 		for (int i = 0; i < comboItems.length; i++)
@@ -180,11 +180,11 @@ public class AutoComplete extends Combobox
 			boolean match = false;
 			if (compare.length() < 3)
 			{
-				match = comboItems[i].toLowerCase().startsWith(compare);
+				match = comboItems[i].toLowerCase().startsWith(compare); // IDEMPIERE-7089-P4
 			}
 			else
 			{
-				match = comboItems[i].toLowerCase().contains(compare);
+				match = comboItems[i].toLowerCase().contains(compare); // IDEMPIERE-7089-P4
 			}
 			if (match)
 			{

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/FlexHlayout.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/FlexHlayout.java
@@ -35,7 +35,7 @@ public class FlexHlayout extends org.zkoss.zul.Hlayout {
 	public void setPack(String pack) {
 		if (pack == null) return;
 	    try {
-	        setPack(PackType.valueOf(pack.toUpperCase()));
+	        setPack(PackType.valueOf(pack.toUpperCase())); // IDEMPIERE-7089-P2
 	    } catch (IllegalArgumentException e) {
 	    	throw new IllegalArgumentException("Unknown pack type=" + pack);
 	    }
@@ -49,7 +49,7 @@ public class FlexHlayout extends org.zkoss.zul.Hlayout {
 	public void setAlign(String align) {
 		if (align == null) return;
 	    try {
-	    	setAlign(AlignType.valueOf(align.toUpperCase()));
+		setAlign(AlignType.valueOf(align.toUpperCase())); // IDEMPIERE-7089-P2
 	    } catch (IllegalArgumentException e) {
 	    	throw new IllegalArgumentException("Unknown align type=" + align);
 	    }

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/FlexHlayout.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/FlexHlayout.java
@@ -35,7 +35,7 @@ public class FlexHlayout extends org.zkoss.zul.Hlayout {
 	public void setPack(String pack) {
 		if (pack == null) return;
 	    try {
-	        setPack(PackType.valueOf(pack.toUpperCase())); // IDEMPIERE-7089-P2
+	        setPack(PackType.valueOf(pack.toUpperCase(java.util.Locale.ROOT))); // IDEMPIERE-7089-P2
 	    } catch (IllegalArgumentException e) {
 	    	throw new IllegalArgumentException("Unknown pack type=" + pack);
 	    }
@@ -49,7 +49,7 @@ public class FlexHlayout extends org.zkoss.zul.Hlayout {
 	public void setAlign(String align) {
 		if (align == null) return;
 	    try {
-		setAlign(AlignType.valueOf(align.toUpperCase())); // IDEMPIERE-7089-P2
+		setAlign(AlignType.valueOf(align.toUpperCase(java.util.Locale.ROOT))); // IDEMPIERE-7089-P2
 	    } catch (IllegalArgumentException e) {
 	    	throw new IllegalArgumentException("Unknown align type=" + align);
 	    }

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/FlexVlayout.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/FlexVlayout.java
@@ -35,7 +35,7 @@ public class FlexVlayout extends org.zkoss.zul.Vlayout {
 	public void setPack(String pack) {
 		if (pack == null) return;
 	    try {
-	        setPack(PackType.valueOf(pack.toUpperCase()));
+	        setPack(PackType.valueOf(pack.toUpperCase())); // IDEMPIERE-7089-P2
 	    } catch (IllegalArgumentException e) {
 	    	throw new IllegalArgumentException("Unknown pack type=" + pack);
 	    }
@@ -49,7 +49,7 @@ public class FlexVlayout extends org.zkoss.zul.Vlayout {
 	public void setAlign(String align) {
 		if (align == null) return;
 	    try {
-	    	setAlign(AlignType.valueOf(align.toUpperCase()));
+		setAlign(AlignType.valueOf(align.toUpperCase())); // IDEMPIERE-7089-P2
 	    } catch (IllegalArgumentException e) {
 	    	throw new IllegalArgumentException("Unknown align type=" + align);
 	    }

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/FlexVlayout.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/FlexVlayout.java
@@ -35,7 +35,7 @@ public class FlexVlayout extends org.zkoss.zul.Vlayout {
 	public void setPack(String pack) {
 		if (pack == null) return;
 	    try {
-	        setPack(PackType.valueOf(pack.toUpperCase())); // IDEMPIERE-7089-P2
+	        setPack(PackType.valueOf(pack.toUpperCase(java.util.Locale.ROOT))); // IDEMPIERE-7089-P2
 	    } catch (IllegalArgumentException e) {
 	    	throw new IllegalArgumentException("Unknown pack type=" + pack);
 	    }
@@ -49,7 +49,7 @@ public class FlexVlayout extends org.zkoss.zul.Vlayout {
 	public void setAlign(String align) {
 		if (align == null) return;
 	    try {
-		setAlign(AlignType.valueOf(align.toUpperCase())); // IDEMPIERE-7089-P2
+		setAlign(AlignType.valueOf(align.toUpperCase(java.util.Locale.ROOT))); // IDEMPIERE-7089-P2
 	    } catch (IllegalArgumentException e) {
 	    	throw new IllegalArgumentException("Unknown align type=" + align);
 	    }

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/WAppsAction.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/WAppsAction.java
@@ -77,7 +77,7 @@ public class WAppsAction
        int pos = newToolTipText.indexOf('&');
        if (pos != -1  && newToolTipText.length() > pos)   //  We have a nemonic - creates ALT-_
        {
-           Character ch = Character.valueOf(newToolTipText.toLowerCase().charAt(pos + 1));
+           Character ch = Character.valueOf(newToolTipText.toLowerCase().charAt(pos + 1)); // IDEMPIERE-7089-P4
            if (ch != ' ')
            {
                // remove ampersand

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WEditor.java
@@ -745,10 +745,10 @@ public abstract class WEditor implements EventListener<Event>, PropertyChangeLis
 	 */
 	protected void setLabelStyle(String style) {
 		if (label != null) {
-			if (style != null && style.toLowerCase().startsWith(MStyle.SCLASS_PREFIX)) {
+			if (style != null && style.toLowerCase().startsWith(MStyle.SCLASS_PREFIX)) { // IDEMPIERE-7089-P2
 				String sclass = style.substring(MStyle.SCLASS_PREFIX.length());
 				label.setSclass(sclass);
-			} else if (style != null && style.toLowerCase().startsWith(MStyle.ZCLASS_PREFIX)) {
+			} else if (style != null && style.toLowerCase().startsWith(MStyle.ZCLASS_PREFIX)) { // IDEMPIERE-7089-P2
 				String zclass = style.substring(MStyle.ZCLASS_PREFIX.length());
 				label.setZclass(zclass);
 			} else {

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WEditor.java
@@ -745,10 +745,10 @@ public abstract class WEditor implements EventListener<Event>, PropertyChangeLis
 	 */
 	protected void setLabelStyle(String style) {
 		if (label != null) {
-			if (style != null && style.toLowerCase().startsWith(MStyle.SCLASS_PREFIX)) { // IDEMPIERE-7089-P2
+			if (style != null && style.toLowerCase(java.util.Locale.ROOT).startsWith(MStyle.SCLASS_PREFIX)) { // IDEMPIERE-7089-P2
 				String sclass = style.substring(MStyle.SCLASS_PREFIX.length());
 				label.setSclass(sclass);
-			} else if (style != null && style.toLowerCase().startsWith(MStyle.ZCLASS_PREFIX)) { // IDEMPIERE-7089-P2
+			} else if (style != null && style.toLowerCase(java.util.Locale.ROOT).startsWith(MStyle.ZCLASS_PREFIX)) { // IDEMPIERE-7089-P2
 				String zclass = style.substring(MStyle.ZCLASS_PREFIX.length());
 				label.setZclass(zclass);
 			} else {

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WTableDirEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WTableDirEditor.java
@@ -305,7 +305,7 @@ ContextMenuListener, IZoomableEditor
 		if(getGridField() != null && getGridField().getGridTab() != null && getGridField().getColumnName().endsWith("_ID") 
 				&& MRole.getDefault().isCanReport(getGridField().getGridTab().getAD_Table_ID()))
 			enableDrill = true;
-        if (tableName.toUpperCase().equals("C_BPARTNER_LOCATION"))    				
+        if (tableName.toUpperCase().equals("C_BPARTNER_LOCATION"))    				 // IDEMPIERE-7089-P3
 		{
 			popupMenu = new WEditorPopupMenu(true, true, isShowPreference(), false, false, true, enableDrill, lookup);
 		} else {

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WTableDirEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/editor/WTableDirEditor.java
@@ -305,7 +305,7 @@ ContextMenuListener, IZoomableEditor
 		if(getGridField() != null && getGridField().getGridTab() != null && getGridField().getColumnName().endsWith("_ID") 
 				&& MRole.getDefault().isCanReport(getGridField().getGridTab().getAD_Table_ID()))
 			enableDrill = true;
-        if (tableName.toUpperCase().equals("C_BPARTNER_LOCATION"))    				 // IDEMPIERE-7089-P3
+        if (tableName.toUpperCase(java.util.Locale.ROOT).equals("C_BPARTNER_LOCATION"))    				 // IDEMPIERE-7089-P3
 		{
 			popupMenu = new WEditorPopupMenu(true, true, isShowPreference(), false, false, true, enableDrill, lookup);
 		} else {

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/ButtonFactory.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/ButtonFactory.java
@@ -98,7 +98,7 @@ public class ButtonFactory {
         }
                 
         //add named class for further customization option 
-        String className = "btn-" + name.toLowerCase(); // IDEMPIERE-7089-P2
+        String className = "btn-" + name.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P2
         LayoutUtils.addSclass(className, button);
         if (ThemeManager.isUseFontIconForImage())
         	LayoutUtils.addSclass("font-icon-button", button);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/ButtonFactory.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/ButtonFactory.java
@@ -98,7 +98,7 @@ public class ButtonFactory {
         }
                 
         //add named class for further customization option 
-        String className = "btn-" + name.toLowerCase();
+        String className = "btn-" + name.toLowerCase(); // IDEMPIERE-7089-P2
         LayoutUtils.addSclass(className, button);
         if (ThemeManager.isUseFontIconForImage())
         	LayoutUtils.addSclass("font-icon-button", button);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/ZulDashboardGadgetFactory.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/ZulDashboardGadgetFactory.java
@@ -29,7 +29,7 @@ import org.zkoss.zk.ui.Executions;
 public class ZulDashboardGadgetFactory implements IDashboardGadgetFactory {
 	@Override
 	public Component getGadget(String uri, Component parent) {
-		if (uri != null && uri.toLowerCase().endsWith(".zul")) { // IDEMPIERE-7089-P2
+		if (uri != null && uri.toLowerCase(java.util.Locale.ROOT).endsWith(".zul")) { // IDEMPIERE-7089-P2
 	        IResourceFinder rf = Core.getResourceFinder();
 	        URL url =  rf.getResource(uri);
 	        if(url!=null)

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/ZulDashboardGadgetFactory.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/ZulDashboardGadgetFactory.java
@@ -29,7 +29,7 @@ import org.zkoss.zk.ui.Executions;
 public class ZulDashboardGadgetFactory implements IDashboardGadgetFactory {
 	@Override
 	public Component getGadget(String uri, Component parent) {
-		if (uri != null && uri.toLowerCase().endsWith(".zul")) {
+		if (uri != null && uri.toLowerCase().endsWith(".zul")) { // IDEMPIERE-7089-P2
 	        IResourceFinder rf = Core.getResourceFinder();
 	        URL url =  rf.getResource(uri);
 	        if(url!=null)

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
@@ -1189,7 +1189,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 			{
 				ColumnInfo columnInfo = null;
 				String colSQL = infoColumn.getSelectClause();
-				if (! colSQL.toUpperCase().contains(" AS ")) // IDEMPIERE-7089-P3
+				if (! colSQL.toUpperCase(java.util.Locale.ROOT).contains(" AS ")) // IDEMPIERE-7089-P3
 					colSQL += " AS " + infoColumn.getColumnName();
 				if (infoColumn.getAD_Reference_ID() == DisplayType.ID) 
 				{
@@ -1292,7 +1292,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
         editor.setReadWrite(false);
 
 		String colSQL = infoColumn.getSelectClause();
-		if (! colSQL.toUpperCase().contains(" AS ")) // IDEMPIERE-7089-P3
+		if (! colSQL.toUpperCase(java.util.Locale.ROOT).contains(" AS ")) // IDEMPIERE-7089-P3
 			colSQL += " AS " + infoColumn.getColumnName();
         editorMap.put(colSQL, editor);
         Class<?> colClass = columnName.endsWith("_ID") || columnName.equals("CreatedBy") || columnName.equals("UpdatedBy") ? KeyNamePair.class : String.class;
@@ -1420,7 +1420,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 					continue;
 				}
 				String columnName = InfoColumnVO.getSelectClause();
-				int asIndex = columnName.toUpperCase().lastIndexOf(" AS "); // IDEMPIERE-7089-P3
+				int asIndex = columnName.toUpperCase(java.util.Locale.ROOT).lastIndexOf(" AS "); // IDEMPIERE-7089-P3
 				if (asIndex > 0) {
 					columnName = columnName.substring(0, asIndex);
 				}
@@ -1499,7 +1499,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 						builder.append(columnClause)
 							   .append(" ")
 							   .append(InfoColumnVO.getQueryOperator());
-						if (columnClause.toUpperCase().startsWith("UPPER(")) { // IDEMPIERE-7089-P3
+						if (columnClause.toUpperCase(java.util.Locale.ROOT).startsWith("UPPER(")) { // IDEMPIERE-7089-P3
 							builder.append(" UPPER(?)");
 						} else {
 							builder.append(" ?");
@@ -1511,7 +1511,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 							builder.append(columnClause)
 							.append(" ")
 							.append(X_AD_InfoColumn.QUERYOPERATOR_GtEq);
-							if (columnClause.toUpperCase().startsWith("UPPER(")) { // IDEMPIERE-7089-P3
+							if (columnClause.toUpperCase(java.util.Locale.ROOT).startsWith("UPPER(")) { // IDEMPIERE-7089-P3
 								builder.append(" UPPER(?)");
 							} else {
 								builder.append(" ?");
@@ -1525,7 +1525,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 							builder.append(columnClause)
 							.append(" ")
 							.append(X_AD_InfoColumn.QUERYOPERATOR_LeEq);
-							if (columnClause.toUpperCase().startsWith("UPPER(")) { // IDEMPIERE-7089-P3
+							if (columnClause.toUpperCase(java.util.Locale.ROOT).startsWith("UPPER(")) { // IDEMPIERE-7089-P3
 								builder.append(" UPPER(?)");
 							} else {
 								builder.append(" ?");
@@ -2562,7 +2562,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 					parenthesisLevel++;
 	
 				// RegEx ^(\s+FROM)(\s) checks for <whitespace>FROM<whitespace> pattern
-				if(sql.substring(i, i+6).toUpperCase().matches("^(\\s+FROM)(\\s)") && parenthesisLevel == 0) // IDEMPIERE-7089-P3
+				if(sql.substring(i, i+6).toUpperCase(java.util.Locale.ROOT).matches("^(\\s+FROM)(\\s)") && parenthesisLevel == 0) // IDEMPIERE-7089-P3
 					return i;
 		}
 	
@@ -2978,7 +2978,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 			{
 				ColumnInfo columnInfo = null;
 				String colSQL = infoColumn.getSelectClause();
-				if (! colSQL.toUpperCase().contains(" AS ")) // IDEMPIERE-7089-P3
+				if (! colSQL.toUpperCase(java.util.Locale.ROOT).contains(" AS ")) // IDEMPIERE-7089-P3
 					colSQL += " AS " + infoColumn.getColumnName();
 				if (infoColumn.getAD_Reference_ID() == DisplayType.ID)
 				{

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java
@@ -1189,7 +1189,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 			{
 				ColumnInfo columnInfo = null;
 				String colSQL = infoColumn.getSelectClause();
-				if (! colSQL.toUpperCase().contains(" AS "))
+				if (! colSQL.toUpperCase().contains(" AS ")) // IDEMPIERE-7089-P3
 					colSQL += " AS " + infoColumn.getColumnName();
 				if (infoColumn.getAD_Reference_ID() == DisplayType.ID) 
 				{
@@ -1292,7 +1292,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
         editor.setReadWrite(false);
 
 		String colSQL = infoColumn.getSelectClause();
-		if (! colSQL.toUpperCase().contains(" AS "))
+		if (! colSQL.toUpperCase().contains(" AS ")) // IDEMPIERE-7089-P3
 			colSQL += " AS " + infoColumn.getColumnName();
         editorMap.put(colSQL, editor);
         Class<?> colClass = columnName.endsWith("_ID") || columnName.equals("CreatedBy") || columnName.equals("UpdatedBy") ? KeyNamePair.class : String.class;
@@ -1420,7 +1420,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 					continue;
 				}
 				String columnName = InfoColumnVO.getSelectClause();
-				int asIndex = columnName.toUpperCase().lastIndexOf(" AS ");
+				int asIndex = columnName.toUpperCase().lastIndexOf(" AS "); // IDEMPIERE-7089-P3
 				if (asIndex > 0) {
 					columnName = columnName.substring(0, asIndex);
 				}
@@ -1446,7 +1446,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 					String column = columnName;
 					if (column.indexOf(".") > 0)
 						column = column.substring(column.indexOf(".")+1);
-					int cnt = DB.getSQLValueEx(null, "SELECT Count(*) From AD_Column WHERE IsActive='Y' AND AD_Client_ID=0 AND Upper(ColumnName)=? AND AD_Reference_ID=?", column.toUpperCase(), DisplayType.ChosenMultipleSelectionList);
+					int cnt = DB.getSQLValueEx(null, "SELECT Count(*) From AD_Column WHERE IsActive='Y' AND AD_Client_ID=0 AND Upper(ColumnName)=Upper(?) AND AD_Reference_ID=?", column, DisplayType.ChosenMultipleSelectionList); // IDEMPIERE-7089-P1
 					if (cnt > 0)
 					{
 						SQLFragment filter = DB.intersectFilterForCSV(columnName, pString);
@@ -1499,7 +1499,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 						builder.append(columnClause)
 							   .append(" ")
 							   .append(InfoColumnVO.getQueryOperator());
-						if (columnClause.toUpperCase().startsWith("UPPER(")) {
+						if (columnClause.toUpperCase().startsWith("UPPER(")) { // IDEMPIERE-7089-P3
 							builder.append(" UPPER(?)");
 						} else {
 							builder.append(" ?");
@@ -1511,7 +1511,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 							builder.append(columnClause)
 							.append(" ")
 							.append(X_AD_InfoColumn.QUERYOPERATOR_GtEq);
-							if (columnClause.toUpperCase().startsWith("UPPER(")) {
+							if (columnClause.toUpperCase().startsWith("UPPER(")) { // IDEMPIERE-7089-P3
 								builder.append(" UPPER(?)");
 							} else {
 								builder.append(" ?");
@@ -1525,7 +1525,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 							builder.append(columnClause)
 							.append(" ")
 							.append(X_AD_InfoColumn.QUERYOPERATOR_LeEq);
-							if (columnClause.toUpperCase().startsWith("UPPER(")) {
+							if (columnClause.toUpperCase().startsWith("UPPER(")) { // IDEMPIERE-7089-P3
 								builder.append(" UPPER(?)");
 							} else {
 								builder.append(" ?");
@@ -2562,7 +2562,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 					parenthesisLevel++;
 	
 				// RegEx ^(\s+FROM)(\s) checks for <whitespace>FROM<whitespace> pattern
-				if(sql.substring(i, i+6).toUpperCase().matches("^(\\s+FROM)(\\s)") && parenthesisLevel == 0)
+				if(sql.substring(i, i+6).toUpperCase().matches("^(\\s+FROM)(\\s)") && parenthesisLevel == 0) // IDEMPIERE-7089-P3
 					return i;
 		}
 	
@@ -2978,7 +2978,7 @@ public class InfoWindow extends InfoPanel implements ValueChangeListener, EventL
 			{
 				ColumnInfo columnInfo = null;
 				String colSQL = infoColumn.getSelectClause();
-				if (! colSQL.toUpperCase().contains(" AS "))
+				if (! colSQL.toUpperCase().contains(" AS ")) // IDEMPIERE-7089-P3
 					colSQL += " AS " + infoColumn.getColumnName();
 				if (infoColumn.getAD_Reference_ID() == DisplayType.ID)
 				{

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/RelatedInfoWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/RelatedInfoWindow.java
@@ -539,7 +539,7 @@ public class RelatedInfoWindow implements EventListener<Event>, Sortable<Object>
 			{
 				String tmp = colsql.substring(0, lastSpaceIdx).trim();
 				char last = tmp.charAt(tmp.length() - 1);
-				if (tmp.toLowerCase().endsWith("as")) // IDEMPIERE-7089-P3
+				if (tmp.toLowerCase(java.util.Locale.ROOT).endsWith("as")) // IDEMPIERE-7089-P3
 				{
 					colsql = colsql.substring(lastSpaceIdx).trim();
 				}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/RelatedInfoWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/RelatedInfoWindow.java
@@ -539,7 +539,7 @@ public class RelatedInfoWindow implements EventListener<Event>, Sortable<Object>
 			{
 				String tmp = colsql.substring(0, lastSpaceIdx).trim();
 				char last = tmp.charAt(tmp.length() - 1);
-				if (tmp.toLowerCase().endsWith("as"))
+				if (tmp.toLowerCase().endsWith("as")) // IDEMPIERE-7089-P3
 				{
 					colsql = colsql.substring(lastSpaceIdx).trim();
 				}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoPanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoPanel.java
@@ -1541,7 +1541,7 @@ public abstract class InfoPanel extends Window implements EventListener<Event>, 
 			String alias = colsql.substring(lastSpaceIdx).trim();
 			boolean hasAlias = alias.matches("^[a-zA-Z_][a-zA-Z0-9_]*$"); // valid SQL alias - starts with letter then digits, letters, underscore
 
-			if (tmp.toLowerCase().endsWith("as") && hasAlias)
+			if (tmp.toLowerCase().endsWith("as") && hasAlias) // IDEMPIERE-7089-P3
 			{
 				colsql = alias;
 			}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoPanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/InfoPanel.java
@@ -1541,7 +1541,7 @@ public abstract class InfoPanel extends Window implements EventListener<Event>, 
 			String alias = colsql.substring(lastSpaceIdx).trim();
 			boolean hasAlias = alias.matches("^[a-zA-Z_][a-zA-Z0-9_]*$"); // valid SQL alias - starts with letter then digits, letters, underscore
 
-			if (tmp.toLowerCase().endsWith("as") && hasAlias) // IDEMPIERE-7089-P3
+			if (tmp.toLowerCase(java.util.Locale.ROOT).endsWith("as") && hasAlias) // IDEMPIERE-7089-P3
 			{
 				colsql = alias;
 			}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/LoginPanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/LoginPanel.java
@@ -894,15 +894,15 @@ public class LoginPanel extends Window implements EventListener<Event>
 				s = s.trim();
 				if (!s.startsWith("q=")) {
 					if (s.contains("_") && s.length() == 5) {
-						String baselang = s.substring(0, 2).toLowerCase();
-						StringBuffer lang = new StringBuffer(baselang).append("_").append(s.substring(3).toUpperCase());
+						String baselang = s.substring(0, 2).toLowerCase(); // IDEMPIERE-7089-P2
+						StringBuffer lang = new StringBuffer(baselang).append("_").append(s.substring(3).toUpperCase()); // IDEMPIERE-7089-P2
 						if (!arrstr.contains(lang.toString()))
 							arrstr.add(lang.toString());
 						if (!arrstr.contains(baselang))
 							arrstr.add(baselang);
 					} else {
-						if (s.length() == 2 && !arrstr.contains(s.toLowerCase()))
-							arrstr.add(s.toLowerCase());
+						if (s.length() == 2 && !arrstr.contains(s.toLowerCase())) // IDEMPIERE-7089-P2
+							arrstr.add(s.toLowerCase()); // IDEMPIERE-7089-P2
 					}
 				}
 			}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/LoginPanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/panel/LoginPanel.java
@@ -894,15 +894,15 @@ public class LoginPanel extends Window implements EventListener<Event>
 				s = s.trim();
 				if (!s.startsWith("q=")) {
 					if (s.contains("_") && s.length() == 5) {
-						String baselang = s.substring(0, 2).toLowerCase(); // IDEMPIERE-7089-P2
-						StringBuffer lang = new StringBuffer(baselang).append("_").append(s.substring(3).toUpperCase()); // IDEMPIERE-7089-P2
+						String baselang = s.substring(0, 2).toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P2
+						StringBuffer lang = new StringBuffer(baselang).append("_").append(s.substring(3).toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P2
 						if (!arrstr.contains(lang.toString()))
 							arrstr.add(lang.toString());
 						if (!arrstr.contains(baselang))
 							arrstr.add(baselang);
 					} else {
-						if (s.length() == 2 && !arrstr.contains(s.toLowerCase())) // IDEMPIERE-7089-P2
-							arrstr.add(s.toLowerCase()); // IDEMPIERE-7089-P2
+						if (s.length() == 2 && !arrstr.contains(s.toLowerCase(java.util.Locale.ROOT))) // IDEMPIERE-7089-P2
+							arrstr.add(s.toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P2
 					}
 				}
 			}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/sso/filter/SSOWebUIFilter.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/sso/filter/SSOWebUIFilter.java
@@ -112,15 +112,15 @@ public class SSOWebUIFilter implements Filter
 			boolean isAdminResRequest = false;
 			if (httpRequest.getSession().getAttribute(ISSOPrincipalService.SSO_ADMIN_LOGIN) != null)
 				isAdminResRequest = (boolean) httpRequest.getSession().getAttribute(ISSOPrincipalService.SSO_ADMIN_LOGIN);
-			isAdminResRequest = isAdminResRequest || httpRequest.getServletPath().toLowerCase().startsWith("/admin");
+			isAdminResRequest = isAdminResRequest || httpRequest.getServletPath().toLowerCase().startsWith("/admin"); // IDEMPIERE-7089-P2
 
 			// work as default log in
-			if (httpRequest.getServletPath().toLowerCase().startsWith("/index") || httpRequest.getServletPath().equalsIgnoreCase("/"))
+			if (httpRequest.getServletPath().toLowerCase().startsWith("/index") || httpRequest.getServletPath().equalsIgnoreCase("/")) // IDEMPIERE-7089-P2
 				isAdminResRequest = false;
 
 			httpRequest.getSession().setAttribute(ISSOPrincipalService.SSO_ADMIN_LOGIN, isAdminResRequest);
 			// redirect to admin zul file
-			if (isAdminResRequest && httpRequest.getServletPath().toLowerCase().endsWith("admin"))
+			if (isAdminResRequest && httpRequest.getServletPath().toLowerCase().endsWith("admin")) // IDEMPIERE-7089-P2
 			{
 				httpResponse.sendRedirect("/webui/admin.zul");
 				return;

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/sso/filter/SSOWebUIFilter.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/sso/filter/SSOWebUIFilter.java
@@ -112,15 +112,15 @@ public class SSOWebUIFilter implements Filter
 			boolean isAdminResRequest = false;
 			if (httpRequest.getSession().getAttribute(ISSOPrincipalService.SSO_ADMIN_LOGIN) != null)
 				isAdminResRequest = (boolean) httpRequest.getSession().getAttribute(ISSOPrincipalService.SSO_ADMIN_LOGIN);
-			isAdminResRequest = isAdminResRequest || httpRequest.getServletPath().toLowerCase().startsWith("/admin"); // IDEMPIERE-7089-P2
+			isAdminResRequest = isAdminResRequest || httpRequest.getServletPath().toLowerCase(java.util.Locale.ROOT).startsWith("/admin"); // IDEMPIERE-7089-P2
 
 			// work as default log in
-			if (httpRequest.getServletPath().toLowerCase().startsWith("/index") || httpRequest.getServletPath().equalsIgnoreCase("/")) // IDEMPIERE-7089-P2
+			if (httpRequest.getServletPath().toLowerCase(java.util.Locale.ROOT).startsWith("/index") || httpRequest.getServletPath().equalsIgnoreCase("/")) // IDEMPIERE-7089-P2
 				isAdminResRequest = false;
 
 			httpRequest.getSession().setAttribute(ISSOPrincipalService.SSO_ADMIN_LOGIN, isAdminResRequest);
 			// redirect to admin zul file
-			if (isAdminResRequest && httpRequest.getServletPath().toLowerCase().endsWith("admin")) // IDEMPIERE-7089-P2
+			if (isAdminResRequest && httpRequest.getServletPath().toLowerCase(java.util.Locale.ROOT).endsWith("admin")) // IDEMPIERE-7089-P2
 			{
 				httpResponse.sendRedirect("/webui/admin.zul");
 				return;

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/theme/ThemeManager.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/theme/ThemeManager.java
@@ -130,7 +130,7 @@ public final class ThemeManager {
 		MUserDefTheme userDef = MUserDefTheme.getBestMatch(Env.getCtx(), getTheme());
 		if (userDef != null && !Util.isEmpty(userDef.getStylesheet())) {
 			String styleSheet = userDef.getStylesheet();
-			if (styleSheet.toLowerCase().startsWith("https://")) { // IDEMPIERE-7089-P2
+			if (styleSheet.toLowerCase(java.util.Locale.ROOT).startsWith("https://")) { // IDEMPIERE-7089-P2
 				return styleSheet;
 			} else if (MAttachment.isAttachmentURLPath(styleSheet)) {
 				return MAttachment.getStyleSheetAttachmentURLFromPath(null, styleSheet);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/theme/ThemeManager.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/theme/ThemeManager.java
@@ -130,7 +130,7 @@ public final class ThemeManager {
 		MUserDefTheme userDef = MUserDefTheme.getBestMatch(Env.getCtx(), getTheme());
 		if (userDef != null && !Util.isEmpty(userDef.getStylesheet())) {
 			String styleSheet = userDef.getStylesheet();
-			if (styleSheet.toLowerCase().startsWith("https://")) {
+			if (styleSheet.toLowerCase().startsWith("https://")) { // IDEMPIERE-7089-P2
 				return styleSheet;
 			} else if (MAttachment.isAttachmentURLPath(styleSheet)) {
 				return MAttachment.getStyleSheetAttachmentURLFromPath(null, styleSheet);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/FindWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/FindWindow.java
@@ -1722,7 +1722,7 @@ public class FindWindow extends Window implements EventListener<Event>, ValueCha
 						if (((String) key).length() == 0)
 							return true;
 					}
-					return value.toString().toLowerCase().startsWith(key.toString().toLowerCase());
+					return value.toString().toLowerCase().startsWith(key.toString().toLowerCase()); // IDEMPIERE-7089-P4
 				}
 				
 				protected int getMaxNumberInSubModel(int nRows) {

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/RecordTimeLinePanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/RecordTimeLinePanel.java
@@ -248,7 +248,7 @@ public class RecordTimeLinePanel extends Vlayout {
 				if (i > 0) {
 					if (i+1 == columns.size()) {
 						sb.append(" ")
-						  .append(Msg.getMsg(Env.getCtx(), "AND").toLowerCase())
+						  .append(Msg.getMsg(Env.getCtx(), "AND").toLowerCase()) // IDEMPIERE-7089-P4
 						  .append(" ");
 					} else {
 						sb.append(", ");

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WAutoCompleterCity.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WAutoCompleterCity.java
@@ -98,10 +98,10 @@ public class WAutoCompleterCity extends AutoComplete implements EventListener<Ev
 		this.setDict(null);
 		this.setDescription(null);
 		boolean truncated = false;
-		search = search.toUpperCase();
+		search = search.toUpperCase(); // IDEMPIERE-7089-P4
 		int i = 0;
 		for (CityVO vo : m_cities) {
-			if (vo.CityName.toUpperCase().startsWith(search)) {
+			if (vo.CityName.toUpperCase().startsWith(search)) { // IDEMPIERE-7089-P4
 				if (i > 0 && i == m_maxRows+1)
 				{
 					m_citiesShow.add(ITEM_More);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WMediaDialog.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WMediaDialog.java
@@ -285,7 +285,7 @@ public class WMediaDialog extends Window implements EventListener<Event>
 			Clob clob = (Clob)m_data;
 			long length = clob.length() > 100 ? 100 : clob.length();
 			String data = ((Clob)m_data).getSubString(1, Long.valueOf(length).intValue());
-			if (data.toUpperCase().indexOf("<html>") >= 0)
+			if (data.toUpperCase().indexOf("<html>") >= 0) // IDEMPIERE-7089-P2
 			{
 				contentType = "text/html";
 			}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WMediaDialog.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/WMediaDialog.java
@@ -285,7 +285,7 @@ public class WMediaDialog extends Window implements EventListener<Event>
 			Clob clob = (Clob)m_data;
 			long length = clob.length() > 100 ? 100 : clob.length();
 			String data = ((Clob)m_data).getSubString(1, Long.valueOf(length).intValue());
-			if (data.toUpperCase().indexOf("<html>") >= 0) // IDEMPIERE-7089-P2
+			if (data.toUpperCase(java.util.Locale.ROOT).indexOf("<html>") >= 0) // IDEMPIERE-7089-P2
 			{
 				contentType = "text/html";
 			}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/servlet/AttachmentImageServlet.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/servlet/AttachmentImageServlet.java
@@ -63,7 +63,7 @@ public class AttachmentImageServlet extends AttachmentDataServlet {
 		}
 		//imageio not workings for svg
 		if (contentType == null) {
-			if (imageData.name() != null && imageData.name().toLowerCase().endsWith(".svg")) { // IDEMPIERE-7089-P2
+			if (imageData.name() != null && imageData.name().toLowerCase(java.util.Locale.ROOT).endsWith(".svg")) { // IDEMPIERE-7089-P2
 				contentType = "image/svg+xml";
 			}
 		}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/servlet/AttachmentImageServlet.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/servlet/AttachmentImageServlet.java
@@ -63,7 +63,7 @@ public class AttachmentImageServlet extends AttachmentDataServlet {
 		}
 		//imageio not workings for svg
 		if (contentType == null) {
-			if (imageData.name() != null && imageData.name().toLowerCase().endsWith(".svg")) {
+			if (imageData.name() != null && imageData.name().toLowerCase().endsWith(".svg")) { // IDEMPIERE-7089-P2
 				contentType = "image/svg+xml";
 			}
 		}

--- a/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/ServerPushEndPoint.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/ServerPushEndPoint.java
@@ -279,7 +279,7 @@ public class ServerPushEndPoint {
 												// process max-age and other attributes
 												for (int i = 1; i < cookieElements.length; i++) {
 													String attr = cookieElements[i].trim();
-													String lowerAttr = attr.toLowerCase();
+													String lowerAttr = attr.toLowerCase(); // IDEMPIERE-7089-P2
 													if (lowerAttr.startsWith("max-age=")) {
 														try {
 															long maxAge = Long.parseLong(attr.substring(8));

--- a/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/ServerPushEndPoint.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/ServerPushEndPoint.java
@@ -279,7 +279,7 @@ public class ServerPushEndPoint {
 												// process max-age and other attributes
 												for (int i = 1; i < cookieElements.length; i++) {
 													String attr = cookieElements[i].trim();
-													String lowerAttr = attr.toLowerCase(); // IDEMPIERE-7089-P2
+													String lowerAttr = attr.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P2
 													if (lowerAttr.startsWith("max-age=")) {
 														try {
 															long maxAge = Long.parseLong(attr.substring(8));

--- a/org.adempiere.ui.zk/WEB-INF/src/org/zkforge/keylistener/Keylistener.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/zkforge/keylistener/Keylistener.java
@@ -135,7 +135,7 @@ public class Keylistener extends HtmlBasedComponent {
 					throw new WrongValueException(MCommon.UNEXPECTED_CHARACTER,
 							new Object[] { Character.valueOf(cc), keys });
 
-				final String s = keys.substring(j + 1, k).toLowerCase(); // IDEMPIERE-7089-P2
+				final String s = keys.substring(j + 1, k).toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P2
 				if ("pgup".equals(s))
 					cc = 'A';
 				else if ("pgdn".equals(s))

--- a/org.adempiere.ui.zk/WEB-INF/src/org/zkforge/keylistener/Keylistener.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/zkforge/keylistener/Keylistener.java
@@ -135,7 +135,7 @@ public class Keylistener extends HtmlBasedComponent {
 					throw new WrongValueException(MCommon.UNEXPECTED_CHARACTER,
 							new Object[] { Character.valueOf(cc), keys });
 
-				final String s = keys.substring(j + 1, k).toLowerCase();
+				final String s = keys.substring(j + 1, k).toLowerCase(); // IDEMPIERE-7089-P2
 				if ("pgup".equals(s))
 					cc = 'A';
 				else if ("pgdn".equals(s))

--- a/org.adempiere.ui.zk/WEB-INF/src/org/zkoss/addon/chosenbox/Chosenbox.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/zkoss/addon/chosenbox/Chosenbox.java
@@ -661,13 +661,13 @@ public class Chosenbox<T> extends HtmlBasedComponent {
 				if (excludeUnselected) {
 					for (int i = 0; i < _selIdxs.size(); i++) {
 						String s = renderer.render(this, model.getElementAt(_selIdxs.get(i)), _selIdxs.get(i));
-						if (prefix == null || s.toLowerCase().startsWith(prefix.toLowerCase()))
+						if (prefix == null || s.toLowerCase().startsWith(prefix.toLowerCase())) // IDEMPIERE-7089-P4
 							optList.add(s);
 					}
 				} else {
 					for (int i = 0; i < model.getSize(); i++) {
 						String s = renderer.render(this, model.getElementAt(i), i);
-						if (prefix == null || s.toLowerCase().startsWith(prefix.toLowerCase()))
+						if (prefix == null || s.toLowerCase().startsWith(prefix.toLowerCase())) // IDEMPIERE-7089-P4
 							optList.add(s);
 					}
 				}

--- a/org.adempiere.ui/src/org/compiere/apps/AbstractProcessCtl.java
+++ b/org.adempiere.ui/src/org/compiere/apps/AbstractProcessCtl.java
@@ -356,7 +356,7 @@ public abstract class AbstractProcessCtl implements Runnable
 	private boolean startProcess ()
 	{
 		if (log.isLoggable(Level.FINE)) log.fine(m_pi.toString());
-		if (m_pi.getClassName().toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) {
+		if (m_pi.getClassName().toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) { // IDEMPIERE-7089-P2
 			m_pi.setProcessUI(m_processUI);
 			return ProcessUtil.startScriptProcess(Env.getCtx(), m_pi, m_trx);
 		} else {

--- a/org.adempiere.ui/src/org/compiere/apps/AbstractProcessCtl.java
+++ b/org.adempiere.ui/src/org/compiere/apps/AbstractProcessCtl.java
@@ -356,7 +356,7 @@ public abstract class AbstractProcessCtl implements Runnable
 	private boolean startProcess ()
 	{
 		if (log.isLoggable(Level.FINE)) log.fine(m_pi.toString());
-		if (m_pi.getClassName().toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) { // IDEMPIERE-7089-P2
+		if (m_pi.getClassName().toLowerCase(java.util.Locale.ROOT).startsWith(MRule.SCRIPT_PREFIX)) { // IDEMPIERE-7089-P2
 			m_pi.setProcessUI(m_processUI);
 			return ProcessUtil.startScriptProcess(Env.getCtx(), m_pi, m_trx);
 		} else {

--- a/org.apache.ecs/src/org/apache/ecs/GenericElement.java
+++ b/org.apache.ecs/src/org/apache/ecs/GenericElement.java
@@ -354,9 +354,9 @@ public abstract class GenericElement implements Element,Serializable
         switch (getCase())
         {
             case UPPERCASE:
-                return value.toUpperCase();
+                return value.toUpperCase(); // IDEMPIERE-7089-P6
             case LOWERCASE:
-                return value.toLowerCase();
+                return value.toLowerCase(); // IDEMPIERE-7089-P6
             default:
                 return value;
         }

--- a/org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/config/ConfigOracle.java
+++ b/org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/config/ConfigOracle.java
@@ -92,8 +92,8 @@ public class ConfigOracle implements IDatabaseConfig
 		if (def != null && def.trim().length() == 0)
 			def = null;
 		if (def != null) {
-			list.add(def.toLowerCase()); // IDEMPIERE-7089-P3
-			dblist.add(def.toLowerCase()); // IDEMPIERE-7089-P3
+			list.add(def.toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
+			dblist.add(def.toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 		}
 
 		if (m_XE)
@@ -114,7 +114,7 @@ public class ConfigOracle implements IDatabaseConfig
 			String[] entries = path.split(File.pathSeparator);
 			for (int e = 0; e < entries.length; e++)
 			{
-				String entry = entries[e].toLowerCase(); // IDEMPIERE-7089-P3
+				String entry = entries[e].toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 				if (entry.indexOf("ora") != -1 && entry.endsWith("bin"))
 				{
 					StringBuffer sb = getTNS_File (entries[e].substring(0, entries[e].length()-4));
@@ -266,7 +266,7 @@ public class ConfigOracle implements IDatabaseConfig
 					&& line.indexOf("EXTPROC_") == -1
 					&& line.indexOf("_HTTP") == -1)
 				{
-					String entry = line.substring(0, line.indexOf('=')).trim().toLowerCase(); // IDEMPIERE-7089-P3
+					String entry = line.substring(0, line.indexOf('=')).trim().toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 					log.fine(entry);
 					list.add(entry);
 				}
@@ -274,9 +274,9 @@ public class ConfigOracle implements IDatabaseConfig
 			else	//	search service names
 			{
 				if (line.length() > 0
-					&& line.toUpperCase().indexOf("SERVICE_NAME") != -1) // IDEMPIERE-7089-P3
+					&& line.toUpperCase(java.util.Locale.ROOT).indexOf("SERVICE_NAME") != -1) // IDEMPIERE-7089-P3
 				{
-					String entry = line.substring(line.indexOf('=')+1).trim().toLowerCase(); // IDEMPIERE-7089-P3
+					String entry = line.substring(line.indexOf('=')+1).trim().toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 					int index = entry.indexOf(')');
 					if (index != 0)
 						entry = entry.substring(0, index).trim();
@@ -337,7 +337,7 @@ public class ConfigOracle implements IDatabaseConfig
 		data.setProperty(ConfigurationData.ADEMPIERE_DB_SERVER, databaseServer!=null ? ((databaseServerProtocol.equals("//") ? "" : databaseServerProtocol) + databaseServerName) : null);
 		//store as lower case for better script level backward compatibility
 		data.setProperty(ConfigurationData.ADEMPIERE_DB_TYPE, data.getDatabaseType());
-		data.setProperty(ConfigurationData.ADEMPIERE_DB_PATH, data.getDatabaseType().toLowerCase()); // IDEMPIERE-7089-P3
+		data.setProperty(ConfigurationData.ADEMPIERE_DB_PATH, data.getDatabaseType().toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 
 		//	Database Port
 		int databasePort = data.getDatabasePort();

--- a/org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/config/ConfigOracle.java
+++ b/org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/config/ConfigOracle.java
@@ -92,8 +92,8 @@ public class ConfigOracle implements IDatabaseConfig
 		if (def != null && def.trim().length() == 0)
 			def = null;
 		if (def != null) {
-			list.add(def.toLowerCase());
-			dblist.add(def.toLowerCase());
+			list.add(def.toLowerCase()); // IDEMPIERE-7089-P3
+			dblist.add(def.toLowerCase()); // IDEMPIERE-7089-P3
 		}
 
 		if (m_XE)
@@ -114,7 +114,7 @@ public class ConfigOracle implements IDatabaseConfig
 			String[] entries = path.split(File.pathSeparator);
 			for (int e = 0; e < entries.length; e++)
 			{
-				String entry = entries[e].toLowerCase();
+				String entry = entries[e].toLowerCase(); // IDEMPIERE-7089-P3
 				if (entry.indexOf("ora") != -1 && entry.endsWith("bin"))
 				{
 					StringBuffer sb = getTNS_File (entries[e].substring(0, entries[e].length()-4));
@@ -266,7 +266,7 @@ public class ConfigOracle implements IDatabaseConfig
 					&& line.indexOf("EXTPROC_") == -1
 					&& line.indexOf("_HTTP") == -1)
 				{
-					String entry = line.substring(0, line.indexOf('=')).trim().toLowerCase();
+					String entry = line.substring(0, line.indexOf('=')).trim().toLowerCase(); // IDEMPIERE-7089-P3
 					log.fine(entry);
 					list.add(entry);
 				}
@@ -274,9 +274,9 @@ public class ConfigOracle implements IDatabaseConfig
 			else	//	search service names
 			{
 				if (line.length() > 0
-					&& line.toUpperCase().indexOf("SERVICE_NAME") != -1)
+					&& line.toUpperCase().indexOf("SERVICE_NAME") != -1) // IDEMPIERE-7089-P3
 				{
-					String entry = line.substring(line.indexOf('=')+1).trim().toLowerCase();
+					String entry = line.substring(line.indexOf('=')+1).trim().toLowerCase(); // IDEMPIERE-7089-P3
 					int index = entry.indexOf(')');
 					if (index != 0)
 						entry = entry.substring(0, index).trim();
@@ -337,7 +337,7 @@ public class ConfigOracle implements IDatabaseConfig
 		data.setProperty(ConfigurationData.ADEMPIERE_DB_SERVER, databaseServer!=null ? ((databaseServerProtocol.equals("//") ? "" : databaseServerProtocol) + databaseServerName) : null);
 		//store as lower case for better script level backward compatibility
 		data.setProperty(ConfigurationData.ADEMPIERE_DB_TYPE, data.getDatabaseType());
-		data.setProperty(ConfigurationData.ADEMPIERE_DB_PATH, data.getDatabaseType().toLowerCase());
+		data.setProperty(ConfigurationData.ADEMPIERE_DB_PATH, data.getDatabaseType().toLowerCase()); // IDEMPIERE-7089-P3
 
 		//	Database Port
 		int databasePort = data.getDatabasePort();

--- a/org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/partition/TablePartitionService.java
+++ b/org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/partition/TablePartitionService.java
@@ -64,7 +64,7 @@ public class TablePartitionService implements ITablePartitionService {
 				SELECT 1 FROM USER_TAB_PARTITIONS
 				WHERE TABLE_NAME = ?
 			""";
-		return DB.getSQLValueEx(trxName, sql, table.getTableName().toUpperCase()) == 1;
+		return DB.getSQLValueEx(trxName, sql, table.getTableName().toUpperCase()) == 1; // IDEMPIERE-7089-P3
 	}
 
 	@Override
@@ -179,7 +179,7 @@ public class TablePartitionService implements ITablePartitionService {
 			return false;
 		MColumn partitionKeyColumn = partitionKeyColumns.get(0);		
 		String sql = "SELECT Column_Name FROM User_Part_Key_Columns WHERE Name=? ORDER BY Column_Position";
-		String partKeyColumn = DB.getSQLValueString(trxName, sql, table.getTableName().toUpperCase());
+		String partKeyColumn = DB.getSQLValueString(trxName, sql, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
 		if (!partitionKeyColumn.getColumnName().equalsIgnoreCase(partKeyColumn))
 			return false;
 		MColumn subPartitionColumn = null;
@@ -267,8 +267,8 @@ public class TablePartitionService implements ITablePartitionService {
 					WHERE Table_Name=? AND Partition_Name=?
 				""";
 		try(PreparedStatement stmt = DB.prepareStatement(sql, trxName)) {
-			stmt.setString(1, table.getTableName().toUpperCase());
-			stmt.setString(2, primaryPartition.getName().toUpperCase());
+			stmt.setString(1, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
+			stmt.setString(2, primaryPartition.getName().toUpperCase()); // IDEMPIERE-7089-P3
 			ResultSet rs = stmt.executeQuery();
 			while(rs.next()) {
 				String expression = rs.getString(1);
@@ -349,7 +349,7 @@ public class TablePartitionService implements ITablePartitionService {
 	private void syncAutoList(MTable table, MColumn partitionKeyColumn, String trxName, ProcessInfo pi) {
 		String keyColumn = partitionKeyColumn.getColumnName();
 		String sql = "SELECT Column_Name FROM User_Part_Key_Columns WHERE Name=? ORDER BY Column_Position";
-		List<List<Object>> columnNames = DB.getSQLArrayObjectsEx(trxName, sql, table.getTableName().toUpperCase());
+		List<List<Object>> columnNames = DB.getSQLArrayObjectsEx(trxName, sql, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
 		boolean notSync = false;
 		if (columnNames.size() != 1) {
 			notSync = true;
@@ -381,10 +381,10 @@ public class TablePartitionService implements ITablePartitionService {
 	 */
 	private void syncInterval(MTable table, MColumn partitionKeyColumn, String trxName, String interval, ProcessInfo pi) {
 		String sql = "SELECT Column_Name FROM User_Part_Key_Columns WHERE Name=? ORDER BY Column_Position";
-		String intervalColumn = DB.getSQLValueString(trxName, sql, table.getTableName().toUpperCase());
+		String intervalColumn = DB.getSQLValueString(trxName, sql, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
 		String expression = getIntervalExpression(partitionKeyColumn);
-		if (partitionKeyColumn.getColumnName().toUpperCase().equals(intervalColumn)) {
-			if (!interval.toUpperCase().equals(expression)) {
+		if (partitionKeyColumn.getColumnName().toUpperCase().equals(intervalColumn)) { // IDEMPIERE-7089-P3
+			if (!interval.toUpperCase().equals(expression)) { // IDEMPIERE-7089-P3
 				//note that this only effect new data inserted into table and will not change existing partition
 				sql = "ALTER TABLE " + table.getTableName() + " SET INTERVAL (" + expression + ")";
 				int no = DB.executeUpdateEx(sql, trxName);
@@ -406,7 +406,7 @@ public class TablePartitionService implements ITablePartitionService {
 	 */
 	private void syncRange(MTable table, MColumn partitionKeyColumn, String trxName, String interval, ProcessInfo pi) {
 		String sql = "SELECT Column_Name FROM User_Part_Key_Columns WHERE Name=? ORDER BY Column_Position";
-		List<List<Object>> columnNames = DB.getSQLArrayObjectsEx(trxName, sql, table.getTableName().toUpperCase());
+		List<List<Object>> columnNames = DB.getSQLArrayObjectsEx(trxName, sql, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
 		boolean notSync = false;
 		if (columnNames.size() != 1) {
 			notSync = true;
@@ -447,7 +447,7 @@ public class TablePartitionService implements ITablePartitionService {
 		List<Integer> matchedIds = new ArrayList<Integer>();
 		List<MColumn> partitionKeyColumns = table.getPartitionKeyColumns(false);
 		try(PreparedStatement stmt = DB.prepareStatement(sql, trxName)) {
-			stmt.setString(1, table.getTableName().toUpperCase());
+			stmt.setString(1, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
 			ResultSet rs = stmt.executeQuery();
 			while (rs.next()) {
 				String partitionName = rs.getString(1);
@@ -485,7 +485,7 @@ public class TablePartitionService implements ITablePartitionService {
 				FROM User_Part_Tables
 				WHERE Table_Name = ?
 			""";
-		String autoList = DB.getSQLValueStringEx(trxName, sql, table.getTableName().toUpperCase());
+		String autoList = DB.getSQLValueStringEx(trxName, sql, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
 		return "YES".equals(autoList);
 	}
 
@@ -501,7 +501,7 @@ public class TablePartitionService implements ITablePartitionService {
 				FROM User_Part_Tables
 				WHERE Table_Name = ?
 			""";
-		String interval = DB.getSQLValueStringEx(trxName, sql, table.getTableName().toUpperCase());
+		String interval = DB.getSQLValueStringEx(trxName, sql, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
 		return interval;
 	}
 	
@@ -517,7 +517,7 @@ public class TablePartitionService implements ITablePartitionService {
 					FROM User_Part_Tables
 					WHERE Table_Name = ?
 				""";
-		String type = DB.getSQLValueStringEx(trxName, sql, table.getTableName().toUpperCase());
+		String type = DB.getSQLValueStringEx(trxName, sql, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
 		return "RANGE".equals(type);
 	}
 	/**
@@ -732,9 +732,9 @@ public class TablePartitionService implements ITablePartitionService {
 			""";
 		
 		try (PreparedStatement stmt = DB.prepareStatement(sql, trxName)) {
-			stmt.setString(1, table.getTableName().toUpperCase());
-			stmt.setString(2, table.getTableName().toUpperCase());
-			stmt.setString(3, table.getTableName().toUpperCase());
+			stmt.setString(1, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
+			stmt.setString(2, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
+			stmt.setString(3, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
 			ResultSet rs = stmt.executeQuery();
 			while(rs.next()) {
 				StringBuilder alter = new StringBuilder("ALTER INDEX ")

--- a/org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/partition/TablePartitionService.java
+++ b/org.compiere.db.oracle.provider/src/org/adempiere/db/oracle/partition/TablePartitionService.java
@@ -64,7 +64,7 @@ public class TablePartitionService implements ITablePartitionService {
 				SELECT 1 FROM USER_TAB_PARTITIONS
 				WHERE TABLE_NAME = ?
 			""";
-		return DB.getSQLValueEx(trxName, sql, table.getTableName().toUpperCase()) == 1; // IDEMPIERE-7089-P3
+		return DB.getSQLValueEx(trxName, sql, table.getTableName().toUpperCase(java.util.Locale.ROOT)) == 1; // IDEMPIERE-7089-P3
 	}
 
 	@Override
@@ -179,7 +179,7 @@ public class TablePartitionService implements ITablePartitionService {
 			return false;
 		MColumn partitionKeyColumn = partitionKeyColumns.get(0);		
 		String sql = "SELECT Column_Name FROM User_Part_Key_Columns WHERE Name=? ORDER BY Column_Position";
-		String partKeyColumn = DB.getSQLValueString(trxName, sql, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
+		String partKeyColumn = DB.getSQLValueString(trxName, sql, table.getTableName().toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 		if (!partitionKeyColumn.getColumnName().equalsIgnoreCase(partKeyColumn))
 			return false;
 		MColumn subPartitionColumn = null;
@@ -267,8 +267,8 @@ public class TablePartitionService implements ITablePartitionService {
 					WHERE Table_Name=? AND Partition_Name=?
 				""";
 		try(PreparedStatement stmt = DB.prepareStatement(sql, trxName)) {
-			stmt.setString(1, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
-			stmt.setString(2, primaryPartition.getName().toUpperCase()); // IDEMPIERE-7089-P3
+			stmt.setString(1, table.getTableName().toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
+			stmt.setString(2, primaryPartition.getName().toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 			ResultSet rs = stmt.executeQuery();
 			while(rs.next()) {
 				String expression = rs.getString(1);
@@ -349,7 +349,7 @@ public class TablePartitionService implements ITablePartitionService {
 	private void syncAutoList(MTable table, MColumn partitionKeyColumn, String trxName, ProcessInfo pi) {
 		String keyColumn = partitionKeyColumn.getColumnName();
 		String sql = "SELECT Column_Name FROM User_Part_Key_Columns WHERE Name=? ORDER BY Column_Position";
-		List<List<Object>> columnNames = DB.getSQLArrayObjectsEx(trxName, sql, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
+		List<List<Object>> columnNames = DB.getSQLArrayObjectsEx(trxName, sql, table.getTableName().toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 		boolean notSync = false;
 		if (columnNames.size() != 1) {
 			notSync = true;
@@ -381,10 +381,10 @@ public class TablePartitionService implements ITablePartitionService {
 	 */
 	private void syncInterval(MTable table, MColumn partitionKeyColumn, String trxName, String interval, ProcessInfo pi) {
 		String sql = "SELECT Column_Name FROM User_Part_Key_Columns WHERE Name=? ORDER BY Column_Position";
-		String intervalColumn = DB.getSQLValueString(trxName, sql, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
+		String intervalColumn = DB.getSQLValueString(trxName, sql, table.getTableName().toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 		String expression = getIntervalExpression(partitionKeyColumn);
-		if (partitionKeyColumn.getColumnName().toUpperCase().equals(intervalColumn)) { // IDEMPIERE-7089-P3
-			if (!interval.toUpperCase().equals(expression)) { // IDEMPIERE-7089-P3
+		if (partitionKeyColumn.getColumnName().toUpperCase(java.util.Locale.ROOT).equals(intervalColumn)) { // IDEMPIERE-7089-P3
+			if (!interval.toUpperCase(java.util.Locale.ROOT).equals(expression)) { // IDEMPIERE-7089-P3
 				//note that this only effect new data inserted into table and will not change existing partition
 				sql = "ALTER TABLE " + table.getTableName() + " SET INTERVAL (" + expression + ")";
 				int no = DB.executeUpdateEx(sql, trxName);
@@ -406,7 +406,7 @@ public class TablePartitionService implements ITablePartitionService {
 	 */
 	private void syncRange(MTable table, MColumn partitionKeyColumn, String trxName, String interval, ProcessInfo pi) {
 		String sql = "SELECT Column_Name FROM User_Part_Key_Columns WHERE Name=? ORDER BY Column_Position";
-		List<List<Object>> columnNames = DB.getSQLArrayObjectsEx(trxName, sql, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
+		List<List<Object>> columnNames = DB.getSQLArrayObjectsEx(trxName, sql, table.getTableName().toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 		boolean notSync = false;
 		if (columnNames.size() != 1) {
 			notSync = true;
@@ -447,7 +447,7 @@ public class TablePartitionService implements ITablePartitionService {
 		List<Integer> matchedIds = new ArrayList<Integer>();
 		List<MColumn> partitionKeyColumns = table.getPartitionKeyColumns(false);
 		try(PreparedStatement stmt = DB.prepareStatement(sql, trxName)) {
-			stmt.setString(1, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
+			stmt.setString(1, table.getTableName().toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 			ResultSet rs = stmt.executeQuery();
 			while (rs.next()) {
 				String partitionName = rs.getString(1);
@@ -485,7 +485,7 @@ public class TablePartitionService implements ITablePartitionService {
 				FROM User_Part_Tables
 				WHERE Table_Name = ?
 			""";
-		String autoList = DB.getSQLValueStringEx(trxName, sql, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
+		String autoList = DB.getSQLValueStringEx(trxName, sql, table.getTableName().toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 		return "YES".equals(autoList);
 	}
 
@@ -501,7 +501,7 @@ public class TablePartitionService implements ITablePartitionService {
 				FROM User_Part_Tables
 				WHERE Table_Name = ?
 			""";
-		String interval = DB.getSQLValueStringEx(trxName, sql, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
+		String interval = DB.getSQLValueStringEx(trxName, sql, table.getTableName().toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 		return interval;
 	}
 	
@@ -517,7 +517,7 @@ public class TablePartitionService implements ITablePartitionService {
 					FROM User_Part_Tables
 					WHERE Table_Name = ?
 				""";
-		String type = DB.getSQLValueStringEx(trxName, sql, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
+		String type = DB.getSQLValueStringEx(trxName, sql, table.getTableName().toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 		return "RANGE".equals(type);
 	}
 	/**
@@ -732,9 +732,9 @@ public class TablePartitionService implements ITablePartitionService {
 			""";
 		
 		try (PreparedStatement stmt = DB.prepareStatement(sql, trxName)) {
-			stmt.setString(1, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
-			stmt.setString(2, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
-			stmt.setString(3, table.getTableName().toUpperCase()); // IDEMPIERE-7089-P3
+			stmt.setString(1, table.getTableName().toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
+			stmt.setString(2, table.getTableName().toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
+			stmt.setString(3, table.getTableName().toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 			ResultSet rs = stmt.executeQuery();
 			while(rs.next()) {
 				StringBuilder alter = new StringBuilder("ALTER INDEX ")

--- a/org.compiere.db.oracle.provider/src/org/compiere/db/DB_Oracle.java
+++ b/org.compiere.db.oracle.provider/src/org/compiere/db/DB_Oracle.java
@@ -297,7 +297,7 @@ public class DB_Oracle implements AdempiereDatabase
     public String getSchema()
     {
         if (m_userName != null)
-            return m_userName.toUpperCase();
+            return m_userName.toUpperCase(); // IDEMPIERE-7089-P3
         log.severe("User Name not set (yet) - call getConnectionURL first");
         return null;
     }   //  getSchema
@@ -838,14 +838,14 @@ public class DB_Oracle implements AdempiereDatabase
 	}
 
 	public int getNextID(String name, String trxName) {
-		int m_sequence_id = DB.getSQLValueEx(trxName, "SELECT "+name.toUpperCase()+".nextval FROM DUAL");
+		int m_sequence_id = DB.getSQLValueEx(trxName, "SELECT "+name.toUpperCase()+".nextval FROM DUAL"); // IDEMPIERE-7089-P3
 		return m_sequence_id;
 	}
 
 	public boolean createSequence(String name , int increment , int minvalue , int maxvalue ,int  start , String trxName)
 	{
 		// Check if Sequence exists
-		final int cnt = DB.getSQLValueEx(trxName, "SELECT COUNT(*) FROM USER_SEQUENCES WHERE UPPER(sequence_name)=?", name.toUpperCase());
+		final int cnt = DB.getSQLValueEx(trxName, "SELECT COUNT(*) FROM USER_SEQUENCES WHERE UPPER(sequence_name)=?", name.toUpperCase()); // IDEMPIERE-7089-P3
 		final int no;
 		if (start < minvalue)
 			start = minvalue;
@@ -853,7 +853,7 @@ public class DB_Oracle implements AdempiereDatabase
 		// New Sequence
 		if (cnt == 0)
 		{
-			no = DB.executeUpdate("CREATE SEQUENCE "+name.toUpperCase()
+			no = DB.executeUpdate("CREATE SEQUENCE "+name.toUpperCase() // IDEMPIERE-7089-P3
 								+ " MINVALUE " + minvalue
 								+ " MAXVALUE " + maxvalue
 								+ " START WITH " + start 
@@ -864,12 +864,12 @@ public class DB_Oracle implements AdempiereDatabase
 		// Already existing sequence => ALTER
 		else
 		{
-			no = DB.executeUpdate("ALTER SEQUENCE "+name.toUpperCase()
+			no = DB.executeUpdate("ALTER SEQUENCE "+name.toUpperCase() // IDEMPIERE-7089-P3
 					+ " INCREMENT BY " + increment
 					// + " MINVALUE " + minvalue // ORA-04007
 					+ " MAXVALUE " + maxvalue
 					+ " CACHE 20", trxName);
-			while (DB.getSQLValue(trxName, "SELECT " + name.toUpperCase() + ".NEXTVAL FROM DUAL") < start) {
+			while (DB.getSQLValue(trxName, "SELECT " + name.toUpperCase() + ".NEXTVAL FROM DUAL") < start) { // IDEMPIERE-7089-P3
 	        	// do nothing - the while is incrementing the sequence
 	        }
 		}

--- a/org.compiere.db.oracle.provider/src/org/compiere/db/DB_Oracle.java
+++ b/org.compiere.db.oracle.provider/src/org/compiere/db/DB_Oracle.java
@@ -297,7 +297,7 @@ public class DB_Oracle implements AdempiereDatabase
     public String getSchema()
     {
         if (m_userName != null)
-            return m_userName.toUpperCase(); // IDEMPIERE-7089-P3
+            return m_userName.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
         log.severe("User Name not set (yet) - call getConnectionURL first");
         return null;
     }   //  getSchema
@@ -838,14 +838,14 @@ public class DB_Oracle implements AdempiereDatabase
 	}
 
 	public int getNextID(String name, String trxName) {
-		int m_sequence_id = DB.getSQLValueEx(trxName, "SELECT "+name.toUpperCase()+".nextval FROM DUAL"); // IDEMPIERE-7089-P3
+		int m_sequence_id = DB.getSQLValueEx(trxName, "SELECT "+name.toUpperCase(java.util.Locale.ROOT)+".nextval FROM DUAL"); // IDEMPIERE-7089-P3
 		return m_sequence_id;
 	}
 
 	public boolean createSequence(String name , int increment , int minvalue , int maxvalue ,int  start , String trxName)
 	{
 		// Check if Sequence exists
-		final int cnt = DB.getSQLValueEx(trxName, "SELECT COUNT(*) FROM USER_SEQUENCES WHERE UPPER(sequence_name)=?", name.toUpperCase()); // IDEMPIERE-7089-P3
+		final int cnt = DB.getSQLValueEx(trxName, "SELECT COUNT(*) FROM USER_SEQUENCES WHERE UPPER(sequence_name)=?", name.toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 		final int no;
 		if (start < minvalue)
 			start = minvalue;
@@ -853,7 +853,7 @@ public class DB_Oracle implements AdempiereDatabase
 		// New Sequence
 		if (cnt == 0)
 		{
-			no = DB.executeUpdate("CREATE SEQUENCE "+name.toUpperCase() // IDEMPIERE-7089-P3
+			no = DB.executeUpdate("CREATE SEQUENCE "+name.toUpperCase(java.util.Locale.ROOT) // IDEMPIERE-7089-P3
 								+ " MINVALUE " + minvalue
 								+ " MAXVALUE " + maxvalue
 								+ " START WITH " + start 
@@ -864,12 +864,12 @@ public class DB_Oracle implements AdempiereDatabase
 		// Already existing sequence => ALTER
 		else
 		{
-			no = DB.executeUpdate("ALTER SEQUENCE "+name.toUpperCase() // IDEMPIERE-7089-P3
+			no = DB.executeUpdate("ALTER SEQUENCE "+name.toUpperCase(java.util.Locale.ROOT) // IDEMPIERE-7089-P3
 					+ " INCREMENT BY " + increment
 					// + " MINVALUE " + minvalue // ORA-04007
 					+ " MAXVALUE " + maxvalue
 					+ " CACHE 20", trxName);
-			while (DB.getSQLValue(trxName, "SELECT " + name.toUpperCase() + ".NEXTVAL FROM DUAL") < start) { // IDEMPIERE-7089-P3
+			while (DB.getSQLValue(trxName, "SELECT " + name.toUpperCase(java.util.Locale.ROOT) + ".NEXTVAL FROM DUAL") < start) { // IDEMPIERE-7089-P3
 	        	// do nothing - the while is incrementing the sequence
 	        }
 		}

--- a/org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/config/ConfigPostgreSQL.java
+++ b/org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/config/ConfigPostgreSQL.java
@@ -107,7 +107,7 @@ public class ConfigPostgreSQL implements IDatabaseConfig
 		data.setProperty(ConfigurationData.ADEMPIERE_DB_SERVER, databaseServer!=null ? databaseServer.getHostName() : null);
 		//store as lower case for better script level backward compatibility
 		data.setProperty(ConfigurationData.ADEMPIERE_DB_TYPE, data.getDatabaseType());
-		data.setProperty(ConfigurationData.ADEMPIERE_DB_PATH, data.getDatabaseType().toLowerCase());
+		data.setProperty(ConfigurationData.ADEMPIERE_DB_PATH, data.getDatabaseType().toLowerCase()); // IDEMPIERE-7089-P3
 
 		//	Database Port
 		int databasePort = data.getDatabasePort();

--- a/org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/config/ConfigPostgreSQL.java
+++ b/org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/config/ConfigPostgreSQL.java
@@ -107,7 +107,7 @@ public class ConfigPostgreSQL implements IDatabaseConfig
 		data.setProperty(ConfigurationData.ADEMPIERE_DB_SERVER, databaseServer!=null ? databaseServer.getHostName() : null);
 		//store as lower case for better script level backward compatibility
 		data.setProperty(ConfigurationData.ADEMPIERE_DB_TYPE, data.getDatabaseType());
-		data.setProperty(ConfigurationData.ADEMPIERE_DB_PATH, data.getDatabaseType().toLowerCase()); // IDEMPIERE-7089-P3
+		data.setProperty(ConfigurationData.ADEMPIERE_DB_PATH, data.getDatabaseType().toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 
 		//	Database Port
 		int databasePort = data.getDatabasePort();

--- a/org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java
+++ b/org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java
@@ -147,7 +147,7 @@ public class TablePartitionService implements ITablePartitionService {
 
 					List<String> lowerCasePartitionKeyColumnNames = new ArrayList<String>();
 					for (String partitionKeyColumnName : partitionKeyColumnNames)
-						lowerCasePartitionKeyColumnNames.add(partitionKeyColumnName.toLowerCase());
+						lowerCasePartitionKeyColumnNames.add(partitionKeyColumnName.toLowerCase()); // IDEMPIERE-7089-P3
 					String constraintColumnsStr = constraint_definition.substring(constraint_definition.indexOf("(")+1, constraint_definition.length()-1);
 					StringTokenizer st = new StringTokenizer(constraintColumnsStr, ",");
 					while (st.hasMoreTokens()) {
@@ -185,8 +185,8 @@ public class TablePartitionService implements ITablePartitionService {
 				
 				if (constraint_definition.startsWith("CHECK ") || constraint_definition.startsWith("FOREIGN KEY "))
 				{
-					if (constraint_definition.indexOf(getDefaultPartitionName(table).toLowerCase()) >= 0) {
-						constraint_definition = constraint_definition.replace(getDefaultPartitionName(table).toLowerCase(), table.getTableName().toLowerCase());
+					if (constraint_definition.indexOf(getDefaultPartitionName(table).toLowerCase()) >= 0) { // IDEMPIERE-7089-P3
+						constraint_definition = constraint_definition.replace(getDefaultPartitionName(table).toLowerCase(), table.getTableName().toLowerCase()); // IDEMPIERE-7089-P3
 					}
 					StringBuilder alterStmt = new StringBuilder();
 					alterStmt.append("ALTER TABLE ").append(table.getTableName()).append(" ");
@@ -224,7 +224,7 @@ public class TablePartitionService implements ITablePartitionService {
 		Map<String, String> indexMap = new HashMap<String, String>();
 		Map<String, String> uniqueMap = new HashMap<String, String>();
 		try (PreparedStatement stmt = DB.prepareStatement(indexs, trxName)) {
-			stmt.setString(1, getDefaultPartitionName(table).toLowerCase());
+			stmt.setString(1, getDefaultPartitionName(table).toLowerCase()); // IDEMPIERE-7089-P3
 			ResultSet rs = stmt.executeQuery();
 			while(rs.next()) {
 				String indexName = rs.getString(1);
@@ -242,22 +242,22 @@ public class TablePartitionService implements ITablePartitionService {
 		List<String> partitionKeyColumnNames = table.getPartitionKeyColumnNames();
 		for(String indexName : uniqueMap.keySet()) {
 			String consql = "select conindid::regclass from pg_constraint where conrelid = ?::regclass and conindid = ?::regclass";
-			String conindid = DB.getSQLValueString(trxName, consql, table.getTableName().toLowerCase(), indexName.toLowerCase());
+			String conindid = DB.getSQLValueString(trxName, consql, table.getTableName().toLowerCase(), indexName.toLowerCase()); // IDEMPIERE-7089-P3
 			if (conindid != null && conindid.equalsIgnoreCase(indexName))
 				continue;
 			
 			//unique index must include partition key column
 			String indexdef = uniqueMap.get(indexName);
 			for(String partitionKey : partitionKeyColumnNames) {
-				if (!indexdef.contains(partitionKey.toLowerCase()+",") && !indexdef.contains(partitionKey.toLowerCase()+")")) {
-					int whereIndex = indexdef.toLowerCase().indexOf(" where ");
+				if (!indexdef.contains(partitionKey.toLowerCase()+",") && !indexdef.contains(partitionKey.toLowerCase()+")")) { // IDEMPIERE-7089-P3
+					int whereIndex = indexdef.toLowerCase().indexOf(" where "); // IDEMPIERE-7089-P3
 					if (whereIndex > 0) {
 						String whereClause = indexdef.substring(whereIndex);
 						indexdef = indexdef.substring(0, whereIndex);
-						indexdef = indexdef.substring(0, indexdef.length()-1)+", "+partitionKey.toLowerCase()+")";
+						indexdef = indexdef.substring(0, indexdef.length()-1)+", "+partitionKey.toLowerCase()+")"; // IDEMPIERE-7089-P3
 						indexdef = indexdef + whereClause;
 					} else {
-						indexdef = indexdef.substring(0, indexdef.length()-1)+", "+partitionKey.toLowerCase()+")";
+						indexdef = indexdef.substring(0, indexdef.length()-1)+", "+partitionKey.toLowerCase()+")"; // IDEMPIERE-7089-P3
 					}
 				}
 			}			
@@ -265,7 +265,7 @@ public class TablePartitionService implements ITablePartitionService {
 			DB.executeUpdateEx(alter.toString(), trxName);
 			if (pi != null)
 				pi.addLog(0, null, null, alter.toString());
-			indexdef = indexdef.replace(" ON adempiere."+getDefaultPartitionName(table).toLowerCase()+" ", " ON adempiere."+table.getTableName().toLowerCase()+" ");
+			indexdef = indexdef.replace(" ON adempiere."+getDefaultPartitionName(table).toLowerCase()+" ", " ON adempiere."+table.getTableName().toLowerCase()+" "); // IDEMPIERE-7089-P3
 			DB.executeUpdateEx(indexdef, trxName);
 			if (pi != null)
 				pi.addLog(0, null, null, indexdef);
@@ -273,7 +273,7 @@ public class TablePartitionService implements ITablePartitionService {
 		
 		for(String indexName : indexMap.keySet()) {
 			String consql = "select conindid::regclass from pg_constraint where conrelid = ?::regclass and conindid = ?::regclass";
-			String conindid = DB.getSQLValueString(trxName, consql, table.getTableName().toLowerCase(), indexName.toLowerCase());
+			String conindid = DB.getSQLValueString(trxName, consql, table.getTableName().toLowerCase(), indexName.toLowerCase()); // IDEMPIERE-7089-P3
 			if (conindid != null && conindid.equalsIgnoreCase(indexName))
 				continue;
 			
@@ -282,7 +282,7 @@ public class TablePartitionService implements ITablePartitionService {
 			DB.executeUpdateEx(alter.toString(), trxName);
 			if (pi != null)
 				pi.addLog(0, null, null, alter.toString());
-			indexdef = indexdef.replace(" ON adempiere."+getDefaultPartitionName(table).toLowerCase()+" ", " ON adempiere."+table.getTableName().toLowerCase()+" ");
+			indexdef = indexdef.replace(" ON adempiere."+getDefaultPartitionName(table).toLowerCase()+" ", " ON adempiere."+table.getTableName().toLowerCase()+" "); // IDEMPIERE-7089-P3
 			DB.executeUpdateEx(indexdef, trxName);
 			if (pi != null)
 				pi.addLog(0, null, null, indexdef);
@@ -451,8 +451,8 @@ public class TablePartitionService implements ITablePartitionService {
 			)
 			select relname, viewoid, max(depth) from depv group by relname, viewoid order by 3 desc
 			""";
-		String defaultPartitionName = getDefaultPartitionName(table).toLowerCase();
-		String tableName = table.getTableName().toLowerCase();
+		String defaultPartitionName = getDefaultPartitionName(table).toLowerCase(); // IDEMPIERE-7089-P3
+		String tableName = table.getTableName().toLowerCase(); // IDEMPIERE-7089-P3
 		List<String> viewTexts = new ArrayList<String>();
 		List<String> viewNames = new ArrayList<String>();
 		List<String> grants = new ArrayList<String>();
@@ -476,7 +476,7 @@ public class TablePartitionService implements ITablePartitionService {
 			for(int i = 0; i < viewNames.size(); i++) {
 				String viewName = viewNames.get(i);
 				try(PreparedStatement stmt1 = DB.prepareStatement(grantSQL, trxName)) {
-					stmt1.setString(1, viewName.toLowerCase());
+					stmt1.setString(1, viewName.toLowerCase()); // IDEMPIERE-7089-P3
 					ResultSet rs1 = stmt1.executeQuery();
 					while(rs1.next()) {
 						grants.add(rs1.getString(1));
@@ -566,7 +566,7 @@ public class TablePartitionService implements ITablePartitionService {
 			currentPartitionKey = "LIST";
 		else if (partitioningMethod.equals(MColumn.PARTITIONINGMETHOD_Range))
 			currentPartitionKey = "RANGE";
-		currentPartitionKey += " (" + partitionKeyColumn.getColumnName().toLowerCase() + ")";
+		currentPartitionKey += " (" + partitionKeyColumn.getColumnName().toLowerCase() + ")"; // IDEMPIERE-7089-P3
 		currentPartitionKey = currentPartitionKey.replace(",", ", ");				
 		if (!currentPartitionKey.equalsIgnoreCase(partitionKey))
 			return Msg.getMsg(Env.getCtx(), "PartitionConfigurationChanged") + ": " + partitionKey;
@@ -748,7 +748,7 @@ public class TablePartitionService implements ITablePartitionService {
 		
 		for (RangePartitionInterval rangePartitionInterval : rangePartitionIntervals)
 		{
-			X_AD_TablePartition partition = createNewRangePartition(rangePartitionInterval, tablePartitionNames, table, partitionKeyColumn, table.getTableName().toLowerCase(), 
+			X_AD_TablePartition partition = createNewRangePartition(rangePartitionInterval, tablePartitionNames, table, partitionKeyColumn, table.getTableName().toLowerCase(),  // IDEMPIERE-7089-P3
 					getDefaultPartitionName(table), null, trxName);			
 			if (partition != null)
 			{
@@ -787,7 +787,7 @@ public class TablePartitionService implements ITablePartitionService {
 				ResultSet rs = stmt.executeQuery();
 				while(rs.next()) {
 					X_AD_TablePartition partition = new X_AD_TablePartition(Env.getCtx(), rs, trxName);
-					if (partition.getName().toLowerCase().endsWith("_default_partition"))
+					if (partition.getName().toLowerCase().endsWith("_default_partition")) // IDEMPIERE-7089-P3
 						continue;
 					partitions.add(partition);
 					tablePartitionNames.add(partition.getName());
@@ -947,7 +947,7 @@ public class TablePartitionService implements ITablePartitionService {
 	private boolean addListPartition(MTable table, MColumn partitionKeyColumn, String trxName, ProcessInfo pi, MColumn subPartitionColumn) {
 		boolean isUpdated = false;
 		HashMap<String, Object> columnValues = new HashMap<>();
-		List<X_AD_TablePartition> partitions = generateListPartition(table, table.getTableName().toLowerCase(), getDefaultPartitionName(table), partitionKeyColumn, columnValues, null, trxName);
+		List<X_AD_TablePartition> partitions = generateListPartition(table, table.getTableName().toLowerCase(), getDefaultPartitionName(table), partitionKeyColumn, columnValues, null, trxName); // IDEMPIERE-7089-P3
 		for (X_AD_TablePartition partition : partitions)
 		{
 			Object value = columnValues.get(partition.getName());
@@ -988,7 +988,7 @@ public class TablePartitionService implements ITablePartitionService {
 				ResultSet rs = stmt.executeQuery();
 				while(rs.next()) {
 					X_AD_TablePartition partition = new X_AD_TablePartition(Env.getCtx(), rs, trxName);
-					if (partition.getName().toLowerCase().endsWith("_default_partition"))
+					if (partition.getName().toLowerCase().endsWith("_default_partition")) // IDEMPIERE-7089-P3
 						continue;
 					partitions.add(partition);
 					tablePartitionNames.add(partition.getName());
@@ -1099,7 +1099,7 @@ public class TablePartitionService implements ITablePartitionService {
 		else if (partitioningMethod.equals(MColumn.PARTITIONINGMETHOD_Range))
 			currentPartitionKey = "RANGE";
 		String partitionKey = getPartitionKeyDefinition(table, trxName);
-		if (!partitionKey.toLowerCase().startsWith(currentPartitionKey.toLowerCase()))
+		if (!partitionKey.toLowerCase().startsWith(currentPartitionKey.toLowerCase())) // IDEMPIERE-7089-P3
 			return Msg.getMsg(Env.getCtx(), "PartitionConfigurationChanged") + " [" + MColumn.COLUMNNAME_PartitioningMethod + "]";
 		return null;
 	}

--- a/org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java
+++ b/org.compiere.db.postgresql.provider/src/org/adempiere/db/postgresql/partition/TablePartitionService.java
@@ -147,7 +147,7 @@ public class TablePartitionService implements ITablePartitionService {
 
 					List<String> lowerCasePartitionKeyColumnNames = new ArrayList<String>();
 					for (String partitionKeyColumnName : partitionKeyColumnNames)
-						lowerCasePartitionKeyColumnNames.add(partitionKeyColumnName.toLowerCase()); // IDEMPIERE-7089-P3
+						lowerCasePartitionKeyColumnNames.add(partitionKeyColumnName.toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 					String constraintColumnsStr = constraint_definition.substring(constraint_definition.indexOf("(")+1, constraint_definition.length()-1);
 					StringTokenizer st = new StringTokenizer(constraintColumnsStr, ",");
 					while (st.hasMoreTokens()) {
@@ -185,8 +185,8 @@ public class TablePartitionService implements ITablePartitionService {
 				
 				if (constraint_definition.startsWith("CHECK ") || constraint_definition.startsWith("FOREIGN KEY "))
 				{
-					if (constraint_definition.indexOf(getDefaultPartitionName(table).toLowerCase()) >= 0) { // IDEMPIERE-7089-P3
-						constraint_definition = constraint_definition.replace(getDefaultPartitionName(table).toLowerCase(), table.getTableName().toLowerCase()); // IDEMPIERE-7089-P3
+					if (constraint_definition.indexOf(getDefaultPartitionName(table).toLowerCase(java.util.Locale.ROOT)) >= 0) { // IDEMPIERE-7089-P3
+						constraint_definition = constraint_definition.replace(getDefaultPartitionName(table).toLowerCase(java.util.Locale.ROOT), table.getTableName().toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 					}
 					StringBuilder alterStmt = new StringBuilder();
 					alterStmt.append("ALTER TABLE ").append(table.getTableName()).append(" ");
@@ -224,7 +224,7 @@ public class TablePartitionService implements ITablePartitionService {
 		Map<String, String> indexMap = new HashMap<String, String>();
 		Map<String, String> uniqueMap = new HashMap<String, String>();
 		try (PreparedStatement stmt = DB.prepareStatement(indexs, trxName)) {
-			stmt.setString(1, getDefaultPartitionName(table).toLowerCase()); // IDEMPIERE-7089-P3
+			stmt.setString(1, getDefaultPartitionName(table).toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 			ResultSet rs = stmt.executeQuery();
 			while(rs.next()) {
 				String indexName = rs.getString(1);
@@ -242,22 +242,22 @@ public class TablePartitionService implements ITablePartitionService {
 		List<String> partitionKeyColumnNames = table.getPartitionKeyColumnNames();
 		for(String indexName : uniqueMap.keySet()) {
 			String consql = "select conindid::regclass from pg_constraint where conrelid = ?::regclass and conindid = ?::regclass";
-			String conindid = DB.getSQLValueString(trxName, consql, table.getTableName().toLowerCase(), indexName.toLowerCase()); // IDEMPIERE-7089-P3
+			String conindid = DB.getSQLValueString(trxName, consql, table.getTableName().toLowerCase(java.util.Locale.ROOT), indexName.toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 			if (conindid != null && conindid.equalsIgnoreCase(indexName))
 				continue;
 			
 			//unique index must include partition key column
 			String indexdef = uniqueMap.get(indexName);
 			for(String partitionKey : partitionKeyColumnNames) {
-				if (!indexdef.contains(partitionKey.toLowerCase()+",") && !indexdef.contains(partitionKey.toLowerCase()+")")) { // IDEMPIERE-7089-P3
-					int whereIndex = indexdef.toLowerCase().indexOf(" where "); // IDEMPIERE-7089-P3
+				if (!indexdef.contains(partitionKey.toLowerCase(java.util.Locale.ROOT)+",") && !indexdef.contains(partitionKey.toLowerCase(java.util.Locale.ROOT)+")")) { // IDEMPIERE-7089-P3
+					int whereIndex = indexdef.toLowerCase(java.util.Locale.ROOT).indexOf(" where "); // IDEMPIERE-7089-P3
 					if (whereIndex > 0) {
 						String whereClause = indexdef.substring(whereIndex);
 						indexdef = indexdef.substring(0, whereIndex);
-						indexdef = indexdef.substring(0, indexdef.length()-1)+", "+partitionKey.toLowerCase()+")"; // IDEMPIERE-7089-P3
+						indexdef = indexdef.substring(0, indexdef.length()-1)+", "+partitionKey.toLowerCase(java.util.Locale.ROOT)+")"; // IDEMPIERE-7089-P3
 						indexdef = indexdef + whereClause;
 					} else {
-						indexdef = indexdef.substring(0, indexdef.length()-1)+", "+partitionKey.toLowerCase()+")"; // IDEMPIERE-7089-P3
+						indexdef = indexdef.substring(0, indexdef.length()-1)+", "+partitionKey.toLowerCase(java.util.Locale.ROOT)+")"; // IDEMPIERE-7089-P3
 					}
 				}
 			}			
@@ -265,7 +265,7 @@ public class TablePartitionService implements ITablePartitionService {
 			DB.executeUpdateEx(alter.toString(), trxName);
 			if (pi != null)
 				pi.addLog(0, null, null, alter.toString());
-			indexdef = indexdef.replace(" ON adempiere."+getDefaultPartitionName(table).toLowerCase()+" ", " ON adempiere."+table.getTableName().toLowerCase()+" "); // IDEMPIERE-7089-P3
+			indexdef = indexdef.replace(" ON adempiere."+getDefaultPartitionName(table).toLowerCase(java.util.Locale.ROOT)+" ", " ON adempiere."+table.getTableName().toLowerCase(java.util.Locale.ROOT)+" "); // IDEMPIERE-7089-P3
 			DB.executeUpdateEx(indexdef, trxName);
 			if (pi != null)
 				pi.addLog(0, null, null, indexdef);
@@ -273,7 +273,7 @@ public class TablePartitionService implements ITablePartitionService {
 		
 		for(String indexName : indexMap.keySet()) {
 			String consql = "select conindid::regclass from pg_constraint where conrelid = ?::regclass and conindid = ?::regclass";
-			String conindid = DB.getSQLValueString(trxName, consql, table.getTableName().toLowerCase(), indexName.toLowerCase()); // IDEMPIERE-7089-P3
+			String conindid = DB.getSQLValueString(trxName, consql, table.getTableName().toLowerCase(java.util.Locale.ROOT), indexName.toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 			if (conindid != null && conindid.equalsIgnoreCase(indexName))
 				continue;
 			
@@ -282,7 +282,7 @@ public class TablePartitionService implements ITablePartitionService {
 			DB.executeUpdateEx(alter.toString(), trxName);
 			if (pi != null)
 				pi.addLog(0, null, null, alter.toString());
-			indexdef = indexdef.replace(" ON adempiere."+getDefaultPartitionName(table).toLowerCase()+" ", " ON adempiere."+table.getTableName().toLowerCase()+" "); // IDEMPIERE-7089-P3
+			indexdef = indexdef.replace(" ON adempiere."+getDefaultPartitionName(table).toLowerCase(java.util.Locale.ROOT)+" ", " ON adempiere."+table.getTableName().toLowerCase(java.util.Locale.ROOT)+" "); // IDEMPIERE-7089-P3
 			DB.executeUpdateEx(indexdef, trxName);
 			if (pi != null)
 				pi.addLog(0, null, null, indexdef);
@@ -451,8 +451,8 @@ public class TablePartitionService implements ITablePartitionService {
 			)
 			select relname, viewoid, max(depth) from depv group by relname, viewoid order by 3 desc
 			""";
-		String defaultPartitionName = getDefaultPartitionName(table).toLowerCase(); // IDEMPIERE-7089-P3
-		String tableName = table.getTableName().toLowerCase(); // IDEMPIERE-7089-P3
+		String defaultPartitionName = getDefaultPartitionName(table).toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
+		String tableName = table.getTableName().toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 		List<String> viewTexts = new ArrayList<String>();
 		List<String> viewNames = new ArrayList<String>();
 		List<String> grants = new ArrayList<String>();
@@ -476,7 +476,7 @@ public class TablePartitionService implements ITablePartitionService {
 			for(int i = 0; i < viewNames.size(); i++) {
 				String viewName = viewNames.get(i);
 				try(PreparedStatement stmt1 = DB.prepareStatement(grantSQL, trxName)) {
-					stmt1.setString(1, viewName.toLowerCase()); // IDEMPIERE-7089-P3
+					stmt1.setString(1, viewName.toLowerCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 					ResultSet rs1 = stmt1.executeQuery();
 					while(rs1.next()) {
 						grants.add(rs1.getString(1));
@@ -566,7 +566,7 @@ public class TablePartitionService implements ITablePartitionService {
 			currentPartitionKey = "LIST";
 		else if (partitioningMethod.equals(MColumn.PARTITIONINGMETHOD_Range))
 			currentPartitionKey = "RANGE";
-		currentPartitionKey += " (" + partitionKeyColumn.getColumnName().toLowerCase() + ")"; // IDEMPIERE-7089-P3
+		currentPartitionKey += " (" + partitionKeyColumn.getColumnName().toLowerCase(java.util.Locale.ROOT) + ")"; // IDEMPIERE-7089-P3
 		currentPartitionKey = currentPartitionKey.replace(",", ", ");				
 		if (!currentPartitionKey.equalsIgnoreCase(partitionKey))
 			return Msg.getMsg(Env.getCtx(), "PartitionConfigurationChanged") + ": " + partitionKey;
@@ -748,7 +748,7 @@ public class TablePartitionService implements ITablePartitionService {
 		
 		for (RangePartitionInterval rangePartitionInterval : rangePartitionIntervals)
 		{
-			X_AD_TablePartition partition = createNewRangePartition(rangePartitionInterval, tablePartitionNames, table, partitionKeyColumn, table.getTableName().toLowerCase(),  // IDEMPIERE-7089-P3
+			X_AD_TablePartition partition = createNewRangePartition(rangePartitionInterval, tablePartitionNames, table, partitionKeyColumn, table.getTableName().toLowerCase(java.util.Locale.ROOT),  // IDEMPIERE-7089-P3
 					getDefaultPartitionName(table), null, trxName);			
 			if (partition != null)
 			{
@@ -787,7 +787,7 @@ public class TablePartitionService implements ITablePartitionService {
 				ResultSet rs = stmt.executeQuery();
 				while(rs.next()) {
 					X_AD_TablePartition partition = new X_AD_TablePartition(Env.getCtx(), rs, trxName);
-					if (partition.getName().toLowerCase().endsWith("_default_partition")) // IDEMPIERE-7089-P3
+					if (partition.getName().toLowerCase(java.util.Locale.ROOT).endsWith("_default_partition")) // IDEMPIERE-7089-P3
 						continue;
 					partitions.add(partition);
 					tablePartitionNames.add(partition.getName());
@@ -947,7 +947,7 @@ public class TablePartitionService implements ITablePartitionService {
 	private boolean addListPartition(MTable table, MColumn partitionKeyColumn, String trxName, ProcessInfo pi, MColumn subPartitionColumn) {
 		boolean isUpdated = false;
 		HashMap<String, Object> columnValues = new HashMap<>();
-		List<X_AD_TablePartition> partitions = generateListPartition(table, table.getTableName().toLowerCase(), getDefaultPartitionName(table), partitionKeyColumn, columnValues, null, trxName); // IDEMPIERE-7089-P3
+		List<X_AD_TablePartition> partitions = generateListPartition(table, table.getTableName().toLowerCase(java.util.Locale.ROOT), getDefaultPartitionName(table), partitionKeyColumn, columnValues, null, trxName); // IDEMPIERE-7089-P3
 		for (X_AD_TablePartition partition : partitions)
 		{
 			Object value = columnValues.get(partition.getName());
@@ -988,7 +988,7 @@ public class TablePartitionService implements ITablePartitionService {
 				ResultSet rs = stmt.executeQuery();
 				while(rs.next()) {
 					X_AD_TablePartition partition = new X_AD_TablePartition(Env.getCtx(), rs, trxName);
-					if (partition.getName().toLowerCase().endsWith("_default_partition")) // IDEMPIERE-7089-P3
+					if (partition.getName().toLowerCase(java.util.Locale.ROOT).endsWith("_default_partition")) // IDEMPIERE-7089-P3
 						continue;
 					partitions.add(partition);
 					tablePartitionNames.add(partition.getName());
@@ -1099,7 +1099,7 @@ public class TablePartitionService implements ITablePartitionService {
 		else if (partitioningMethod.equals(MColumn.PARTITIONINGMETHOD_Range))
 			currentPartitionKey = "RANGE";
 		String partitionKey = getPartitionKeyDefinition(table, trxName);
-		if (!partitionKey.toLowerCase().startsWith(currentPartitionKey.toLowerCase())) // IDEMPIERE-7089-P3
+		if (!partitionKey.toLowerCase(java.util.Locale.ROOT).startsWith(currentPartitionKey.toLowerCase(java.util.Locale.ROOT))) // IDEMPIERE-7089-P3
 			return Msg.getMsg(Env.getCtx(), "PartitionConfigurationChanged") + " [" + MColumn.COLUMNNAME_PartitioningMethod + "]";
 		return null;
 	}

--- a/org.compiere.db.postgresql.provider/src/org/compiere/db/DB_PostgreSQL.java
+++ b/org.compiere.db.postgresql.provider/src/org/compiere/db/DB_PostgreSQL.java
@@ -854,7 +854,7 @@ public class DB_PostgreSQL implements AdempiereDatabase
 	{
 		if (IXName == null || IXName.length()==0)
 			return "0";
-		if (IXName.toUpperCase().endsWith("_KEY")) // IDEMPIERE-7089-P3
+		if (IXName.toUpperCase(java.util.Locale.ROOT).endsWith("_KEY")) // IDEMPIERE-7089-P3
 			return "1"+IXName;
 		else
 			return "0";
@@ -919,7 +919,7 @@ public class DB_PostgreSQL implements AdempiereDatabase
 				trxName = Trx.createTrxName("getNextval");
 				trx = Trx.get(trxName, true);
 			}
-			m_sequence_id = DB.getSQLValueEx(trxName, "SELECT nextval('"+name.toLowerCase()+"')"); // IDEMPIERE-7089-P3
+			m_sequence_id = DB.getSQLValueEx(trxName, "SELECT nextval('"+name.toLowerCase(java.util.Locale.ROOT)+"')"); // IDEMPIERE-7089-P3
 		} catch (Exception e) {
 			if (trx != null) {
 				trx.rollback();
@@ -935,7 +935,7 @@ public class DB_PostgreSQL implements AdempiereDatabase
 	public boolean createSequence(String name , int increment , int minvalue , int maxvalue ,int  start, String trxName)
 	{
 		// Check if Sequence exists
-		final int cnt = DB.getSQLValueEx(trxName, "SELECT COUNT(*) FROM pg_class WHERE UPPER(relname)=? AND relkind='S'", name.toUpperCase()); // IDEMPIERE-7089-P3
+		final int cnt = DB.getSQLValueEx(trxName, "SELECT COUNT(*) FROM pg_class WHERE UPPER(relname)=? AND relkind='S'", name.toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P3
 		final int no;
 		if (start < minvalue)
 			start = minvalue;
@@ -943,7 +943,7 @@ public class DB_PostgreSQL implements AdempiereDatabase
 		// New Sequence
 		if (cnt == 0)
 		{
-			no = DB.executeUpdate("CREATE SEQUENCE "+name.toUpperCase() // IDEMPIERE-7089-P3
+			no = DB.executeUpdate("CREATE SEQUENCE "+name.toUpperCase(java.util.Locale.ROOT) // IDEMPIERE-7089-P3
 								+ " INCREMENT BY " + increment
 								+ " MINVALUE " + minvalue
 								+ " MAXVALUE " + maxvalue
@@ -953,7 +953,7 @@ public class DB_PostgreSQL implements AdempiereDatabase
 		// Already existing sequence => ALTER
 		else
 		{
-			no = DB.executeUpdate("ALTER SEQUENCE "+name.toUpperCase() // IDEMPIERE-7089-P3
+			no = DB.executeUpdate("ALTER SEQUENCE "+name.toUpperCase(java.util.Locale.ROOT) // IDEMPIERE-7089-P3
 					+ " INCREMENT BY " + increment
 					+ " MINVALUE " + minvalue
 					+ " MAXVALUE " + maxvalue
@@ -1162,7 +1162,7 @@ public class DB_PostgreSQL implements AdempiereDatabase
 			return columnName;
 		}
 		
-		String lowerCase = columnName.toLowerCase(); // IDEMPIERE-7089-P3
+		String lowerCase = columnName.toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 		if (reservedKeywords.contains(lowerCase)) {
 			StringBuilder sql = new StringBuilder("\"");
 			sql.append(lowerCase).append("\"");

--- a/org.compiere.db.postgresql.provider/src/org/compiere/db/DB_PostgreSQL.java
+++ b/org.compiere.db.postgresql.provider/src/org/compiere/db/DB_PostgreSQL.java
@@ -854,7 +854,7 @@ public class DB_PostgreSQL implements AdempiereDatabase
 	{
 		if (IXName == null || IXName.length()==0)
 			return "0";
-		if (IXName.toUpperCase().endsWith("_KEY"))
+		if (IXName.toUpperCase().endsWith("_KEY")) // IDEMPIERE-7089-P3
 			return "1"+IXName;
 		else
 			return "0";
@@ -919,7 +919,7 @@ public class DB_PostgreSQL implements AdempiereDatabase
 				trxName = Trx.createTrxName("getNextval");
 				trx = Trx.get(trxName, true);
 			}
-			m_sequence_id = DB.getSQLValueEx(trxName, "SELECT nextval('"+name.toLowerCase()+"')");
+			m_sequence_id = DB.getSQLValueEx(trxName, "SELECT nextval('"+name.toLowerCase()+"')"); // IDEMPIERE-7089-P3
 		} catch (Exception e) {
 			if (trx != null) {
 				trx.rollback();
@@ -935,7 +935,7 @@ public class DB_PostgreSQL implements AdempiereDatabase
 	public boolean createSequence(String name , int increment , int minvalue , int maxvalue ,int  start, String trxName)
 	{
 		// Check if Sequence exists
-		final int cnt = DB.getSQLValueEx(trxName, "SELECT COUNT(*) FROM pg_class WHERE UPPER(relname)=? AND relkind='S'", name.toUpperCase());
+		final int cnt = DB.getSQLValueEx(trxName, "SELECT COUNT(*) FROM pg_class WHERE UPPER(relname)=? AND relkind='S'", name.toUpperCase()); // IDEMPIERE-7089-P3
 		final int no;
 		if (start < minvalue)
 			start = minvalue;
@@ -943,7 +943,7 @@ public class DB_PostgreSQL implements AdempiereDatabase
 		// New Sequence
 		if (cnt == 0)
 		{
-			no = DB.executeUpdate("CREATE SEQUENCE "+name.toUpperCase()
+			no = DB.executeUpdate("CREATE SEQUENCE "+name.toUpperCase() // IDEMPIERE-7089-P3
 								+ " INCREMENT BY " + increment
 								+ " MINVALUE " + minvalue
 								+ " MAXVALUE " + maxvalue
@@ -953,7 +953,7 @@ public class DB_PostgreSQL implements AdempiereDatabase
 		// Already existing sequence => ALTER
 		else
 		{
-			no = DB.executeUpdate("ALTER SEQUENCE "+name.toUpperCase()
+			no = DB.executeUpdate("ALTER SEQUENCE "+name.toUpperCase() // IDEMPIERE-7089-P3
 					+ " INCREMENT BY " + increment
 					+ " MINVALUE " + minvalue
 					+ " MAXVALUE " + maxvalue
@@ -1162,7 +1162,7 @@ public class DB_PostgreSQL implements AdempiereDatabase
 			return columnName;
 		}
 		
-		String lowerCase = columnName.toLowerCase();
+		String lowerCase = columnName.toLowerCase(); // IDEMPIERE-7089-P3
 		if (reservedKeywords.contains(lowerCase)) {
 			StringBuilder sql = new StringBuilder("\"");
 			sql.append(lowerCase).append("\"");

--- a/org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java
+++ b/org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java
@@ -108,7 +108,7 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 			statement = convertSimilarTo(statement);
 			statement = DB_PostgreSQL.removeNativeKeyworkMarker(statement);
 
-			String cmpString = statement.toUpperCase();
+			String cmpString = statement.toUpperCase(); // IDEMPIERE-7089-P3
 			boolean isCreate = cmpString.startsWith("CREATE ");
 
 			// Process
@@ -257,16 +257,16 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 		String retValue = sqlStatement;
 
 		// Convert all decode parts
-		int found = retValue.toUpperCase().indexOf("DECODE"); 
+		int found = retValue.toUpperCase().indexOf("DECODE");  // IDEMPIERE-7089-P3
 		int fromIndex = 0;
 		while ( found != -1) {
 			retValue = convertDecode(retValue, fromIndex);
 			fromIndex = found + 6;
-			found = retValue.toUpperCase().indexOf("DECODE", fromIndex);
+			found = retValue.toUpperCase().indexOf("DECODE", fromIndex); // IDEMPIERE-7089-P3
 		}
 		
 		// Outer Join Handling -----------------------------------------------
-		int index = retValue.toUpperCase().indexOf("SELECT ");
+		int index = retValue.toUpperCase().indexOf("SELECT "); // IDEMPIERE-7089-P3
 		if (index != -1 && retValue.indexOf("(+)", index) != -1)
 			retValue = convertOuterJoin(retValue);
 
@@ -304,7 +304,7 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 			String arg1 = m.group(gidx_arg1);
 			String arg2 = m.group(gidx_arg2);
 			//
-			String datatype = convertMap.get("\\b"+arg2.toUpperCase()+"\\b");
+			String datatype = convertMap.get("\\b"+arg2.toUpperCase()+"\\b"); // IDEMPIERE-7089-P3
 			if (datatype == null)
 				datatype = arg2;
 			m.appendReplacement(retValue, "cast("+arg1+" as "+datatype+")");
@@ -473,7 +473,7 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 		String targetTable = null;
 		String targetAlias = null;
 		
-		String sqlUpper = sqlStatement.toUpperCase();
+		String sqlUpper = sqlStatement.toUpperCase(); // IDEMPIERE-7089-P3
 		StringBuilder token = new StringBuilder();
 		String previousToken = null;
 		int charIndex = 0;
@@ -687,7 +687,7 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 					{
 						if (token.length() == 0 && 
 							( "SELECT".equalsIgnoreCase(previousToken) || 
-							  (previousToken != null && previousToken.toUpperCase().endsWith("SELECT")))) 
+							  (previousToken != null && previousToken.toUpperCase().endsWith("SELECT"))))  // IDEMPIERE-7089-P3
 							joinFieldsBegin = i;
 					}
 					else if (c == '(')
@@ -813,7 +813,7 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 	 */
 	private boolean useAggregateFunction(String fields) 
 	{
-		String fieldsUpper = fields.toUpperCase();
+		String fieldsUpper = fields.toUpperCase(); // IDEMPIERE-7089-P3
 		int size = fieldsUpper.length();
 		StringBuilder buffer = new StringBuilder();
 		String token = null;
@@ -910,7 +910,7 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 					}
 					if (t.length() > 0)
 					{
-						if ("SELECT".equalsIgnoreCase(t.toString().toUpperCase())) 
+						if ("SELECT".equalsIgnoreCase(t.toString().toUpperCase()))  // IDEMPIERE-7089-P3
 						{
 							o = 0;
 							result = result + t.toString();
@@ -1054,27 +1054,27 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 	// ALTER TABLE AD_FieldGroup ALTER COLUMN IsTab TYPE CHAR(1); ALTER TABLE
 	// AD_FieldGroup ALTER COLUMN SET DEFAULT 'N';
 	private String convertDDL(String sqlStatement) {
-		if (sqlStatement.toUpperCase().indexOf("ALTER TABLE ") == 0) {
+		if (sqlStatement.toUpperCase().indexOf("ALTER TABLE ") == 0) { // IDEMPIERE-7089-P3
 			String action = null;
 			int begin_col = -1;
-			if (sqlStatement.toUpperCase().indexOf(" MODIFY ") > 0) {
+			if (sqlStatement.toUpperCase().indexOf(" MODIFY ") > 0) { // IDEMPIERE-7089-P3
 				action = " MODIFY ";
-				begin_col = sqlStatement.toUpperCase().indexOf(" MODIFY ")
+				begin_col = sqlStatement.toUpperCase().indexOf(" MODIFY ") // IDEMPIERE-7089-P3
 						+ action.length();
-			} else if (sqlStatement.toUpperCase().indexOf(" ADD ") > 0) {
-				if (sqlStatement.toUpperCase().indexOf(" ADD CONSTRAINT ") < 0 &&
-						sqlStatement.toUpperCase().indexOf(" ADD FOREIGN KEY " ) < 0 )
+			} else if (sqlStatement.toUpperCase().indexOf(" ADD ") > 0) { // IDEMPIERE-7089-P3
+				if (sqlStatement.toUpperCase().indexOf(" ADD CONSTRAINT ") < 0 && // IDEMPIERE-7089-P3
+						sqlStatement.toUpperCase().indexOf(" ADD FOREIGN KEY " ) < 0 ) // IDEMPIERE-7089-P3
 				{
 					action = " ADD ";
-					begin_col = sqlStatement.toUpperCase().indexOf(" ADD ")
+					begin_col = sqlStatement.toUpperCase().indexOf(" ADD ") // IDEMPIERE-7089-P3
 							+ action.length();
 				}
 			}
 
 			// System.out.println( "MODIFY :" +
-			// sqlStatement.toUpperCase().indexOf(" MODIFY "));
+			// sqlStatement.toUpperCase().indexOf(" MODIFY ")); // IDEMPIERE-7089-P6
 			// System.out.println( "ADD :" +
-			// sqlStatement.toUpperCase().indexOf(" ADD "));
+			// sqlStatement.toUpperCase().indexOf(" ADD ")); // IDEMPIERE-7089-P6
 			// System.out.println( "begincolumn:" + sqlStatement +
 			// "begincolumn:" + begin_col );
 
@@ -1101,9 +1101,9 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 				String rest = sqlStatement.substring(end_col + 1); 
 				
 				if (action.equals(" ADD ")) {
-					if (rest.toUpperCase().indexOf(" DEFAULT ") != -1) {
-						String beforeDefault = rest.substring(0, rest.toUpperCase().indexOf(" DEFAULT "));
-						begin_default = rest.toUpperCase().indexOf(
+					if (rest.toUpperCase().indexOf(" DEFAULT ") != -1) { // IDEMPIERE-7089-P3
+						String beforeDefault = rest.substring(0, rest.toUpperCase().indexOf(" DEFAULT ")); // IDEMPIERE-7089-P3
+						begin_default = rest.toUpperCase().indexOf( // IDEMPIERE-7089-P3
 								" DEFAULT ") + 9;
 						defaultvalue = rest.substring(begin_default);
 						String endDefaultChar = " ";
@@ -1158,8 +1158,8 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 				} else if (action.equals(" MODIFY "))
 				{
 					rest = rest.trim();
-					if (rest.toUpperCase().startsWith("NOT ") || rest.toUpperCase().startsWith("NULL ") 
-							|| rest.toUpperCase().equals("NULL") || rest.toUpperCase().equals("NOT NULL"))
+					if (rest.toUpperCase().startsWith("NOT ") || rest.toUpperCase().startsWith("NULL ")  // IDEMPIERE-7089-P3
+							|| rest.toUpperCase().equals("NULL") || rest.toUpperCase().equals("NOT NULL")) // IDEMPIERE-7089-P3
 					{
 						type = null;
 					}
@@ -1170,8 +1170,8 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 						rest = typeEnd > 0 ? rest.substring(typeEnd) : "";
 					}
 
-					if (rest.toUpperCase().indexOf(" DEFAULT ") != -1) {
-						begin_default = rest.toUpperCase().indexOf(
+					if (rest.toUpperCase().indexOf(" DEFAULT ") != -1) { // IDEMPIERE-7089-P3
+						begin_default = rest.toUpperCase().indexOf( // IDEMPIERE-7089-P3
 								" DEFAULT ") + 9;
 						defaultvalue = rest.substring(begin_default);
 						String endDefaultChar = " ";
@@ -1192,26 +1192,26 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 						if(defaultvalue.startsWith("'") && defaultvalue.endsWith("'"))
 							defaultvalue = defaultvalue.substring(1, defaultvalue.length() - 1);
 						
-						if (rest != null && rest.toUpperCase().indexOf("NOT NULL") >= 0)
+						if (rest != null && rest.toUpperCase().indexOf("NOT NULL") >= 0) // IDEMPIERE-7089-P3
 							nullclause = "NOT NULL";
-						else if (rest != null && rest.toUpperCase().indexOf("NULL") >= 0)
+						else if (rest != null && rest.toUpperCase().indexOf("NULL") >= 0) // IDEMPIERE-7089-P3
 							nullclause = "NULL";
 							
 						// return DDL;
 					}
-					else if ( rest != null && rest.toUpperCase().indexOf("NOT NULL") >= 0 ) {
+					else if ( rest != null && rest.toUpperCase().indexOf("NOT NULL") >= 0 ) { // IDEMPIERE-7089-P3
 						nullclause = "NOT NULL";
 						
 					}
-					else if ( rest != null && rest.toUpperCase().indexOf("NULL") >= 0) {
+					else if ( rest != null && rest.toUpperCase().indexOf("NULL") >= 0) { // IDEMPIERE-7089-P3
 						nullclause = "NULL";
 						
 					}
 
 					DDL = "INSERT INTO t_alter_column values('";
 					String tableName = sqlStatement.substring(0, begin_col - action.length());
-					tableName = tableName.toUpperCase().replace("ALTER TABLE", "");
-					tableName = tableName.trim().toLowerCase();
+					tableName = tableName.toUpperCase().replace("ALTER TABLE", ""); // IDEMPIERE-7089-P3
+					tableName = tableName.trim().toLowerCase(); // IDEMPIERE-7089-P3
 					DDL = DDL + tableName + "','" + column + "',";
 					if (type != null)
 						DDL = DDL + "'" + type +"',";
@@ -1241,7 +1241,7 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 	 * @return
 	 */
 	private String convertAddJson(String statement) {
-		if (statement.toUpperCase().matches(".*\\bCLOB\\b.*\\bCONSTRAINT\\b.*CHECK\\b.*\\bIS JSON\\).*")) {
+		if (statement.toUpperCase().matches(".*\\bCLOB\\b.*\\bCONSTRAINT\\b.*CHECK\\b.*\\bIS JSON\\).*")) { // IDEMPIERE-7089-P3
 			// remove the CONSTRAINT ... IS JSON part
 			statement = statement.replaceAll("(?i)\\bCONSTRAINT\\b.*CHECK\\b.*\\(.*\\bIS JSON\\)", "");
 			// change type CLOB to JSONB

--- a/org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java
+++ b/org.compiere.db.postgresql.provider/src/org/compiere/dbPort/Convert_PostgreSQL.java
@@ -108,7 +108,7 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 			statement = convertSimilarTo(statement);
 			statement = DB_PostgreSQL.removeNativeKeyworkMarker(statement);
 
-			String cmpString = statement.toUpperCase(); // IDEMPIERE-7089-P3
+			String cmpString = statement.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 			boolean isCreate = cmpString.startsWith("CREATE ");
 
 			// Process
@@ -257,16 +257,16 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 		String retValue = sqlStatement;
 
 		// Convert all decode parts
-		int found = retValue.toUpperCase().indexOf("DECODE");  // IDEMPIERE-7089-P3
+		int found = retValue.toUpperCase(java.util.Locale.ROOT).indexOf("DECODE");  // IDEMPIERE-7089-P3
 		int fromIndex = 0;
 		while ( found != -1) {
 			retValue = convertDecode(retValue, fromIndex);
 			fromIndex = found + 6;
-			found = retValue.toUpperCase().indexOf("DECODE", fromIndex); // IDEMPIERE-7089-P3
+			found = retValue.toUpperCase(java.util.Locale.ROOT).indexOf("DECODE", fromIndex); // IDEMPIERE-7089-P3
 		}
 		
 		// Outer Join Handling -----------------------------------------------
-		int index = retValue.toUpperCase().indexOf("SELECT "); // IDEMPIERE-7089-P3
+		int index = retValue.toUpperCase(java.util.Locale.ROOT).indexOf("SELECT "); // IDEMPIERE-7089-P3
 		if (index != -1 && retValue.indexOf("(+)", index) != -1)
 			retValue = convertOuterJoin(retValue);
 
@@ -304,7 +304,7 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 			String arg1 = m.group(gidx_arg1);
 			String arg2 = m.group(gidx_arg2);
 			//
-			String datatype = convertMap.get("\\b"+arg2.toUpperCase()+"\\b"); // IDEMPIERE-7089-P3
+			String datatype = convertMap.get("\\b"+arg2.toUpperCase(java.util.Locale.ROOT)+"\\b"); // IDEMPIERE-7089-P3
 			if (datatype == null)
 				datatype = arg2;
 			m.appendReplacement(retValue, "cast("+arg1+" as "+datatype+")");
@@ -473,7 +473,7 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 		String targetTable = null;
 		String targetAlias = null;
 		
-		String sqlUpper = sqlStatement.toUpperCase(); // IDEMPIERE-7089-P3
+		String sqlUpper = sqlStatement.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 		StringBuilder token = new StringBuilder();
 		String previousToken = null;
 		int charIndex = 0;
@@ -687,7 +687,7 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 					{
 						if (token.length() == 0 && 
 							( "SELECT".equalsIgnoreCase(previousToken) || 
-							  (previousToken != null && previousToken.toUpperCase().endsWith("SELECT"))))  // IDEMPIERE-7089-P3
+							  (previousToken != null && previousToken.toUpperCase(java.util.Locale.ROOT).endsWith("SELECT"))))  // IDEMPIERE-7089-P3
 							joinFieldsBegin = i;
 					}
 					else if (c == '(')
@@ -813,7 +813,7 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 	 */
 	private boolean useAggregateFunction(String fields) 
 	{
-		String fieldsUpper = fields.toUpperCase(); // IDEMPIERE-7089-P3
+		String fieldsUpper = fields.toUpperCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 		int size = fieldsUpper.length();
 		StringBuilder buffer = new StringBuilder();
 		String token = null;
@@ -910,7 +910,7 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 					}
 					if (t.length() > 0)
 					{
-						if ("SELECT".equalsIgnoreCase(t.toString().toUpperCase()))  // IDEMPIERE-7089-P3
+						if ("SELECT".equalsIgnoreCase(t.toString().toUpperCase(java.util.Locale.ROOT)))  // IDEMPIERE-7089-P3
 						{
 							o = 0;
 							result = result + t.toString();
@@ -1054,19 +1054,19 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 	// ALTER TABLE AD_FieldGroup ALTER COLUMN IsTab TYPE CHAR(1); ALTER TABLE
 	// AD_FieldGroup ALTER COLUMN SET DEFAULT 'N';
 	private String convertDDL(String sqlStatement) {
-		if (sqlStatement.toUpperCase().indexOf("ALTER TABLE ") == 0) { // IDEMPIERE-7089-P3
+		if (sqlStatement.toUpperCase(java.util.Locale.ROOT).indexOf("ALTER TABLE ") == 0) { // IDEMPIERE-7089-P3
 			String action = null;
 			int begin_col = -1;
-			if (sqlStatement.toUpperCase().indexOf(" MODIFY ") > 0) { // IDEMPIERE-7089-P3
+			if (sqlStatement.toUpperCase(java.util.Locale.ROOT).indexOf(" MODIFY ") > 0) { // IDEMPIERE-7089-P3
 				action = " MODIFY ";
-				begin_col = sqlStatement.toUpperCase().indexOf(" MODIFY ") // IDEMPIERE-7089-P3
+				begin_col = sqlStatement.toUpperCase(java.util.Locale.ROOT).indexOf(" MODIFY ") // IDEMPIERE-7089-P3
 						+ action.length();
-			} else if (sqlStatement.toUpperCase().indexOf(" ADD ") > 0) { // IDEMPIERE-7089-P3
-				if (sqlStatement.toUpperCase().indexOf(" ADD CONSTRAINT ") < 0 && // IDEMPIERE-7089-P3
-						sqlStatement.toUpperCase().indexOf(" ADD FOREIGN KEY " ) < 0 ) // IDEMPIERE-7089-P3
+			} else if (sqlStatement.toUpperCase(java.util.Locale.ROOT).indexOf(" ADD ") > 0) { // IDEMPIERE-7089-P3
+				if (sqlStatement.toUpperCase(java.util.Locale.ROOT).indexOf(" ADD CONSTRAINT ") < 0 && // IDEMPIERE-7089-P3
+						sqlStatement.toUpperCase(java.util.Locale.ROOT).indexOf(" ADD FOREIGN KEY " ) < 0 ) // IDEMPIERE-7089-P3
 				{
 					action = " ADD ";
-					begin_col = sqlStatement.toUpperCase().indexOf(" ADD ") // IDEMPIERE-7089-P3
+					begin_col = sqlStatement.toUpperCase(java.util.Locale.ROOT).indexOf(" ADD ") // IDEMPIERE-7089-P3
 							+ action.length();
 				}
 			}
@@ -1101,9 +1101,9 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 				String rest = sqlStatement.substring(end_col + 1); 
 				
 				if (action.equals(" ADD ")) {
-					if (rest.toUpperCase().indexOf(" DEFAULT ") != -1) { // IDEMPIERE-7089-P3
-						String beforeDefault = rest.substring(0, rest.toUpperCase().indexOf(" DEFAULT ")); // IDEMPIERE-7089-P3
-						begin_default = rest.toUpperCase().indexOf( // IDEMPIERE-7089-P3
+					if (rest.toUpperCase(java.util.Locale.ROOT).indexOf(" DEFAULT ") != -1) { // IDEMPIERE-7089-P3
+						String beforeDefault = rest.substring(0, rest.toUpperCase(java.util.Locale.ROOT).indexOf(" DEFAULT ")); // IDEMPIERE-7089-P3
+						begin_default = rest.toUpperCase(java.util.Locale.ROOT).indexOf( // IDEMPIERE-7089-P3
 								" DEFAULT ") + 9;
 						defaultvalue = rest.substring(begin_default);
 						String endDefaultChar = " ";
@@ -1158,8 +1158,8 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 				} else if (action.equals(" MODIFY "))
 				{
 					rest = rest.trim();
-					if (rest.toUpperCase().startsWith("NOT ") || rest.toUpperCase().startsWith("NULL ")  // IDEMPIERE-7089-P3
-							|| rest.toUpperCase().equals("NULL") || rest.toUpperCase().equals("NOT NULL")) // IDEMPIERE-7089-P3
+					if (rest.toUpperCase(java.util.Locale.ROOT).startsWith("NOT ") || rest.toUpperCase(java.util.Locale.ROOT).startsWith("NULL ")  // IDEMPIERE-7089-P3
+							|| rest.toUpperCase(java.util.Locale.ROOT).equals("NULL") || rest.toUpperCase(java.util.Locale.ROOT).equals("NOT NULL")) // IDEMPIERE-7089-P3
 					{
 						type = null;
 					}
@@ -1170,8 +1170,8 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 						rest = typeEnd > 0 ? rest.substring(typeEnd) : "";
 					}
 
-					if (rest.toUpperCase().indexOf(" DEFAULT ") != -1) { // IDEMPIERE-7089-P3
-						begin_default = rest.toUpperCase().indexOf( // IDEMPIERE-7089-P3
+					if (rest.toUpperCase(java.util.Locale.ROOT).indexOf(" DEFAULT ") != -1) { // IDEMPIERE-7089-P3
+						begin_default = rest.toUpperCase(java.util.Locale.ROOT).indexOf( // IDEMPIERE-7089-P3
 								" DEFAULT ") + 9;
 						defaultvalue = rest.substring(begin_default);
 						String endDefaultChar = " ";
@@ -1192,26 +1192,26 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 						if(defaultvalue.startsWith("'") && defaultvalue.endsWith("'"))
 							defaultvalue = defaultvalue.substring(1, defaultvalue.length() - 1);
 						
-						if (rest != null && rest.toUpperCase().indexOf("NOT NULL") >= 0) // IDEMPIERE-7089-P3
+						if (rest != null && rest.toUpperCase(java.util.Locale.ROOT).indexOf("NOT NULL") >= 0) // IDEMPIERE-7089-P3
 							nullclause = "NOT NULL";
-						else if (rest != null && rest.toUpperCase().indexOf("NULL") >= 0) // IDEMPIERE-7089-P3
+						else if (rest != null && rest.toUpperCase(java.util.Locale.ROOT).indexOf("NULL") >= 0) // IDEMPIERE-7089-P3
 							nullclause = "NULL";
 							
 						// return DDL;
 					}
-					else if ( rest != null && rest.toUpperCase().indexOf("NOT NULL") >= 0 ) { // IDEMPIERE-7089-P3
+					else if ( rest != null && rest.toUpperCase(java.util.Locale.ROOT).indexOf("NOT NULL") >= 0 ) { // IDEMPIERE-7089-P3
 						nullclause = "NOT NULL";
 						
 					}
-					else if ( rest != null && rest.toUpperCase().indexOf("NULL") >= 0) { // IDEMPIERE-7089-P3
+					else if ( rest != null && rest.toUpperCase(java.util.Locale.ROOT).indexOf("NULL") >= 0) { // IDEMPIERE-7089-P3
 						nullclause = "NULL";
 						
 					}
 
 					DDL = "INSERT INTO t_alter_column values('";
 					String tableName = sqlStatement.substring(0, begin_col - action.length());
-					tableName = tableName.toUpperCase().replace("ALTER TABLE", ""); // IDEMPIERE-7089-P3
-					tableName = tableName.trim().toLowerCase(); // IDEMPIERE-7089-P3
+					tableName = tableName.toUpperCase(java.util.Locale.ROOT).replace("ALTER TABLE", ""); // IDEMPIERE-7089-P3
+					tableName = tableName.trim().toLowerCase(java.util.Locale.ROOT); // IDEMPIERE-7089-P3
 					DDL = DDL + tableName + "','" + column + "',";
 					if (type != null)
 						DDL = DDL + "'" + type +"',";
@@ -1241,7 +1241,7 @@ public class Convert_PostgreSQL extends Convert_SQL92 {
 	 * @return
 	 */
 	private String convertAddJson(String statement) {
-		if (statement.toUpperCase().matches(".*\\bCLOB\\b.*\\bCONSTRAINT\\b.*CHECK\\b.*\\bIS JSON\\).*")) { // IDEMPIERE-7089-P3
+		if (statement.toUpperCase(java.util.Locale.ROOT).matches(".*\\bCLOB\\b.*\\bCONSTRAINT\\b.*CHECK\\b.*\\bIS JSON\\).*")) { // IDEMPIERE-7089-P3
 			// remove the CONSTRAINT ... IS JSON part
 			statement = statement.replaceAll("(?i)\\bCONSTRAINT\\b.*CHECK\\b.*\\(.*\\bIS JSON\\)", "");
 			// change type CLOB to JSONB

--- a/org.idempiere.acct/src/org/idempiere/acct/AccountingSetupServiceImpl.java
+++ b/org.idempiere.acct/src/org/idempiere/acct/AccountingSetupServiceImpl.java
@@ -562,7 +562,7 @@ public class AccountingSetupServiceImpl implements IAccountingSetupService {
 	{
 		if (log.isLoggable(Level.FINE)) log.fine(key);
 		//  Element
-		int C_ElementValue_ID = setupCtx.m_nap.getC_ElementValue_ID(key.toUpperCase()); // IDEMPIERE-7089-P5
+		int C_ElementValue_ID = setupCtx.m_nap.getC_ElementValue_ID(key.toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P5
 		if (C_ElementValue_ID == 0)
 		{
 			throw new AdempiereUserError("Account not defined: " + key);

--- a/org.idempiere.acct/src/org/idempiere/acct/AccountingSetupServiceImpl.java
+++ b/org.idempiere.acct/src/org/idempiere/acct/AccountingSetupServiceImpl.java
@@ -562,7 +562,7 @@ public class AccountingSetupServiceImpl implements IAccountingSetupService {
 	{
 		if (log.isLoggable(Level.FINE)) log.fine(key);
 		//  Element
-		int C_ElementValue_ID = setupCtx.m_nap.getC_ElementValue_ID(key.toUpperCase());
+		int C_ElementValue_ID = setupCtx.m_nap.getC_ElementValue_ID(key.toUpperCase()); // IDEMPIERE-7089-P5
 		if (C_ElementValue_ID == 0)
 		{
 			throw new AdempiereUserError("Account not defined: " + key);

--- a/org.idempiere.extension.manager/src/org/idempiere/extension/manager/form/ExtensionBrowserFormController.java
+++ b/org.idempiere.extension.manager/src/org/idempiere/extension/manager/form/ExtensionBrowserFormController.java
@@ -596,7 +596,7 @@ public class ExtensionBrowserFormController implements IFormController {
 			return;
 		}
 		
-		String filterLower = filter.toLowerCase();
+		String filterLower = filter.toLowerCase(); // IDEMPIERE-7089-P4
 		boolean filterTag = filterLower.startsWith("tag:");
 		boolean filterCategory = filterLower.startsWith("category:");
 		String searchStr = filterLower;
@@ -608,7 +608,7 @@ public class ExtensionBrowserFormController implements IFormController {
 			if (filterTag) {
 				if (ext.hasTags()) {
 					for (JsonElement tag : ext.getTags()) {
-						if (tag.getAsString().toLowerCase().contains(searchStr)) {
+						if (tag.getAsString().toLowerCase().contains(searchStr)) { // IDEMPIERE-7089-P4
 							match = true;
 							break;
 						}
@@ -617,16 +617,16 @@ public class ExtensionBrowserFormController implements IFormController {
 			} else if (filterCategory) {
 				if (ext.hasCategories()) {
 					for (JsonElement cat : ext.getCategories()) {
-						if (cat.getAsString().toLowerCase().contains(searchStr)) {
+						if (cat.getAsString().toLowerCase().contains(searchStr)) { // IDEMPIERE-7089-P4
 							match = true;
 							break;
 						}
 					}
 				}
 			} else {
-				if (ext.getName() != null && ext.getName().toLowerCase().contains(searchStr)) {
+				if (ext.getName() != null && ext.getName().toLowerCase().contains(searchStr)) { // IDEMPIERE-7089-P4
 					match = true;
-				} else if (ext.getDescription() != null && ext.getDescription().toLowerCase().contains(searchStr)) {
+				} else if (ext.getDescription() != null && ext.getDescription().toLowerCase().contains(searchStr)) { // IDEMPIERE-7089-P4
 					match = true;
 				}
 			}

--- a/org.idempiere.test/src/org/idempiere/test/adwindow/GridTabTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/adwindow/GridTabTest.java
@@ -199,7 +199,7 @@ public class GridTabTest extends AbstractTestCase {
 		
 		// test with function
 		query = new MQuery(MBPartner.Table_Name);
-		query.addRestriction("Upper("+MBPartner.COLUMNNAME_Name+")", MQuery.EQUAL, bpartner.getName().toUpperCase()); // IDEMPIERE-7089-P6
+		query.addRestriction("Upper("+MBPartner.COLUMNNAME_Name+")", MQuery.EQUAL, bpartner.getName().toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P6
 		gTab.setQuery(query);
 		gTab.query(false, 0, 0);
 		assertTrue(gTab.getRowCount()==1, "GridTab Row Count is not 1. GridTab="+gTab.getName());

--- a/org.idempiere.test/src/org/idempiere/test/adwindow/GridTabTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/adwindow/GridTabTest.java
@@ -199,7 +199,7 @@ public class GridTabTest extends AbstractTestCase {
 		
 		// test with function
 		query = new MQuery(MBPartner.Table_Name);
-		query.addRestriction("Upper("+MBPartner.COLUMNNAME_Name+")", MQuery.EQUAL, bpartner.getName().toUpperCase());
+		query.addRestriction("Upper("+MBPartner.COLUMNNAME_Name+")", MQuery.EQUAL, bpartner.getName().toUpperCase()); // IDEMPIERE-7089-P6
 		gTab.setQuery(query);
 		gTab.query(false, 0, 0);
 		assertTrue(gTab.getRowCount()==1, "GridTab Row Count is not 1. GridTab="+gTab.getName());

--- a/org.idempiere.test/src/org/idempiere/test/base/MTableTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/base/MTableTest.java
@@ -435,7 +435,7 @@ public class MTableTest extends AbstractTestCase {
 		String indexName = MTable.getUUIDIndexName(MUser.Table_Name);
 		assertNotNull(indexName, "UUID index name must not be null");
 		assertTrue(indexName.length() > 0, "UUID index name must not be empty");
-		assertTrue(indexName.toUpperCase().contains("AD_USER"), "UUID index name should contain the table name");
+		assertTrue(indexName.toUpperCase().contains("AD_USER"), "UUID index name should contain the table name"); // IDEMPIERE-7089-P6
 
 	    String tableName = MTable.Table_Name;
 	    String uuidCol = PO.getUUIDColumnName(tableName);

--- a/org.idempiere.test/src/org/idempiere/test/base/MTableTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/base/MTableTest.java
@@ -435,7 +435,7 @@ public class MTableTest extends AbstractTestCase {
 		String indexName = MTable.getUUIDIndexName(MUser.Table_Name);
 		assertNotNull(indexName, "UUID index name must not be null");
 		assertTrue(indexName.length() > 0, "UUID index name must not be empty");
-		assertTrue(indexName.toUpperCase().contains("AD_USER"), "UUID index name should contain the table name"); // IDEMPIERE-7089-P6
+		assertTrue(indexName.toUpperCase(java.util.Locale.ROOT).contains("AD_USER"), "UUID index name should contain the table name"); // IDEMPIERE-7089-P6
 
 	    String tableName = MTable.Table_Name;
 	    String uuidCol = PO.getUUIDColumnName(tableName);

--- a/org.idempiere.test/src/org/idempiere/test/base/M_ElementTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/base/M_ElementTest.java
@@ -190,7 +190,7 @@ public class M_ElementTest extends AbstractTestCase {
 	public void testGetColumnNameHelper() {
 		String columnName = DB.getSQLValueString(getTrxName(), "SELECT ColumnName FROM AD_Element WHERE AD_Element_ID=?", testElementId);
 		assertNotNull(columnName, "ColumnName must exist for test element");
-		String resolved = M_Element.getColumnName(columnName.toUpperCase()); // IDEMPIERE-7089-P6
+		String resolved = M_Element.getColumnName(columnName.toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P6
 		assertNotNull(resolved, "getColumnName should return a case-sensitive column name when present");
 		assertEquals(resolved, columnName, "M_Element.getColumnName(columnName) must have column name");
 	}
@@ -275,7 +275,7 @@ public class M_ElementTest extends AbstractTestCase {
             assertTrue(existing.save(), "New record should save successfully");
 
             duplicate = new M_Element(ctx, 0, getTrxName());
-            duplicate.setColumnName(columnName.toUpperCase()); // IDEMPIERE-7089-P6
+            duplicate.setColumnName(columnName.toUpperCase(java.util.Locale.ROOT)); // IDEMPIERE-7089-P6
             duplicate.setName(name);
             duplicate.setPrintName(name);
             duplicate.setEntityType(entityType);

--- a/org.idempiere.test/src/org/idempiere/test/base/M_ElementTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/base/M_ElementTest.java
@@ -33,6 +33,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.util.Locale;
 import java.util.Properties;
 
 import org.compiere.model.MColumn;
@@ -56,6 +57,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
 
 /**
  * Comprehensive JUnit 5 tests for {@link M_Element}.
@@ -152,6 +156,24 @@ public class M_ElementTest extends AbstractTestCase {
 	}
 
 	/**
+	 * Verify that case-insensitive database lookup does not depend on the JVM
+	 * default locale.
+	 */
+	@Test
+	@ResourceLock(value = Resources.GLOBAL, mode = ResourceAccessMode.READ_WRITE)
+	public void testStaticGetByColumnNameWithTurkishDefaultLocale() {
+		Locale originalLocale = Locale.getDefault();
+		try {
+			Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+			M_Element element = M_Element.get(ctx, "isactive", getTrxName());
+			assertNotNull(element, "Lookup must not depend on Java's default locale");
+			assertEquals("IsActive", element.getColumnName());
+		} finally {
+			Locale.setDefault(originalLocale);
+		}
+	}
+
+	/**
 	 * Test getOfColumn(ctx, AD_Column_ID) helper.
 	 */
 	@Test
@@ -168,7 +190,7 @@ public class M_ElementTest extends AbstractTestCase {
 	public void testGetColumnNameHelper() {
 		String columnName = DB.getSQLValueString(getTrxName(), "SELECT ColumnName FROM AD_Element WHERE AD_Element_ID=?", testElementId);
 		assertNotNull(columnName, "ColumnName must exist for test element");
-		String resolved = M_Element.getColumnName(columnName.toUpperCase());
+		String resolved = M_Element.getColumnName(columnName.toUpperCase()); // IDEMPIERE-7089-P6
 		assertNotNull(resolved, "getColumnName should return a case-sensitive column name when present");
 		assertEquals(resolved, columnName, "M_Element.getColumnName(columnName) must have column name");
 	}
@@ -253,7 +275,7 @@ public class M_ElementTest extends AbstractTestCase {
             assertTrue(existing.save(), "New record should save successfully");
 
             duplicate = new M_Element(ctx, 0, getTrxName());
-            duplicate.setColumnName(columnName.toUpperCase());
+            duplicate.setColumnName(columnName.toUpperCase()); // IDEMPIERE-7089-P6
             duplicate.setName(name);
             duplicate.setPrintName(name);
             duplicate.setEntityType(entityType);

--- a/org.idempiere.test/src/org/idempiere/test/base/POTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/base/POTest.java
@@ -1357,7 +1357,7 @@ public class POTest extends AbstractTestCase
     @Test
     void testGetFindParameter() {
     	MBPartner bp = new MBPartner(Env.getCtx(), DictionaryIDs.C_BPartner.C_AND_W.id, getTrxName());
-    	MBPartnerInfo[] bpInfos = MBPartnerInfo.find(Env.getCtx(), null, bp.getName().toLowerCase(), "", null, "%", null);
+	MBPartnerInfo[] bpInfos = MBPartnerInfo.find(Env.getCtx(), null, bp.getName().toLowerCase(), "", null, "%", null); // IDEMPIERE-7089-P6
     	assertTrue(bpInfos.length > 0);
     	Optional<MBPartnerInfo> optional = Arrays.stream(bpInfos).filter(e -> e.getName().equals(bp.getName())).findFirst();
     	assertTrue(optional.isPresent());		

--- a/org.idempiere.test/src/org/idempiere/test/base/POTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/base/POTest.java
@@ -1357,7 +1357,7 @@ public class POTest extends AbstractTestCase
     @Test
     void testGetFindParameter() {
     	MBPartner bp = new MBPartner(Env.getCtx(), DictionaryIDs.C_BPartner.C_AND_W.id, getTrxName());
-	MBPartnerInfo[] bpInfos = MBPartnerInfo.find(Env.getCtx(), null, bp.getName().toLowerCase(), "", null, "%", null); // IDEMPIERE-7089-P6
+	MBPartnerInfo[] bpInfos = MBPartnerInfo.find(Env.getCtx(), null, bp.getName().toLowerCase(java.util.Locale.ROOT), "", null, "%", null); // IDEMPIERE-7089-P6
     	assertTrue(bpInfos.length > 0);
     	Optional<MBPartnerInfo> optional = Arrays.stream(bpInfos).filter(e -> e.getName().equals(bp.getName())).findFirst();
     	assertTrue(optional.isPresent());		

--- a/org.idempiere.test/src/org/idempiere/test/base/QueryTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/base/QueryTest.java
@@ -436,7 +436,7 @@ public class QueryTest extends AbstractTestCase {
 		assertNotNull(user, "Failed to retrieve garden user record");
 		
 		String sql = query.getSQL();
-		assertTrue(sql.toLowerCase().contains("inner join c_bpartner on (ad_user.c_bpartner_id=c_bpartner.c_bpartner_id)"), "Unexpected SQL clause generated from query");
+		assertTrue(sql.toLowerCase().contains("inner join c_bpartner on (ad_user.c_bpartner_id=c_bpartner.c_bpartner_id)"), "Unexpected SQL clause generated from query"); // IDEMPIERE-7089-P6
 	}
 	
 	@Test

--- a/org.idempiere.test/src/org/idempiere/test/base/QueryTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/base/QueryTest.java
@@ -436,7 +436,7 @@ public class QueryTest extends AbstractTestCase {
 		assertNotNull(user, "Failed to retrieve garden user record");
 		
 		String sql = query.getSQL();
-		assertTrue(sql.toLowerCase().contains("inner join c_bpartner on (ad_user.c_bpartner_id=c_bpartner.c_bpartner_id)"), "Unexpected SQL clause generated from query"); // IDEMPIERE-7089-P6
+		assertTrue(sql.toLowerCase(java.util.Locale.ROOT).contains("inner join c_bpartner on (ad_user.c_bpartner_id=c_bpartner.c_bpartner_id)"), "Unexpected SQL clause generated from query"); // IDEMPIERE-7089-P6
 	}
 	
 	@Test

--- a/org.idempiere.test/src/org/idempiere/test/base/ReportTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/base/ReportTest.java
@@ -164,7 +164,7 @@ public class ReportTest extends AbstractTestCase {
 			assertEquals(1, attachment.getEntryCount(), "Unexpected number of notice attachment");
 			MAttachmentEntry entry = attachment.getEntry(0);
 			assertNotNull(entry, "Failed to retrieve attachment entry");
-			assertTrue(entry.getName() != null && entry.getName().toUpperCase().contains(".PDF"), "No PDF report attach to notice"); // IDEMPIERE-7089-P6
+			assertTrue(entry.getName() != null && entry.getName().toUpperCase(java.util.Locale.ROOT).contains(".PDF"), "No PDF report attach to notice"); // IDEMPIERE-7089-P6
 			
 		} finally {
 			rollback();

--- a/org.idempiere.test/src/org/idempiere/test/base/ReportTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/base/ReportTest.java
@@ -164,7 +164,7 @@ public class ReportTest extends AbstractTestCase {
 			assertEquals(1, attachment.getEntryCount(), "Unexpected number of notice attachment");
 			MAttachmentEntry entry = attachment.getEntry(0);
 			assertNotNull(entry, "Failed to retrieve attachment entry");
-			assertTrue(entry.getName() != null && entry.getName().toUpperCase().contains(".PDF"), "No PDF report attach to notice");
+			assertTrue(entry.getName() != null && entry.getName().toUpperCase().contains(".PDF"), "No PDF report attach to notice"); // IDEMPIERE-7089-P6
 			
 		} finally {
 			rollback();

--- a/org.idempiere.test/src/org/idempiere/test/model/CalloutTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/CalloutTest.java
@@ -161,7 +161,7 @@ public class CalloutTest extends AbstractTestCase {
 			while (st.hasMoreTokens()) {
 				String cmd = st.nextToken().trim();
 	
-				if (cmd.toLowerCase().startsWith(MRule.SCRIPT_PREFIX))
+				if (cmd.toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) // IDEMPIERE-7089-P6
 					continue;
 				int methodStart = cmd.lastIndexOf('.');
 				try {

--- a/org.idempiere.test/src/org/idempiere/test/model/CalloutTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/CalloutTest.java
@@ -161,7 +161,7 @@ public class CalloutTest extends AbstractTestCase {
 			while (st.hasMoreTokens()) {
 				String cmd = st.nextToken().trim();
 	
-				if (cmd.toLowerCase().startsWith(MRule.SCRIPT_PREFIX)) // IDEMPIERE-7089-P6
+				if (cmd.toLowerCase(java.util.Locale.ROOT).startsWith(MRule.SCRIPT_PREFIX)) // IDEMPIERE-7089-P6
 					continue;
 				int methodStart = cmd.lastIndexOf('.');
 				try {

--- a/org.idempiere.test/src/org/idempiere/test/tracking/AuditTraceContextTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/tracking/AuditTraceContextTest.java
@@ -173,7 +173,7 @@ public class AuditTraceContextTest extends AbstractTestCase {
 			assertEquals(1, attachment.getEntryCount(), "Unexpected number of notice attachment");
 			MAttachmentEntry entry = attachment.getEntry(0);
 			assertNotNull(entry, "Failed to retrieve attachment entry");
-			assertTrue(entry.getName() != null && entry.getName().toUpperCase().contains(".PDF"), "No PDF report attach to notice");
+			assertTrue(entry.getName() != null && entry.getName().toUpperCase().contains(".PDF"), "No PDF report attach to notice"); // IDEMPIERE-7089-P6
 						
 			pinstance.load((String) null);
 			assertEquals(externalTraceId, pinstance.getExternalTraceId(), "Unexpected ExternalTraceId");

--- a/org.idempiere.test/src/org/idempiere/test/tracking/AuditTraceContextTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/tracking/AuditTraceContextTest.java
@@ -173,7 +173,7 @@ public class AuditTraceContextTest extends AbstractTestCase {
 			assertEquals(1, attachment.getEntryCount(), "Unexpected number of notice attachment");
 			MAttachmentEntry entry = attachment.getEntry(0);
 			assertNotNull(entry, "Failed to retrieve attachment entry");
-			assertTrue(entry.getName() != null && entry.getName().toUpperCase().contains(".PDF"), "No PDF report attach to notice"); // IDEMPIERE-7089-P6
+			assertTrue(entry.getName() != null && entry.getName().toUpperCase(java.util.Locale.ROOT).contains(".PDF"), "No PDF report attach to notice"); // IDEMPIERE-7089-P6
 						
 			pinstance.load((String) null);
 			assertEquals(externalTraceId, pinstance.getExternalTraceId(), "Unexpected ExternalTraceId");


### PR DESCRIPTION
# IDEMPIERE-7089 Implementation Proposal

## Ticket

[IDEMPIERE-7089: Audit remaining locale-dependent Java case conversions outside IDEMPIERE-7082](https://idempiere.atlassian.net/browse/IDEMPIERE-7089)

## Objective

Remove unintended dependencies on `Locale.getDefault()` from Java case conversion while preserving the correct semantics for database values, technical tokens, SQL/schema identifiers, user-facing text, and domain-specific values.

This must be a semantic migration. It must not be implemented as a global replacement of every parameterless `toUpperCase()` or `toLowerCase()` call with `Locale.ROOT`.

## Baseline and Scope Boundary

The implementation branch is based on `upstream/master` at commit:

```text
28acd37703
```

At this commit, tracked Java sources contain 460 parameterless case-conversion locations. This differs from the 410 locations visible on the original IDEMPIERE-7082 PR branch because PR #3332 has not yet been merged into `master` and because `master` has evolved since that PR branch was created.

The original ticket baseline is:

- 460 classified locations in total;
- 52 locations classified as `IDEMPIERE_7082_HANDLED` and excluded from IDEMPIERE-7089;
- 408 locations in scope for IDEMPIERE-7089.

The 52 excluded locations consist of 50 conversions that PR #3332 removes and two compatibility-sensitive conversions that it deliberately retains. IDEMPIERE-7089 must not modify any of them.

The current `master` delta is:

- two original `TECH_TOKEN` locations have already been removed or corrected independently;
- three new `TECH_TOKEN` locations have been introduced;
- the active IDEMPIERE-7089 implementation scope is therefore 409 locations;
- the active `TECH_TOKEN` implementation scope is 66 locations.

Before an IDEMPIERE-7089 pull request is finalized, the branch should be rebased after PR #3332 is merged. Until then, reviews and automated scans must subtract the 52 `IDEMPIERE_7082_HANDLED` locations from the raw `master` result.

## Delivery Strategy

IDEMPIERE-7089 will be delivered in one draft pull request. The current 409-location scope remains divided into six internal implementation phases so that database behavior, technical normalization, UI behavior, domain decisions, and maintenance code remain separately reviewable within the same pull request.

The current `workspace/IDEMPIERE-7089` branch is the single draft pull request. Its WIP commits are organized according to the six phases below. The current implementation covers 364 of the 409 active locations; the remaining 45 locations carry explicit phase markers until their product or maintenance decision is completed.

During the draft stage, affected source locations are marked with compact comments that preserve the originally proposed pull-request grouping:

- `// IDEMPIERE-7089-P1` — `DB_VALUE`
- `// IDEMPIERE-7089-P2` — `TECH_TOKEN`
- `// IDEMPIERE-7089-P3` — `DB_SCHEMA_SQL`
- `// IDEMPIERE-7089-P4` — `USER_TEXT`
- `// IDEMPIERE-7089-P5` — `DOMAIN`
- `// IDEMPIERE-7089-P6` — `TEST`, `VENDORED`, and `INERT`

The comments are work-in-progress markers. Each marker must be replaced by the final implementation or an explicit source-level justification before the draft is marked ready for review.

### Phase 1: Database Value Comparisons

Implement the 14 high-priority `DB_VALUE` locations. Each currently applies `UPPER(...)` to the database expression but applies Java `toUpperCase()` to the value. The proposed change is:

```sql
-- Before
UPPER(column_name) = ?
```

```java
statement.setString(index, value.toUpperCase());
```

```sql
-- After
UPPER(column_name) = UPPER(?)
```

```java
statement.setString(index, value);
```

This delegates both mappings to the same database engine, removes dependence on the JVM default locale, and preserves the existing case-insensitive equality contract.

#### Proposed Source Changes

1. `org.adempiere.base/src/org/compiere/model/MColumn.java`
   - Change both foreign-key constraint-name duplicate checks to `UPPER(FkConstraintName)=UPPER(?)`.
   - Bind `fkConstraintName` without Java case conversion.

2. `org.adempiere.base/src/org/compiere/model/MQuery.java`
   - Change the `AD_Column.ColumnName` lookup to `UPPER(ColumnName)=UPPER(?)`.
   - Pass `ParameterName` unchanged.

3. `org.adempiere.base/src/org/compiere/model/MSearchDefinition.java`
   - Change both transaction-code lookups to `UPPER(TransactionCode)=UPPER(?)`.
   - Bind `transactionCode` unchanged.

4. `org.adempiere.base/src/org/compiere/model/M_Element.java`
   - Change the static element lookup and duplicate check to normalize both SQL operands.
   - Bind `columnName` unchanged.
   - In the dynamically constructed `AD_Process_Para` update, apply database `UPPER(...)` to the quoted original value instead of applying Java `toUpperCase()` before quoting it.

5. `org.adempiere.base/src/org/compiere/util/Msg.java`
   - Change both base-language and translated element queries to `UPPER(ColumnName)=UPPER(?)`.
   - Bind `ColumnName` unchanged.

6. `org.adempiere.pipo/src/org/adempiere/pipo2/IDFinder.java`
   - For all three `ignoreCase` paths, generate `UPPER(column)=UPPER(?)`.
   - Preserve decoded and direct values without Java case conversion.
   - Preserve the case-sensitive paths unchanged.

7. `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/DocumentSearchController.java`
   - Change the transaction-code predicate to `UPPER(TransactionCode)=UPPER(?)`.
   - Pass `transactionCode` unchanged.

8. `org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/info/InfoWindow.java`
   - Change the `AD_Column.ColumnName` metadata lookup to `UPPER(ColumnName)=UPPER(?)`.
   - Pass `column` unchanged.

#### Phase 1 Non-Goals

- Do not modify any of the 52 `IDEMPIERE_7082_HANDLED` locations.
- Do not add `Locale.ROOT` to database-bound values.
- Do not change equality to `LIKE`, wildcard handling, or accent behavior.
- Do not introduce database-specific functions.
- Do not address the 264 `DB_SCHEMA_SQL` or 66 active `TECH_TOKEN` locations in this phase.
- Do not change user-facing text or domain-value semantics.

#### Phase 1 Tests

Add focused integration tests that:

- set the JVM default locale to `tr-TR` and restore it in `finally` or test cleanup;
- prevent parallel execution while the global default locale is changed;
- verify a public lookup containing the ASCII letter `i`, for example an `M_Element` column-name lookup, using a differently cased input;
- verify that the lookup result is identical under `Locale.ROOT`, `en-US`, `de-DE`, and `tr-TR`;
- verify a database value containing `ß` where a suitable isolated test record can be created;
- execute on both PostgreSQL and Oracle;
- confirm that case-sensitive `IDFinder` paths remain case-sensitive;
- confirm that transaction-code and column-name equality semantics are unchanged.

The test must restore the original default locale even when an assertion or database operation fails. Because `Locale.setDefault(...)` changes global JVM state, the test must use the test suite's global resource lock or an equivalent serialization mechanism.

#### Phase 1 Validation

```bash
git grep -n -E '\.to(Lower|Upper)Case\(\)' -- '*.java'
git diff --check
mvn -pl org.idempiere.test verify
```

The exact Maven module selection may be narrowed during implementation if the repository's Tycho setup requires a different invocation, but the final verification must exercise the affected base, PIPO, and ZK code paths.

## Subsequent Phases in the Same Pull Request

### Phase 2: Technical Tokens

Scope: 66 active `TECH_TOKEN` locations, including three additions and excluding two locations already resolved independently on `master`.

Use the following decision order:

1. Prefer `equalsIgnoreCase()` for equality checks.
2. Prefer `regionMatches(true, ...)` or a focused helper for case-insensitive prefix/suffix checks when it improves clarity.
3. Use `Locale.ROOT` when a normalized string is required for a map key, enum conversion, protocol token, file extension, path, MIME value, CSS/OSGi value, or similar language-independent value.
4. Use an explicitly ASCII-specific implementation only where the protocol or file format defines ASCII semantics and the code benefits from enforcing that contract.

Group changes by module and add Turkish-default-locale tests for protocols, paths, file extensions, MIME values, and internal keys.

### Phase 3: SQL and Schema Mechanics

Scope: 264 `DB_SCHEMA_SQL` locations.

These are high-confidence technical strings but form the largest category. Split them further by subsystem if necessary:

- SQL conversion and parsing;
- Oracle identifier handling;
- PostgreSQL identifier handling;
- application-dictionary table and column handling;
- model and migration code generation;
- metadata, constraint, sequence, index, and partition names.

Prefer structural metadata or parser APIs where available. Otherwise use `Locale.ROOT` for unavoidable Java normalization of SQL keywords and identifiers. Preserve the explicit Oracle-uppercase and PostgreSQL-lowercase identifier conventions.

### Phase 4: User-Facing Text

Scope: 37 `USER_TEXT` locations.

Do not implement this category until the expected product behavior is confirmed. For each location, decide whether comparison follows:

- the login/user locale;
- Unicode case-insensitive comparison;
- a `Collator` with a documented strength;
- database collation;
- accent-normalized search already defined by that subsystem; or
- exact case-sensitive behavior.

Menu search, autocomplete, document search, city search, and extension-manager search should be treated as separate behavior groups. `Locale.ROOT` is not the default answer for natural-language text.

### Phase 5: Domain-Specific Values

Scope: 11 `DOMAIN` locations.

Document the normalization contract for every value type before changing code. The current implementation applies explicit `java.util.Locale.ROOT` normalization to the technical domain values in this category. The email comparison remains a candidate for a later `equalsIgnoreCase()` refinement. Likely dispositions include:

- IBAN: explicit locale-neutral uppercase canonicalization;
- fixed-asset and account keys: explicit technical-key normalization;
- unit codes: follow the code-system specification;
- email/preferred username: define equality semantics before changing behavior;
- Web Store context: define whether it is a path, identifier, or user-configurable value.

Do not combine unresolved domain decisions with mechanical technical-token changes.

### Phase 6: Tests and Maintenance Sources

Scope: 9 `TEST`, 5 `VENDORED`, and 3 `INERT` locations.

- Update test conversions to match the production strategy they verify.
- Set locales explicitly in locale-sensitive tests.
- Do not modify embedded third-party or historical migration code without an explicit maintenance decision.
- Remove commented-out occurrences only as non-functional cleanup.

## Implementation Rules

Every changed location must receive one explicit disposition:

- `DB_BOTH_OPERANDS`
- `LOCALE_ROOT`
- `CASE_INSENSITIVE_API`
- `USER_LOCALE_OR_COLLATOR`
- `DOMAIN_SPECIFIC`
- `TEST_ONLY`
- `VENDORED_OR_HISTORIC`
- `INERT`

The companion classification should be updated with the selected disposition and the implementing PR for every completed location. This provides an auditable path from the original 460-location inventory to the final code.

## Review and Compatibility Requirements

- Preserve all public and protected API signatures unless separately approved.
- Preserve PR #3332's compatibility decisions, including `PO.getFindParameter(String)` and the authorization-code handling in `StatementCreateFromBatch`.
- Keep prepared-statement binding; do not concatenate user values into SQL.
- Verify PostgreSQL and Oracle behavior for database changes.
- Review query plans where a change adds or moves a SQL function. In Phase 1, the indexed column expression remains unchanged and only the parameter gains the matching function.
- Preserve existing ASCII behavior unless a deliberate correction is documented.
- Do not include accent-insensitive search or global collation changes.
- Avoid tests that leak a changed JVM default locale into other tests.

## Proposed Definition of Done

IDEMPIERE-7089 is complete when:

1. all 52 `IDEMPIERE_7082_HANDLED` locations remain excluded;
2. each of the 409 currently active in-scope locations has a reviewed final disposition;
3. all approved first-party changes are implemented in one pull request with semantically grouped phases and commits;
4. technical normalization no longer depends unintentionally on `Locale.getDefault()`;
5. database-value comparisons apply the same database function to both operands;
6. user-text and domain behavior follow explicitly documented policies;
7. PostgreSQL and Oracle validation succeeds where applicable;
8. locale tests cover at least `Locale.ROOT`, `en-US`, `de-DE`, and `tr-TR`;
9. the classification records the implementing PR or follow-up decision for every location; and
10. remaining product or compatibility decisions have dedicated follow-up tickets.
