### PR TITLE
IDEMPIERE-7091 Workflow Editor does not display all transition arrows

### DIFF
--- a/migration/iD14/oracle/202609041100_IDEMPIERE-7091.sql
+++ b/migration/iD14/oracle/202609041100_IDEMPIERE-7091.sql
@@ -1,0 +1,210 @@
+-- IDEMPIERE-7091 Workflow Editor does not display all transition arrows
+-- GardenWorld test workflow: fully packed 4x6 grid with hub node, blocked corridors,
+-- bidirectional pairs, back edges and self-referencing transitions
+-- Dictionary IDs reserved at developer.idempiere.com for IDEMPIERE-7091
+SELECT register_migration_script('202609041100_IDEMPIERE-7091.sql') FROM dual;
+
+SET SQLBLANKLINES ON
+SET DEFINE OFF
+
+-- 2026-09-04 11:00:00
+INSERT INTO AD_Workflow (Name,Description,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AccessLevel,EntityType,Author,WorkingTime,Duration,Version,Cost,DurationUnit,WaitingTime,PublishStatus,IsDefault,Value,WorkflowType,IsValid,IsBetaFunctionality,Yield,AD_Workflow_UU) VALUES ('IDEMPIERE-7091 Test Workflow','Test workflow for IDEMPIERE-7091 - 24 nodes in a fully packed 4x6 grid with blocked corridors, hub node, bidirectional pairs, back edges and self references',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'3','D','Markus Bozem',0,1,0,0,'D',0,'R','N','IDEMPIERE-7091-TestWF','G','Y','N',100,'7091fa9d-c694-48b3-ba4d-cb201f036384')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200042,'7091 Start',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',1,'D',1,0,0,0,0,0,0,'X','X',0,'7091Start','70911595-3f43-46e1-9ae5-80290f4080a6')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200043,'7091 Block A',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',1,'D',2,0,0,0,0,0,0,'X','X',0,'7091BlockA','70914e91-597f-499d-b168-0f8291cce351')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200044,'7091 Block B',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',1,'D',3,0,0,0,0,0,0,'X','X',0,'7091BlockB','709149af-202f-492e-b6cd-86e6bda5687c')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200045,'7091 Hub',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',1,'D',4,0,0,0,0,0,0,'X','X',0,'7091Hub','7091cdf5-fceb-4079-a67b-b3c88c833dad')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200046,'7091 In A',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',2,'D',1,0,0,0,0,0,0,'X','X',0,'7091InA','709156a6-5197-4f51-abda-ecdb9e5ee8db')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200047,'7091 Block C',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',2,'D',2,0,0,0,0,0,0,'X','X',0,'7091BlockC','7091d9be-3b4b-45f8-ac66-2322601445ec')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200048,'7091 Block D',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',2,'D',3,0,0,0,0,0,0,'X','X',0,'7091BlockD','70916da5-256c-4243-a20b-59cd203c5460')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200049,'7091 Pair A',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',2,'D',4,0,0,0,0,0,0,'X','X',0,'7091PairA','7091bc91-3cff-47dc-a836-a0766dbbf804')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200050,'7091 In B',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',3,'D',1,0,0,0,0,0,0,'X','X',0,'7091InB','70919769-12c6-47dc-83c7-5e4ce5514dbd')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200051,'7091 Block E',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',3,'D',2,0,0,0,0,0,0,'X','X',0,'7091BlockE','7091c81b-e44e-4f51-8390-5097355bb009')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200052,'7091 Block F',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',3,'D',3,0,0,0,0,0,0,'X','X',0,'7091BlockF','709141ca-6449-4ed2-81d1-2ef4d5849851')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200053,'7091 Pair B',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',3,'D',4,0,0,0,0,0,0,'X','X',0,'7091PairB','7091f4a5-ca54-46e3-a6b9-26baca79726b')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200054,'7091 In C',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',4,'D',1,0,0,0,0,0,0,'X','X',0,'7091InC','7091252a-dd19-4cd6-b909-70b23732eacc')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200055,'7091 Self 1',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',4,'D',2,0,0,0,0,0,0,'X','X',0,'7091Self1','7091dd11-aa44-4324-a5c8-9521065bd26e')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200056,'7091 Self 2',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',4,'D',3,0,0,0,0,0,0,'X','X',0,'7091Self2','709124db-fbc4-4a41-afb8-ea30d12704d1')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200057,'7091 Out A',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',4,'D',4,0,0,0,0,0,0,'X','X',0,'7091OutA','7091475f-2c2a-4499-b40c-15636578c234')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200058,'7091 In D',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',5,'D',1,0,0,0,0,0,0,'X','X',0,'7091InD','7091722d-9f08-4d7f-95b6-e6d3f67a7be0')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200059,'7091 Block G',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',5,'D',2,0,0,0,0,0,0,'X','X',0,'7091BlockG','7091b9ee-9d0f-41ff-a3ae-0cceaf8503eb')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200060,'7091 Block H',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',5,'D',3,0,0,0,0,0,0,'X','X',0,'7091BlockH','7091278d-58ab-42fe-be2d-ab4eea366de2')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200061,'7091 Out B',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',5,'D',4,0,0,0,0,0,0,'X','X',0,'7091OutB','7091f501-87be-4560-8322-03077b42109d')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200062,'7091 Sink',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',6,'D',1,0,0,0,0,0,0,'X','X',0,'7091Sink','7091bbf3-97ba-4e0c-9743-e807478a83d7')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200063,'7091 Block I',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',6,'D',2,0,0,0,0,0,0,'X','X',0,'7091BlockI','70914ce3-be45-4caf-8b52-7286476c1f6d')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200064,'7091 Block J',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',6,'D',3,0,0,0,0,0,0,'X','X',0,'7091BlockJ','70919e84-b058-4006-9e81-0137b5cd6b2b')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,Action,IsCentrallyMaintained,YPosition,EntityType,XPosition,Limit,Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200065,'7091 Out C',200016,11,0,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',6,'D',4,0,0,0,0,0,0,'X','X',0,'7091OutC','70918941-f4fa-4307-90c0-d64009fca9cc')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200042,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200045,'D',10,'Straight line across row 1 over blocked nodes',200034,'N','70913cd1-7703-4895-9ba6-cf795347a145')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200042,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200046,'D',20,'Start down left column',200035,'N','7091b061-d20f-43cf-b1da-3c8faed91394')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200042,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200043,'D',30,'Start to Block A',200071,'N','7091232e-4500-4a7d-b56e-a0abe0244293')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200043,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200044,'D',10,'Row 1 block corridor',200036,'N','709175ae-367c-4036-853b-0ba009adacff')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200044,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200045,'D',10,'Row 1 block corridor into hub',200037,'N','70915778-f9e9-48f1-a019-f4fce020e389')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200045,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200049,'D',10,'Hub straight down',200038,'N','7091789a-7067-4eee-a8a7-1a8bf8910243')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200045,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200046,'D',20,'Hub diagonal',200039,'N','709171c4-5db3-47bd-9136-2f355376b5fb')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200045,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200057,'D',30,'Hub blocked vertical',200040,'N','7091c80a-860c-4b75-9185-2902d8abda8a')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200045,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200050,'D',40,'Hub long diagonal',200041,'N','7091daf2-583a-44fb-87c7-f5b647d34362')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200045,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200061,'D',50,'Hub blocked vertical',200042,'N','7091ee34-279b-4264-9acd-e221e7d6bc99')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200045,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200062,'D',60,'Hub long diagonal',200043,'N','70917a2a-ce80-4c1e-a20a-8df01a174a1e')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200046,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200050,'D',10,'Left column down',200044,'N','70915c69-a689-4d40-ac10-94ab2310604e')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200046,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200042,'D',20,'Back edge to Start',200045,'N','709144f6-e200-449d-ae1f-d4475bf8bda2')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200046,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200047,'D',30,'In A to Block C',200072,'N','70914d62-0bb8-4cde-a291-d76c70b2c446')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200047,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200048,'D',10,'Row 2 block corridor',200046,'N','709187da-edc3-46a5-97f3-88c13e8b0cf4')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200048,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200049,'D',10,'Row 2 into Pair A',200047,'N','7091adc7-15de-463e-9839-a87bb7b43fc7')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200049,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200053,'D',10,'Pair A to Pair B',200048,'N','7091bddd-9632-4719-9a63-524ad3ce51b1')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200049,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200045,'D',20,'Bidirectional Pair A to Hub',200049,'N','7091cc4f-19ac-48f2-a65b-7df98326dc60')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200050,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200054,'D',10,'Left column down',200050,'N','7091164d-8d9d-4101-a3e9-d5f2cc872070')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200050,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200051,'D',20,'Row 3 block corridor',200051,'N','70915850-15c1-48af-adce-fbd673e8e7b8')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200051,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200052,'D',10,'Row 3 block corridor',200052,'N','709191f5-4e93-4755-8b40-15a859df6db9')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200052,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200053,'D',10,'Row 3 into Pair B',200053,'N','7091d384-bc7c-442b-92f9-7f17d557addd')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200053,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200057,'D',10,'Pair B to Out A',200054,'N','70916faa-dd0a-4a9e-87fe-4620d4261979')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200053,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200049,'D',20,'Bidirectional Pair B to Pair A',200055,'N','709117f5-5151-4df7-beec-0fa8505b9028')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200054,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200055,'D',10,'Into Self 1',200056,'N','7091e17d-06c0-488a-b761-7825ab5ee2ae')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200054,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200058,'D',20,'Left column down',200057,'N','70910c48-9dd3-4f75-aa36-e1759e3d3ac3')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200055,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200055,'D',10,'Self reference',200058,'N','709165a4-91a4-4487-a92e-a7a7bd4446de')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200055,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200056,'D',20,'Self 1 to Self 2',200059,'N','70912bd2-e4a6-4288-a4a7-d742f399d5c1')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200056,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200056,'D',10,'Self reference',200060,'N','709161a8-ad1f-4007-aeef-96f544d479a5')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200057,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200061,'D',10,'Out column down',200061,'N','709129f2-37ee-4573-835f-01609a6f9e65')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200058,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200062,'D',10,'Left column down',200062,'N','70913993-32c6-443b-9021-f541889ba950')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200058,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200045,'D',20,'Long back edge to Hub',200063,'N','7091efb7-f27e-4596-bd5c-525254b1e470')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200058,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200059,'D',30,'In D to Block G',200073,'N','7091acb7-60da-4e23-af4b-3f8b238445e8')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200059,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200060,'D',10,'Row 5 block corridor',200064,'N','70918121-0257-4f55-873e-b5b2e3f390df')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200060,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200061,'D',10,'Row 5 into Out B',200065,'N','70917c36-736d-4b3a-bab2-959176042058')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200061,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200065,'D',10,'Out column down',200066,'N','70915fa9-bd37-4094-bcad-f5d007a3a4f6')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200062,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200042,'D',10,'Back edge to Start closes cycle',200067,'N','7091d870-377c-499f-a10d-a43353594501')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200062,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200063,'D',20,'Sink to Block I',200074,'N','709188d2-0b3b-4d40-b8c2-3eaadd23877d')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200063,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200064,'D',10,'Row 6 block corridor',200068,'N','7091367e-6c02-4a4f-a453-c09617d787a0')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200064,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200065,'D',10,'Row 6 into Out C',200069,'N','709191be-39ea-465f-9909-9098cbff7aac')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200065,'Y',TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200062,'D',10,'Out C back to Sink',200070,'N','7091a197-918f-4368-9d45-72041c2197f6')
+;
+-- 2026-09-04 11:00:00
+UPDATE AD_Workflow SET AD_WF_Node_ID=200042, IsValid='Y',Updated=TO_DATE('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Workflow_ID=200016
+;

--- a/migration/iD14/postgresql/202609041100_IDEMPIERE-7091.sql
+++ b/migration/iD14/postgresql/202609041100_IDEMPIERE-7091.sql
@@ -1,0 +1,207 @@
+-- IDEMPIERE-7091 Workflow Editor does not display all transition arrows
+-- GardenWorld test workflow: fully packed 4x6 grid with hub node, blocked corridors,
+-- bidirectional pairs, back edges and self-referencing transitions
+-- Dictionary IDs reserved at developer.idempiere.com for IDEMPIERE-7091
+SELECT register_migration_script('202609041100_IDEMPIERE-7091.sql') FROM dual;
+
+-- 2026-09-04 11:00:00
+INSERT INTO AD_Workflow (Name,Description,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AccessLevel,EntityType,Author,WorkingTime,Duration,Version,Cost,DurationUnit,WaitingTime,PublishStatus,IsDefault,Value,WorkflowType,IsValid,IsBetaFunctionality,Yield,AD_Workflow_UU) VALUES ('IDEMPIERE-7091 Test Workflow','Test workflow for IDEMPIERE-7091 - 24 nodes in a fully packed 4x6 grid with blocked corridors, hub node, bidirectional pairs, back edges and self references',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'3','D','Markus Bozem',0,1,0,0,'D',0,'R','N','IDEMPIERE-7091-TestWF','G','Y','N',100,'7091fa9d-c694-48b3-ba4d-cb201f036384')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200042,'7091 Start',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',1,'D',1,0,0,0,0,0,0,'X','X',0,'7091Start','70911595-3f43-46e1-9ae5-80290f4080a6')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200043,'7091 Block A',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',1,'D',2,0,0,0,0,0,0,'X','X',0,'7091BlockA','70914e91-597f-499d-b168-0f8291cce351')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200044,'7091 Block B',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',1,'D',3,0,0,0,0,0,0,'X','X',0,'7091BlockB','709149af-202f-492e-b6cd-86e6bda5687c')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200045,'7091 Hub',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',1,'D',4,0,0,0,0,0,0,'X','X',0,'7091Hub','7091cdf5-fceb-4079-a67b-b3c88c833dad')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200046,'7091 In A',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',2,'D',1,0,0,0,0,0,0,'X','X',0,'7091InA','709156a6-5197-4f51-abda-ecdb9e5ee8db')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200047,'7091 Block C',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',2,'D',2,0,0,0,0,0,0,'X','X',0,'7091BlockC','7091d9be-3b4b-45f8-ac66-2322601445ec')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200048,'7091 Block D',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',2,'D',3,0,0,0,0,0,0,'X','X',0,'7091BlockD','70916da5-256c-4243-a20b-59cd203c5460')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200049,'7091 Pair A',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',2,'D',4,0,0,0,0,0,0,'X','X',0,'7091PairA','7091bc91-3cff-47dc-a836-a0766dbbf804')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200050,'7091 In B',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',3,'D',1,0,0,0,0,0,0,'X','X',0,'7091InB','70919769-12c6-47dc-83c7-5e4ce5514dbd')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200051,'7091 Block E',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',3,'D',2,0,0,0,0,0,0,'X','X',0,'7091BlockE','7091c81b-e44e-4f51-8390-5097355bb009')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200052,'7091 Block F',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',3,'D',3,0,0,0,0,0,0,'X','X',0,'7091BlockF','709141ca-6449-4ed2-81d1-2ef4d5849851')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200053,'7091 Pair B',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',3,'D',4,0,0,0,0,0,0,'X','X',0,'7091PairB','7091f4a5-ca54-46e3-a6b9-26baca79726b')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200054,'7091 In C',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',4,'D',1,0,0,0,0,0,0,'X','X',0,'7091InC','7091252a-dd19-4cd6-b909-70b23732eacc')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200055,'7091 Self 1',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',4,'D',2,0,0,0,0,0,0,'X','X',0,'7091Self1','7091dd11-aa44-4324-a5c8-9521065bd26e')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200056,'7091 Self 2',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',4,'D',3,0,0,0,0,0,0,'X','X',0,'7091Self2','709124db-fbc4-4a41-afb8-ea30d12704d1')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200057,'7091 Out A',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',4,'D',4,0,0,0,0,0,0,'X','X',0,'7091OutA','7091475f-2c2a-4499-b40c-15636578c234')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200058,'7091 In D',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',5,'D',1,0,0,0,0,0,0,'X','X',0,'7091InD','7091722d-9f08-4d7f-95b6-e6d3f67a7be0')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200059,'7091 Block G',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',5,'D',2,0,0,0,0,0,0,'X','X',0,'7091BlockG','7091b9ee-9d0f-41ff-a3ae-0cceaf8503eb')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200060,'7091 Block H',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',5,'D',3,0,0,0,0,0,0,'X','X',0,'7091BlockH','7091278d-58ab-42fe-be2d-ab4eea366de2')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200061,'7091 Out B',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',5,'D',4,0,0,0,0,0,0,'X','X',0,'7091OutB','7091f501-87be-4560-8322-03077b42109d')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200062,'7091 Sink',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',6,'D',1,0,0,0,0,0,0,'X','X',0,'7091Sink','7091bbf3-97ba-4e0c-9743-e807478a83d7')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200063,'7091 Block I',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',6,'D',2,0,0,0,0,0,0,'X','X',0,'7091BlockI','70914ce3-be45-4caf-8b52-7286476c1f6d')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200064,'7091 Block J',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',6,'D',3,0,0,0,0,0,0,'X','X',0,'7091BlockJ','70919e84-b058-4006-9e81-0137b5cd6b2b')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_Node (AD_WF_Node_ID,Name,AD_Workflow_ID,AD_Client_ID,AD_Org_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,"action",IsCentrallyMaintained,YPosition,EntityType,XPosition,"limit",Duration,Cost,WaitingTime,WorkingTime,Priority,JoinElement,SplitElement,WaitTime,Value,AD_WF_Node_UU) VALUES (200065,'7091 Out C',200016,11,0,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,'Z','Y',6,'D',4,0,0,0,0,0,0,'X','X',0,'7091OutC','70918941-f4fa-4307-90c0-d64009fca9cc')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200042,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200045,'D',10,'Straight line across row 1 over blocked nodes',200034,'N','70913cd1-7703-4895-9ba6-cf795347a145')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200042,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200046,'D',20,'Start down left column',200035,'N','7091b061-d20f-43cf-b1da-3c8faed91394')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200042,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200043,'D',30,'Start to Block A',200071,'N','7091232e-4500-4a7d-b56e-a0abe0244293')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200043,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200044,'D',10,'Row 1 block corridor',200036,'N','709175ae-367c-4036-853b-0ba009adacff')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200044,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200045,'D',10,'Row 1 block corridor into hub',200037,'N','70915778-f9e9-48f1-a019-f4fce020e389')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200045,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200049,'D',10,'Hub straight down',200038,'N','7091789a-7067-4eee-a8a7-1a8bf8910243')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200045,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200046,'D',20,'Hub diagonal',200039,'N','709171c4-5db3-47bd-9136-2f355376b5fb')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200045,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200057,'D',30,'Hub blocked vertical',200040,'N','7091c80a-860c-4b75-9185-2902d8abda8a')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200045,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200050,'D',40,'Hub long diagonal',200041,'N','7091daf2-583a-44fb-87c7-f5b647d34362')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200045,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200061,'D',50,'Hub blocked vertical',200042,'N','7091ee34-279b-4264-9acd-e221e7d6bc99')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200045,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200062,'D',60,'Hub long diagonal',200043,'N','70917a2a-ce80-4c1e-a20a-8df01a174a1e')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200046,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200050,'D',10,'Left column down',200044,'N','70915c69-a689-4d40-ac10-94ab2310604e')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200046,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200042,'D',20,'Back edge to Start',200045,'N','709144f6-e200-449d-ae1f-d4475bf8bda2')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200046,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200047,'D',30,'In A to Block C',200072,'N','70914d62-0bb8-4cde-a291-d76c70b2c446')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200047,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200048,'D',10,'Row 2 block corridor',200046,'N','709187da-edc3-46a5-97f3-88c13e8b0cf4')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200048,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200049,'D',10,'Row 2 into Pair A',200047,'N','7091adc7-15de-463e-9839-a87bb7b43fc7')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200049,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200053,'D',10,'Pair A to Pair B',200048,'N','7091bddd-9632-4719-9a63-524ad3ce51b1')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200049,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200045,'D',20,'Bidirectional Pair A to Hub',200049,'N','7091cc4f-19ac-48f2-a65b-7df98326dc60')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200050,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200054,'D',10,'Left column down',200050,'N','7091164d-8d9d-4101-a3e9-d5f2cc872070')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200050,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200051,'D',20,'Row 3 block corridor',200051,'N','70915850-15c1-48af-adce-fbd673e8e7b8')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200051,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200052,'D',10,'Row 3 block corridor',200052,'N','709191f5-4e93-4755-8b40-15a859df6db9')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200052,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200053,'D',10,'Row 3 into Pair B',200053,'N','7091d384-bc7c-442b-92f9-7f17d557addd')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200053,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200057,'D',10,'Pair B to Out A',200054,'N','70916faa-dd0a-4a9e-87fe-4620d4261979')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200053,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200049,'D',20,'Bidirectional Pair B to Pair A',200055,'N','709117f5-5151-4df7-beec-0fa8505b9028')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200054,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200055,'D',10,'Into Self 1',200056,'N','7091e17d-06c0-488a-b761-7825ab5ee2ae')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200054,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200058,'D',20,'Left column down',200057,'N','70910c48-9dd3-4f75-aa36-e1759e3d3ac3')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200055,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200055,'D',10,'Self reference',200058,'N','709165a4-91a4-4487-a92e-a7a7bd4446de')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200055,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200056,'D',20,'Self 1 to Self 2',200059,'N','70912bd2-e4a6-4288-a4a7-d742f399d5c1')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200056,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200056,'D',10,'Self reference',200060,'N','709161a8-ad1f-4007-aeef-96f544d479a5')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200057,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200061,'D',10,'Out column down',200061,'N','709129f2-37ee-4573-835f-01609a6f9e65')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200058,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200062,'D',10,'Left column down',200062,'N','70913993-32c6-443b-9021-f541889ba950')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200058,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200045,'D',20,'Long back edge to Hub',200063,'N','7091efb7-f27e-4596-bd5c-525254b1e470')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200058,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200059,'D',30,'In D to Block G',200073,'N','7091acb7-60da-4e23-af4b-3f8b238445e8')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200059,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200060,'D',10,'Row 5 block corridor',200064,'N','70918121-0257-4f55-873e-b5b2e3f390df')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200060,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200061,'D',10,'Row 5 into Out B',200065,'N','70917c36-736d-4b3a-bab2-959176042058')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200061,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200065,'D',10,'Out column down',200066,'N','70915fa9-bd37-4094-bcad-f5d007a3a4f6')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200062,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200042,'D',10,'Back edge to Start closes cycle',200067,'N','7091d870-377c-499f-a10d-a43353594501')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200062,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200063,'D',20,'Sink to Block I',200074,'N','709188d2-0b3b-4d40-b8c2-3eaadd23877d')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200063,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200064,'D',10,'Row 6 block corridor',200068,'N','7091367e-6c02-4a4f-a453-c09617d787a0')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200064,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200065,'D',10,'Row 6 into Out C',200069,'N','709191be-39ea-465f-9909-9098cbff7aac')
+;
+-- 2026-09-04 11:00:00
+INSERT INTO AD_WF_NodeNext (AD_WF_Node_ID,IsActive,Created,CreatedBy,Updated,UpdatedBy,AD_Client_ID,AD_Org_ID,AD_WF_Next_ID,EntityType,SeqNo,Description,AD_WF_NodeNext_ID,IsStdUserWorkflow,AD_WF_NodeNext_UU) VALUES (200065,'Y',TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),100,11,0,200062,'D',10,'Out C back to Sink',200070,'N','7091a197-918f-4368-9d45-72041c2197f6')
+;
+-- 2026-09-04 11:00:00
+UPDATE AD_Workflow SET AD_WF_Node_ID=200042, IsValid='Y',Updated=TO_TIMESTAMP('2026-09-04 11:00:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Workflow_ID=200016
+;

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFEditor.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFEditor.java
@@ -341,8 +341,10 @@ public class WFEditor extends ADForm {
 					{
 						int x = c * WFGraphLayout.COLUMN_WIDTH;
 						int y = i * WFGraphLayout.ROW_HEIGHT;
-
-						tg.drawImage(bi.getSubimage(x, y, WFGraphLayout.COLUMN_WIDTH, WFGraphLayout.ROW_HEIGHT), 0, 0, null);
+						int w = Math.min(WFGraphLayout.COLUMN_WIDTH, bi.getWidth() - x);
+						int h = Math.min(WFGraphLayout.ROW_HEIGHT, bi.getHeight() - y);
+						if (w > 0 && h > 0)
+							tg.drawImage(bi.getSubimage(x, y, w, h), 0, 0, null);
 						org.zkoss.zul.Image image = new org.zkoss.zul.Image();
 						image.setContent(t);
 						td.appendChild(image);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFNodeContainer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFNodeContainer.java
@@ -160,6 +160,10 @@ public class WFNodeContainer
 			}
 		}
 
+		if (currentRow > rowCount) {
+			rowCount = currentRow;
+		}
+
 		WFNodeWidget w = (WFNodeWidget) graphScene.addNode(node.getAD_WF_Node_ID());
 		w.setColumn(currentColumn);
 		w.setRow(currentRow);

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFNodeContainer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFNodeContainer.java
@@ -243,7 +243,7 @@ public class WFNodeContainer
 	 */
 	public Dimension getDimension()
 	{
-		return new Dimension(noOfColumns * WFGraphLayout.COLUMN_WIDTH, Math.max(1, rowCount) * WFGraphLayout.ROW_HEIGHT);
+		return new Dimension(noOfColumns * WFGraphLayout.COLUMN_WIDTH, Math.max(currentRow, rowCount) * WFGraphLayout.ROW_HEIGHT);
 	}
 
 	/**
@@ -254,6 +254,7 @@ public class WFNodeContainer
 	{
 		GraphLayout<Integer, MWFNodeNext> graphLayout = new WFGraphLayout();
 		graphLayout.setAnimated(false);
+		graphScene.setMaximumBounds(new Rectangle(0, 0, getDimension().width, getDimension().height));
 		SceneLayout sceneGraphLayout = LayoutFactory.createSceneGraphLayout (graphScene, graphLayout);
 		sceneGraphLayout.invokeLayoutImmediately();
 

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFNodeContainer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/apps/wf/WFNodeContainer.java
@@ -160,10 +160,6 @@ public class WFNodeContainer
 			}
 		}
 
-		if (currentRow > rowCount) {
-			rowCount = currentRow;
-		}
-
 		WFNodeWidget w = (WFNodeWidget) graphScene.addNode(node.getAD_WF_Node_ID());
 		w.setColumn(currentColumn);
 		w.setRow(currentRow);

--- a/org.adempiere.ui/src/org/compiere/apps/wf/WFGraphLayout.java
+++ b/org.adempiere.ui/src/org/compiere/apps/wf/WFGraphLayout.java
@@ -16,8 +16,8 @@ import org.netbeans.api.visual.graph.layout.UniversalGraph;
  */
 public class WFGraphLayout extends GraphLayout<Integer, MWFNodeNext> {
 
-	public final static int COLUMN_WIDTH = 184;
-	public final static int ROW_HEIGHT = 133;
+	public final static int COLUMN_WIDTH = 200;
+	public final static int ROW_HEIGHT = 150;
 
 	@Override
 	protected void performGraphLayout(UniversalGraph<Integer, MWFNodeNext> graph) {

--- a/org.adempiere.ui/src/org/compiere/apps/wf/WFGraphLayout.java
+++ b/org.adempiere.ui/src/org/compiere/apps/wf/WFGraphLayout.java
@@ -31,8 +31,11 @@ public class WFGraphLayout extends GraphLayout<Integer, MWFNodeNext> {
 
 		for(Integer node : nodes) {
 			WFNodeWidget widget = (WFNodeWidget) graph.getScene().findWidget(node);
-			int x = (widget.getColumn() - 1) * COLUMN_WIDTH;
-			int y = (widget.getRow() - 1) * ROW_HEIGHT;
+			// Center the node widget inside its grid cell
+			int x = (widget.getColumn() - 1) * COLUMN_WIDTH
+					+ (COLUMN_WIDTH - WFNodeWidget.NODE_WIDTH) / 2;
+			int y = (widget.getRow() - 1) * ROW_HEIGHT
+					+ (ROW_HEIGHT - WFNodeWidget.NODE_HEIGHT) / 2;
 			Point point = new Point(x, y);
 			setResolvedNodeLocation(graph, node, point);
 			widget.setPreferredLocation(point);

--- a/org.adempiere.ui/src/org/compiere/apps/wf/WorkflowGraphScene.java
+++ b/org.adempiere.ui/src/org/compiere/apps/wf/WorkflowGraphScene.java
@@ -7,7 +7,9 @@ package org.compiere.apps.wf;
 import java.awt.Color;
 import java.awt.Point;
 import java.awt.Rectangle;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.compiere.util.Env;
 import org.compiere.wf.MWFNode;
@@ -35,6 +37,11 @@ public class WorkflowGraphScene extends GraphScene<Integer, MWFNodeNext> {
 
 	private LayerWidget mainLayer;
     private LayerWidget connectionLayer;
+
+    /** Self-reference routing index per connection widget (parallel self-references on the same node get separated loops). */
+    private Map<ConnectionWidget, Integer> selfLoopIndex = new HashMap<> ();
+    /** Self-reference counter per node widget. */
+    private Map<Widget, Integer> selfLoopCount = new HashMap<> ();
 
     private WidgetAction selectAction = createSelectAction();
 
@@ -64,6 +71,14 @@ public class WorkflowGraphScene extends GraphScene<Integer, MWFNodeNext> {
 	protected Widget attachEdgeWidget(MWFNodeNext edge) {
 		 ConnectionWidget connection = new ConnectionWidget (this);
 		 connection.setTargetAnchorShape (AnchorShape.TRIANGLE_FILLED);
+		 if (edge.getAD_WF_Node_ID () == edge.getAD_WF_Next_ID ()) {
+			 // nodes are attached before edges, so the node widget is available here
+			 Widget nodeWidget = findWidget (edge.getAD_WF_Node_ID ());
+			 int index = nodeWidget == null
+					 ? selfLoopIndex.size ()
+					 : selfLoopCount.merge (nodeWidget, 1, Integer::sum) - 1;
+			 selfLoopIndex.put (connection, index);
+		 }
 		 Router orthogonalRouter = RouterFactory.createOrthogonalSearchRouter (createCollisionsCollector ());
 		 Router directRouter = RouterFactory.createDirectRouter ();
 		 // The orthogonal router can return no path depending on the node positions.
@@ -95,7 +110,9 @@ public class WorkflowGraphScene extends GraphScene<Integer, MWFNodeNext> {
 	 * Route a self-reference as a compact loop around the bottom-right corner
 	 * of its node. The workflow grid leaves enough space on these two sides to
 	 * keep the loop inside the canvas, including for nodes in the last row or
-	 * column.
+	 * column. Parallel self-references on the same node are separated by
+	 * alternating between the bottom-right and bottom-left corner and by
+	 * shrinking successive loops, so no two loops share the same geometry.
 	 * @param connection connection being routed
 	 * @return loop control points, or null if this is not a self-reference
 	 */
@@ -111,12 +128,24 @@ public class WorkflowGraphScene extends GraphScene<Integer, MWFNodeNext> {
 		Rectangle bounds = source.convertLocalToScene (source.getBounds ());
 		int right = bounds.x + bounds.width;
 		int bottom = bounds.y + bounds.height;
+		int left = bounds.x;
+		int index = selfLoopIndex.getOrDefault (connection, 0);
+		int corner = index % 2;
+		int size = Math.max (SELF_LOOP_SIZE - (index / 2) * 5, 10);
+		if (corner == 0) {
+			return List.of (
+					new Point (right, bottom - SELF_LOOP_INSET),
+					new Point (right + size, bottom - SELF_LOOP_INSET),
+					new Point (right + size, bottom + size),
+					new Point (right - SELF_LOOP_INSET, bottom + size),
+					new Point (right - SELF_LOOP_INSET, bottom));
+		}
 		return List.of (
-				new Point (right, bottom - SELF_LOOP_INSET),
-				new Point (right + SELF_LOOP_SIZE, bottom - SELF_LOOP_INSET),
-				new Point (right + SELF_LOOP_SIZE, bottom + SELF_LOOP_SIZE),
-				new Point (right - SELF_LOOP_INSET, bottom + SELF_LOOP_SIZE),
-				new Point (right - SELF_LOOP_INSET, bottom));
+				new Point (left, bottom - SELF_LOOP_INSET),
+				new Point (left - size, bottom - SELF_LOOP_INSET),
+				new Point (left - size, bottom + size),
+				new Point (left + SELF_LOOP_INSET, bottom + size),
+				new Point (left + SELF_LOOP_INSET, bottom));
 	}
 
 	/**

--- a/org.adempiere.ui/src/org/compiere/apps/wf/WorkflowGraphScene.java
+++ b/org.adempiere.ui/src/org/compiere/apps/wf/WorkflowGraphScene.java
@@ -5,6 +5,9 @@ package org.compiere.apps.wf;
 
 
 import java.awt.Color;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.util.List;
 
 import org.compiere.util.Env;
 import org.compiere.wf.MWFNode;
@@ -14,6 +17,8 @@ import org.netbeans.api.visual.anchor.AnchorFactory;
 import org.netbeans.api.visual.anchor.AnchorShape;
 import org.netbeans.api.visual.graph.GraphScene;
 import org.netbeans.api.visual.layout.LayoutFactory.ConnectionWidgetLayoutAlignment;
+import org.netbeans.api.visual.router.ConnectionWidgetCollisionsCollector;
+import org.netbeans.api.visual.router.Router;
 import org.netbeans.api.visual.router.RouterFactory;
 import org.netbeans.api.visual.widget.ConnectionWidget;
 import org.netbeans.api.visual.widget.LabelWidget;
@@ -25,6 +30,8 @@ import org.netbeans.api.visual.widget.Widget;
  * @author hengsin
  */
 public class WorkflowGraphScene extends GraphScene<Integer, MWFNodeNext> {
+	private static final int SELF_LOOP_SIZE = 24;
+	private static final int SELF_LOOP_INSET = 28;
 
 	private LayerWidget mainLayer;
     private LayerWidget connectionLayer;
@@ -57,7 +64,18 @@ public class WorkflowGraphScene extends GraphScene<Integer, MWFNodeNext> {
 	protected Widget attachEdgeWidget(MWFNodeNext edge) {
 		 ConnectionWidget connection = new ConnectionWidget (this);
 		 connection.setTargetAnchorShape (AnchorShape.TRIANGLE_FILLED);
-		 connection.setRouter (RouterFactory.createOrthogonalSearchRouter (mainLayer, connectionLayer));
+		 Router orthogonalRouter = RouterFactory.createOrthogonalSearchRouter (createCollisionsCollector ());
+		 Router directRouter = RouterFactory.createDirectRouter ();
+		 // The orthogonal router can return no path depending on the node positions.
+		 // Always provide a drawable direct route in that case.
+		 connection.setRouter (widget -> {
+			 List<Point> controlPoints = routeSelfConnection (widget);
+			 if (controlPoints == null)
+				 controlPoints = orthogonalRouter.routeConnection (widget);
+			 return controlPoints == null || controlPoints.size () < 2
+					? directRouter.routeConnection (widget)
+					: controlPoints;
+		 });
 		 connection.setRoutingPolicy (ConnectionWidget.RoutingPolicy.ALWAYS_ROUTE);
 		 
 		 String description = edge.getDescription();
@@ -71,6 +89,99 @@ public class WorkflowGraphScene extends GraphScene<Integer, MWFNodeNext> {
 			
 	     connectionLayer.addChild (connection);
 	     return connection;
+	}
+
+	/**
+	 * Route a self-reference as a compact loop around the bottom-right corner
+	 * of its node. The workflow grid leaves enough space on these two sides to
+	 * keep the loop inside the canvas, including for nodes in the last row or
+	 * column.
+	 * @param connection connection being routed
+	 * @return loop control points, or null if this is not a self-reference
+	 */
+	private List<Point> routeSelfConnection (ConnectionWidget connection) {
+		if (connection.getSourceAnchor () == null || connection.getTargetAnchor () == null)
+			return null;
+
+		Widget source = connection.getSourceAnchor ().getRelatedWidget ();
+		if (source == null || source != connection.getTargetAnchor ().getRelatedWidget ()
+				|| !source.isValidated () || source.getBounds () == null)
+			return null;
+
+		Rectangle bounds = source.convertLocalToScene (source.getBounds ());
+		int right = bounds.x + bounds.width;
+		int bottom = bounds.y + bounds.height;
+		return List.of (
+				new Point (right, bottom - SELF_LOOP_INSET),
+				new Point (right + SELF_LOOP_SIZE, bottom - SELF_LOOP_INSET),
+				new Point (right + SELF_LOOP_SIZE, bottom + SELF_LOOP_SIZE),
+				new Point (right - SELF_LOOP_INSET, bottom + SELF_LOOP_SIZE),
+				new Point (right - SELF_LOOP_INSET, bottom));
+	}
+
+	/**
+	 * Create a collision collector which avoids nodes and already routed edges,
+	 * but excludes the connection currently being routed.
+	 * @return collision collector
+	 */
+	private ConnectionWidgetCollisionsCollector createCollisionsCollector () {
+		return (connection, verticalCollisions, horizontalCollisions) -> {
+			for (Widget node : mainLayer.getChildren ()) {
+				if (!node.isValidated () || node.getBounds () == null)
+					continue;
+				Rectangle bounds = node.convertLocalToScene (node.getBounds ());
+				bounds.grow (16, 16);
+				verticalCollisions.add (bounds);
+				horizontalCollisions.add (bounds);
+			}
+
+			for (Widget widget : connectionLayer.getChildren ()) {
+				if (widget == connection || !(widget instanceof ConnectionWidget))
+					continue;
+				ConnectionWidget otherConnection = (ConnectionWidget) widget;
+				// Opposite transitions share a route. Treating the first one as an
+				// obstacle makes the second one take a needlessly winding detour.
+				if (connectsOppositeNodes (connection, otherConnection))
+					continue;
+				if (!otherConnection.isRouted ())
+					continue;
+				List<Point> controlPoints = otherConnection.getControlPoints ();
+				for (int i = 0; i < controlPoints.size () - 1; i++) {
+					Point first = otherConnection.convertLocalToScene (controlPoints.get (i));
+					Point second = otherConnection.convertLocalToScene (controlPoints.get (i + 1));
+					if (first.x == second.x) {
+						Rectangle segment = new Rectangle (first.x, Math.min (first.y, second.y), 0,
+								Math.abs (second.y - first.y));
+						segment.grow (8, 8);
+						verticalCollisions.add (segment);
+					}
+					else if (first.y == second.y) {
+						Rectangle segment = new Rectangle (Math.min (first.x, second.x), first.y,
+								Math.abs (second.x - first.x), 0);
+						segment.grow (8, 8);
+						horizontalCollisions.add (segment);
+					}
+				}
+			}
+		};
+	}
+
+	/**
+	 * Test whether two connections link the same nodes in opposite directions.
+	 * @param connection connection being routed
+	 * @param otherConnection other connection in the scene
+	 * @return true if both connections form a bidirectional transition
+	 */
+	private boolean connectsOppositeNodes (ConnectionWidget connection, ConnectionWidget otherConnection) {
+		if (connection.getSourceAnchor () == null || connection.getTargetAnchor () == null
+				|| otherConnection.getSourceAnchor () == null || otherConnection.getTargetAnchor () == null)
+			return false;
+
+		Widget source = connection.getSourceAnchor ().getRelatedWidget ();
+		Widget target = connection.getTargetAnchor ().getRelatedWidget ();
+		return source != null && target != null
+				&& source == otherConnection.getTargetAnchor ().getRelatedWidget ()
+				&& target == otherConnection.getSourceAnchor ().getRelatedWidget ();
 	}
 
 	@Override

--- a/org.adempiere.ui/src/org/compiere/apps/wf/WorkflowGraphScene.java
+++ b/org.adempiere.ui/src/org/compiere/apps/wf/WorkflowGraphScene.java
@@ -30,7 +30,7 @@ import org.netbeans.api.visual.widget.Widget;
  * @author hengsin
  */
 public class WorkflowGraphScene extends GraphScene<Integer, MWFNodeNext> {
-	private static final int SELF_LOOP_SIZE = 24;
+	private static final int SELF_LOOP_SIZE = 20;
 	private static final int SELF_LOOP_INSET = 28;
 
 	private LayerWidget mainLayer;


### PR DESCRIPTION
JIRA: https://idempiere.atlassian.net/browse/IDEMPIERE-7091

## Description

The workflow editor can omit transition arrows when the orthogonal router cannot find a collision-free path for the current node arrangement. This change makes workflow transitions render reliably, including bidirectional and self-referencing transitions.

## Changes

- Improve orthogonal routing around workflow nodes and existing routed edges.
- Keep routes within the visible workflow canvas and use direct routing as a fallback.
- Render bidirectional transitions and self-transitions clearly.
- Size the rendered canvas for all used rows and guard image slicing at its boundaries.
- Center workflow nodes inside their grid cells (discussed and agreed in the ticket).
- Add a GardenWorld test workflow migration script (PostgreSQL/Oracle) with a fully packed 4x6 grid, blocked corridors, bidirectional pairs, back edges and two self-referencing transitions for manual verification.

## Validation

- Validated manually with the GardenWorld test workflow included in this PR: all 41 transitions are rendered, self references are drawn as compact loops, and no arrow gets lost after moving nodes and reopening the editor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workflow diagram sizing to adapt to the number of nodes and available grid space.
  - Prevented rendering errors at workflow image boundaries.
  - Corrected layout sizing when nodes overlap or require additional rows.
  - Improved connection routing around nodes, existing paths, bidirectional connections, and self-referencing transitions.

- **Style**
  - Increased workflow grid spacing and centered nodes within their cells.

- **Tests**
  - Added a sample workflow covering blocked paths, loops, reverse connections, and self-referencing transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->