### PR TITLE
IDEMPIERE-5431 Extend workflow editor canvas dynamically

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFEditor.java
@@ -300,6 +300,11 @@ public class WFEditor extends ADForm {
 
 		//	Add Nodes for Paint
 		MWFNode[] nodes = m_wf.getNodes(true, Env.getAD_Client_ID(Env.getCtx()));
+		int maxColumn = 0;
+		for (MWFNode node : nodes) {
+			maxColumn = Math.max(maxColumn, node.getXPosition());
+		}
+		nodeContainer.setColumnCount(maxColumn + 1);
 		List<Integer> added = new ArrayList<Integer>();
 		for (int i = 0; i < nodes.length; i++)
 		{
@@ -328,7 +333,7 @@ public class WFEditor extends ADForm {
 			for(int i = 0; i < row+1; i++) {
 				Tr tr = new Tr();
 				table.appendChild(tr);
-				for(int c = 0; c < 4; c++) {
+				for(int c = 0; c < nodeContainer.getColumnCount(); c++) {
 					BufferedImage t = new BufferedImage(WFGraphLayout.COLUMN_WIDTH, WFGraphLayout.ROW_HEIGHT, BufferedImage.TYPE_INT_ARGB);
 					Graphics2D tg = t.createGraphics();
 					Td td = new Td();

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFEditor.java
@@ -300,11 +300,7 @@ public class WFEditor extends ADForm {
 
 		//	Add Nodes for Paint
 		MWFNode[] nodes = m_wf.getNodes(true, Env.getAD_Client_ID(Env.getCtx()));
-		int maxColumn = 0;
-		for (MWFNode node : nodes) {
-			maxColumn = Math.max(maxColumn, node.getXPosition());
-		}
-		nodeContainer.setColumnCount(maxColumn + 1);
+		nodeContainer.setColumnCount(nodes, true);
 		List<Integer> added = new ArrayList<Integer>();
 		for (int i = 0; i < nodes.length; i++)
 		{

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFEditor.java
@@ -326,7 +326,8 @@ public class WFEditor extends ADForm {
 
 		try {
 			int row = nodeContainer.getRowCount();
-			for(int i = 0; i < row+1; i++) {
+			int rowsToRender = row + (nodeContainer.canAddRow() ? 1 : 0);
+			for(int i = 0; i < rowsToRender; i++) {
 				Tr tr = new Tr();
 				table.appendChild(tr);
 				for(int c = 0; c < nodeContainer.getColumnCount(); c++) {

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFNodeContainer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFNodeContainer.java
@@ -277,6 +277,14 @@ public class WFNodeContainer
 	}
 
 	/**
+	 * Check whether another row can be added
+	 * @return true if another row can be added
+	 */
+	public boolean canAddRow() {
+		return rowCount < MAX_ROW_COUNT;
+	}
+
+	/**
 	 * Get current row index
 	 * @return current row index
 	 */

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFNodeContainer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFNodeContainer.java
@@ -19,6 +19,7 @@ import java.awt.Rectangle;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.adempiere.exceptions.AdempiereException;
 import org.compiere.apps.wf.WFGraphLayout;
 import org.compiere.apps.wf.WFNodeWidget;
 import org.compiere.apps.wf.WorkflowGraphScene;
@@ -39,9 +40,10 @@ import org.netbeans.api.visual.layout.SceneLayout;
 public class WFNodeContainer
 {
 	private static final int DEFAULT_COLUMN_COUNT = 4;
+	private static final int MAX_COLUMN_COUNT = 20;
+	private static final int MAX_ROW_COUNT = 50;
 
 	/**	Logger			*/
-	@SuppressWarnings("unused")
 	private static final CLogger	log = CLogger.getCLogger(WFNodeContainer.class);
 
 	/** The Workflow		*/
@@ -90,10 +92,21 @@ public class WFNodeContainer
 	}	//	removeAll
 
 	/**
-	 * Set number of columns
-	 * @param columnCount column count
+	 * Set number of columns from valid workflow node positions
+	 * @param nodes workflow nodes
+	 * @param addEmptyColumn whether to add an empty column for editing
 	 */
-	public void setColumnCount(int columnCount) {
+	public void setColumnCount(MWFNode[] nodes, boolean addEmptyColumn) {
+		int columnCount = 0;
+		for (MWFNode node : nodes) {
+			int xPosition = node.getXPosition();
+			if (xPosition > 0 && xPosition <= MAX_COLUMN_COUNT) {
+				columnCount = Math.max(columnCount, xPosition);
+			}
+		}
+		if (addEmptyColumn && columnCount < MAX_COLUMN_COUNT) {
+			columnCount++;
+		}
 		noOfColumns = Math.max(DEFAULT_COLUMN_COUNT, columnCount);
 	}
 
@@ -104,13 +117,14 @@ public class WFNodeContainer
 	public void addNode(MWFNode node) {
 		int oldRow = currentRow;
 		int oldColumn = currentColumn;
-		if (node.getXPosition() > 0 && node.getYPosition() > 0) {
+		if (node.getXPosition() > MAX_COLUMN_COUNT || node.getYPosition() > MAX_ROW_COUNT) {
+			log.warning("Ignoring out-of-range workflow node position for " + node
+					+ ": x=" + node.getXPosition() + ", y=" + node.getYPosition());
+		}
+		if (node.getXPosition() > 0 && node.getXPosition() <= noOfColumns
+				&& node.getYPosition() > 0 && node.getYPosition() <= MAX_ROW_COUNT) {
 			currentColumn = node.getXPosition();
 			currentRow = node.getYPosition();
-			if (currentColumn > noOfColumns) {
-				currentColumn = 1;
-				currentRow ++;
-			}
 		} else if (currentColumn == noOfColumns) {
 			currentColumn = 1;
 			if (m_wf.getWorkflowType().equals(X_AD_Workflow.WORKFLOWTYPE_General)) {
@@ -130,11 +144,8 @@ public class WFNodeContainer
 			}
 		}
 
-		Integer[] nodes = matrix.get(currentRow);
-		if (nodes == null) {
-			nodes = new Integer[noOfColumns];
-			matrix.put(currentRow, nodes);
-		} else {
+		Integer[] nodes = getOrCreateRow(currentRow);
+		if (nodes[currentColumn - 1] != null) {
 			//detect collision
 			while (nodes[currentColumn - 1] != null) {
 				if (nodes[currentColumn - 1] == node.getAD_WF_Node_ID()) {
@@ -142,11 +153,7 @@ public class WFNodeContainer
 				} else if (currentColumn == noOfColumns) {
 					currentColumn = 1;
 					currentRow ++;
-					nodes = matrix.get(currentRow);
-					if (nodes == null) {
-						nodes = new Integer[noOfColumns];
-						matrix.put(currentRow, nodes);
-					}
+					nodes = getOrCreateRow(currentRow);
 				} else {
 					currentColumn ++;
 				}
@@ -171,6 +178,23 @@ public class WFNodeContainer
 		} else if ( currentRow == oldRow && currentColumn < oldColumn) {
 			currentColumn = oldColumn;
 		}
+	}
+
+	/**
+	 * Get or create row in node matrix
+	 * @param row row number
+	 * @return node row
+	 */
+	private Integer[] getOrCreateRow(int row) {
+		if (row > MAX_ROW_COUNT) {
+			throw new AdempiereException("Workflow layout exceeds the maximum of " + MAX_ROW_COUNT + " rows");
+		}
+		Integer[] nodes = matrix.get(row);
+		if (nodes == null) {
+			nodes = new Integer[noOfColumns];
+			matrix.put(row, nodes);
+		}
+		return nodes;
 	}
 
 	/**

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFNodeContainer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFNodeContainer.java
@@ -38,6 +38,8 @@ import org.netbeans.api.visual.layout.SceneLayout;
  */
 public class WFNodeContainer
 {
+	private static final int DEFAULT_COLUMN_COUNT = 4;
+
 	/**	Logger			*/
 	@SuppressWarnings("unused")
 	private static final CLogger	log = CLogger.getCLogger(WFNodeContainer.class);
@@ -47,7 +49,7 @@ public class WFNodeContainer
 
 	private int currentRow = 1;
 	private int currentColumn = 0;
-	private int noOfColumns = 4;
+	private int noOfColumns = DEFAULT_COLUMN_COUNT;
 	private int maxColumn = 0;
 	private int rowCount = 0;
 
@@ -81,8 +83,19 @@ public class WFNodeContainer
 		graphScene = new WorkflowGraphScene();
 		currentColumn = 0;
 		currentRow = 1;
+		noOfColumns = DEFAULT_COLUMN_COUNT;
+		maxColumn = 0;
+		rowCount = 0;
 		matrix = new HashMap<Integer, Integer[]>();
 	}	//	removeAll
+
+	/**
+	 * Set number of columns
+	 * @param columnCount column count
+	 */
+	public void setColumnCount(int columnCount) {
+		noOfColumns = Math.max(DEFAULT_COLUMN_COUNT, columnCount);
+	}
 
 	/**
 	 * Add workflow node
@@ -117,10 +130,6 @@ public class WFNodeContainer
 			}
 		}
 
-		if (currentRow > rowCount) {
-			rowCount = currentRow;
-		}
-
 		Integer[] nodes = matrix.get(currentRow);
 		if (nodes == null) {
 			nodes = new Integer[noOfColumns];
@@ -149,6 +158,9 @@ public class WFNodeContainer
 		w.setRow(currentRow);
 
 		nodes[currentColumn - 1] = node.getAD_WF_Node_ID();
+		if (currentRow > rowCount) {
+			rowCount = currentRow;
+		}
 		if (currentColumn > maxColumn) {
 			maxColumn = currentColumn;
 		}
@@ -207,7 +219,7 @@ public class WFNodeContainer
 	 */
 	public Dimension getDimension()
 	{
-		return new Dimension(noOfColumns * WFGraphLayout.COLUMN_WIDTH, currentRow * WFGraphLayout.ROW_HEIGHT);
+		return new Dimension(noOfColumns * WFGraphLayout.COLUMN_WIDTH, Math.max(1, rowCount) * WFGraphLayout.ROW_HEIGHT);
 	}
 
 	/**

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFPanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFPanel.java
@@ -169,6 +169,11 @@ public class WFPanel extends Borderlayout implements EventListener<Event>, IHelp
 		
 		//	Add Nodes for Paint
 		MWFNode[] nodes = m_wf.getNodes(true, Env.getAD_Client_ID(Env.getCtx()));
+		int maxColumn = 0;
+		for (MWFNode node : nodes) {
+			maxColumn = Math.max(maxColumn, node.getXPosition());
+		}
+		nodeContainer.setColumnCount(maxColumn);
 		List<Integer> added = new ArrayList<Integer>();
 		for (int i = 0; i < nodes.length; i++)
 		{

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFPanel.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFPanel.java
@@ -169,11 +169,7 @@ public class WFPanel extends Borderlayout implements EventListener<Event>, IHelp
 		
 		//	Add Nodes for Paint
 		MWFNode[] nodes = m_wf.getNodes(true, Env.getAD_Client_ID(Env.getCtx()));
-		int maxColumn = 0;
-		for (MWFNode node : nodes) {
-			maxColumn = Math.max(maxColumn, node.getXPosition());
-		}
-		nodeContainer.setColumnCount(maxColumn);
+		nodeContainer.setColumnCount(nodes, false);
 		List<Integer> added = new ArrayList<Integer>();
 		for (int i = 0; i < nodes.length; i++)
 		{


### PR DESCRIPTION
## Description

Extend the workflow editor canvas dynamically for workflows that require more than four columns.

JIRA: https://idempiere.atlassian.net/browse/IDEMPIERE-5431

## Changes

- Keep four columns as the minimum workflow canvas width.
- Size the editor from the highest stored node X position and provide one empty trailing column for further expansion.
- Preserve and render node positions beyond column four instead of wrapping them to the next row.
- Size the read-only workflow panel to existing node positions without adding the editor-only trailing column.
- Reset cached row and column bounds when reloading a workflow.
- Calculate the canvas height from the actual maximum occupied row.

## Impact

Complex workflows can be expanded progressively by dragging a node into the empty rightmost column. Reloading then adds another empty column automatically. No database migration or SysConfig key is required.

## Validation

- Compiled `WFNodeContainer`, `WFEditor`, and `WFPanel` successfully.
- Verified minimum and dynamic container widths, minimum height, and reset behavior with a focused runtime test.
- Verified that the editor uses the dynamic column count and reserves one trailing column.
- Verified that the workflow panel honors stored X positions without reserving an extra column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow diagrams now automatically adjust their grid width to fit the widest node layout.
  * Improved node placement for workflows with varying numbers of columns.
  * Prevented invalid node positions from causing unexpected layout wrapping.
  * Added safeguards for workflows that exceed supported row or column limits.
  * Resetting or reloading a workflow now correctly clears previous layout dimensions.
  * Drop targets now appear only when an additional workflow row can be added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->