### PR TITLE
IDEMPIERE-7070 Add interactive HTML report content type

### DIFF
--- a/org.adempiere.base/src/org/adempiere/base/Core.java
+++ b/org.adempiere.base/src/org/adempiere/base/Core.java
@@ -1366,6 +1366,8 @@ public class Core {
 		private static final ReportContentType[] SUPPORTED_CONTENT_TYPES = {
 				new ReportContentType(Msg.getMsg(Env.getCtx(), "FilePDF"), "pdf", "application/pdf"),
 				new ReportContentType(Msg.getMsg(Env.getCtx(), "FileHTML"), "html", "text/html"),
+				new ReportContentType(Msg.getMsg(Env.getCtx(), "FileHTML"), "html",
+						ReportContentType.HTML_INTERACTIVE_CONTENT_TYPE),
 				new ReportContentType(Msg.getMsg(Env.getCtx(), "FileCSV"), "csv", "text/csv"),
 				new ReportContentType(Msg.getMsg(Env.getCtx(), "FileXLS"), "xls", "application/vnd.ms-excel"),
 				new ReportContentType(Msg.getMsg(Env.getCtx(), "FileXLSX"), "xlsx",
@@ -1379,6 +1381,8 @@ public class Core {
 
 		@Override
 		public File getContent(String contentType, String fileExtension) {
+			if (ReportContentType.isInteractiveHTML(contentType))
+				return null;
 			String extension = fileExtension != null ? fileExtension.toLowerCase() : "";
 			if (!List.of("pdf", "html", "csv", "xls", "xlsx").contains(extension))
 				return null;

--- a/org.adempiere.base/src/org/compiere/tools/FileUtil.java
+++ b/org.adempiere.base/src/org/compiere/tools/FileUtil.java
@@ -535,6 +535,29 @@ public class FileUtil
 	}
 	
 	/**
+	 * Creates a valid file name prefix from "name", replacing every
+	 * character outside the US-ASCII range with an underscore.
+	 * Accented characters are transliterated first via
+	 * {@link Util#setFilenameCorrect(String)}, so e.g. "Ü" becomes "U".
+	 * The result is safe to embed in URLs and URIs.
+	 * @param name
+	 * @return ASCII-safe file name prefix
+	 */
+    public static String makeASCIIPrefix(String name) {
+		String output = Util.setFilenameCorrect(name);
+		StringBuilder prefix = new StringBuilder();
+		char[] nameArray = output.toCharArray();
+		for (char ch : nameArray) {
+			if (ch < 128 && Character.isLetterOrDigit(ch)) {
+				prefix.append(ch);
+			} else {
+				prefix.append("_");
+			}
+		}
+		return prefix.toString();
+	}
+	
+	/**
 	 * 
 	 * @param path
 	 * @return true if deleted

--- a/org.adempiere.base/src/org/idempiere/print/ReportContentType.java
+++ b/org.adempiere.base/src/org/idempiere/print/ReportContentType.java
@@ -13,4 +13,20 @@ package org.idempiere.print;
 
 /** UI-independent description of a supported report output type. */
 public record ReportContentType(String name, String fileExtension, String contentType) {
+
+	/**
+	 * Internal content type for an HTML report with viewer interaction such as
+	 * drill-down links. Content delivered to a browser still uses {@code text/html}.
+	 * Only renderers that actually produce viewer-interactive HTML
+	 * (e.g. with drill-down links) should advertise this type.
+	 */
+	public static final String HTML_INTERACTIVE_CONTENT_TYPE = "text/html; mode=interactive";
+
+	/**
+	 * @param contentType content type to test
+	 * @return {@code true} for the internal interactive HTML content type
+	 */
+	public static boolean isInteractiveHTML(String contentType) {
+		return HTML_INTERACTIVE_CONTENT_TYPE.equalsIgnoreCase(contentType);
+	}
 }

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/DynamicMediaLink.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/component/DynamicMediaLink.java
@@ -33,6 +33,7 @@ public class DynamicMediaLink extends A {
 	private static final long serialVersionUID = 5017833977652241179L;
 	
 	private AMedia media;
+	private boolean openInBrowser;
 
 	/**
 	 * Default constructor
@@ -43,7 +44,11 @@ public class DynamicMediaLink extends A {
 
 			@Override
 			public void onEvent(Event event) throws Exception {
-				Filedownload.save(media);
+				if (media == null)
+					return;
+				//in open-in-browser mode the anchor href/target handled natively by the browser
+				if (!openInBrowser)
+					Filedownload.save(media);
 			}
 		});
 	}
@@ -70,4 +75,14 @@ public class DynamicMediaLink extends A {
 	public void setMedia(AMedia media) {
 		this.media = media;
 	}	
+	
+	/**
+	 * Set whether clicking the link opens the link href (requires href and
+	 * target to be set) in a new browser tab instead of forcing a download
+	 * of the media.
+	 * @param openInBrowser
+	 */
+	public void setOpenInBrowser(boolean openInBrowser) {
+		this.openInBrowser = openInBrowser;
+	}
 }

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/ZkJRViewer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/ZkJRViewer.java
@@ -229,6 +229,8 @@ public class ZkJRViewer extends Window implements EventListener<Event>, ITabOnCl
 		ZKUpdateUtil.setHeight(toolbar, "32px");
 
 		previewType.setMold("select");
+		if (ClientInfo.maxWidth(ClientInfo.SMALL_WIDTH - 1))
+			previewType.setStyle("max-width: 40%");
 		ValueNamePair[] previewTypes = JasperPrintRenderer.getPreviewType(isCanExport);
 		for(int i = 0; i < previewTypes.length; i++) {
 			previewType.appendItem(previewTypes[i].getName(), previewTypes[i].getValue());

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/ZkReportViewer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/ZkReportViewer.java
@@ -40,8 +40,6 @@ import java.util.TreeMap;
 import java.util.logging.Level;
 
 import javax.activation.FileDataSource;
-import javax.servlet.http.HttpServletRequest;
-
 import org.adempiere.base.Core;
 import org.adempiere.base.upload.IUploadService;
 import org.adempiere.exceptions.AdempiereException;
@@ -57,6 +55,7 @@ import org.adempiere.webui.apps.ProcessModalDialog;
 import org.adempiere.webui.apps.WReport;
 import org.adempiere.webui.apps.form.WReportCustomization;
 import org.adempiere.webui.component.Checkbox;
+import org.adempiere.webui.component.DynamicMediaLink;
 import org.adempiere.webui.component.Label;
 import org.adempiere.webui.component.ListItem;
 import org.adempiere.webui.component.Listbox;
@@ -140,7 +139,6 @@ import org.zkoss.zk.ui.event.Events;
 import org.zkoss.zk.ui.event.KeyEvent;
 import org.zkoss.zk.ui.ext.render.DynamicMedia;
 import org.zkoss.zk.ui.util.Clients;
-import org.zkoss.zul.A;
 import org.zkoss.zul.Borderlayout;
 import org.zkoss.zul.Center;
 import org.zkoss.zul.Div;
@@ -233,7 +231,7 @@ public class ZkReportViewer extends Window implements EventListener<Event>, IRep
 	protected AMedia media;
 	private int mediaVersion = 0;
 
-	private A reportLink;
+	private DynamicMediaLink reportLink;
 
 	private boolean init;
 	
@@ -375,6 +373,8 @@ public class ZkReportViewer extends Window implements EventListener<Event>, IRep
 		ZKUpdateUtil.setWidth(toolBar, "100%");
 		
 		previewType.setMold("select");
+		if (ClientInfo.maxWidth(ClientInfo.SMALL_WIDTH - 1))
+			previewType.setStyle("max-width: 40%");
 		setupPreviewType();
 		
 		toolBar.appendChild(previewType);		
@@ -704,8 +704,7 @@ public class ZkReportViewer extends Window implements EventListener<Event>, IRep
 		South south = new South();
 		ZKUpdateUtil.setHeight(south, "50px");
 		layout.appendChild(south);
-		reportLink = new A();
-		reportLink.setTarget("_blank");
+		reportLink = new DynamicMediaLink();
 		Div linkDiv = new Div();
 		linkDiv.setStyle("width:100%; height: 40px; padding: 4px;");
 		linkDiv.appendChild(reportLink);
@@ -793,12 +792,19 @@ public class ZkReportViewer extends Window implements EventListener<Event>, IRep
 		}
 		List<String> previewRendererIds = new ArrayList<>();
 		if (reportContentRenderer != null) {
-			for (ReportContentType contentType : reportContentRenderer.getSupportedContentTypes()) {
+			ReportContentType[] supportedContentTypes = reportContentRenderer.getSupportedContentTypes();
+			boolean supportsInteractiveHTML = Arrays.stream(supportedContentTypes)
+					.anyMatch(type -> ReportContentType.isInteractiveHTML(type.contentType()));
+			for (ReportContentType contentType : supportedContentTypes) {
+				if (supportsInteractiveHTML && "html".equalsIgnoreCase(contentType.fileExtension())
+						&& !ReportContentType.isInteractiveHTML(contentType.contentType()))
+					continue;
 				IReportViewerRenderer renderer = rendererMap.values().stream()
 						.filter(candidate -> candidate.getFileExtension().equalsIgnoreCase(contentType.fileExtension()))
 						.findFirst()
 						.orElse(null);
-				if (renderer == null || !renderer.isPreview(m_isCanExport))
+				if (renderer == null || !renderer.isPreview(m_isCanExport)
+						|| previewRendererIds.contains(renderer.getId()))
 					continue;
 				ListItem li = previewType.appendItem(IReportViewerExportSource.getFormatLabel(
 						contentType.fileExtension(), contentType.name()), renderer.getId());
@@ -816,7 +822,7 @@ public class ZkReportViewer extends Window implements EventListener<Event>, IRep
 					previewType.setSelectedItem(li);
 			}
 			if (summary != null)
-				summary.setVisible(false);
+				summary.setVisible(supportsInteractiveHTML && m_reportEngine.getPrintData() != null);
 		} else if (m_reportEngine.getPrintFormat().getJasperProcess_ID() > 0) {
 			for (ValueNamePair vnp : JasperPrintRenderer.getPreviewType(m_isCanExport)) {
 				ListItem li = previewType.appendItem(vnp.getName(), vnp.getValue());
@@ -901,7 +907,10 @@ public class ZkReportViewer extends Window implements EventListener<Event>, IRep
 			if(media == null) {
 				iframe.setSrc(null);
 				iframe.setContent(null);
+				reportLink.setMedia(null);
+				reportLink.setOpenInBrowser(false);
 				reportLink.setHref("");
+				reportLink.setTarget(null);
 				reportLink.setLabel("");
 				if (rowCount != null)
 					rowCount.setText("");
@@ -909,16 +918,25 @@ public class ZkReportViewer extends Window implements EventListener<Event>, IRep
 			}
 			
 			mediaVersion++;
-			String url = Utils.getDynamicMediaURI(this, mediaVersion, media.getName(), media.getFormat());	
+			String url = Utils.getDynamicMediaURI(this, mediaVersion, media.getName(), media.getFormat());
 			String pdfJsUrl = AEnv.toPdfJsUrl(url);
-			HttpServletRequest request = (HttpServletRequest) Executions.getCurrent().getNativeRequest();
-			if (url.startsWith(request.getContextPath() + "/"))
-				url = url.substring((request.getContextPath() + "/").length());
-			reportLink.setHref(url);
-			reportLink.setLabel(media.getName());			
 			
 			Listitem selected = previewType.getSelectedItem();
 			String outputType = previewType.getSelectedItem().getValue();
+			boolean openInBrowser = HTML_OUTPUT_TYPE.equals(outputType) || PDF_OUTPUT_TYPE.equals(outputType);
+			reportLink.setOpenInBrowser(openInBrowser);
+			if (openInBrowser) {
+				String contextPath = Executions.getCurrent().getContextPath();
+				if (url.startsWith(contextPath + "/"))
+					url = url.substring((contextPath + "/").length());
+				reportLink.setHref(url);
+				reportLink.setTarget("_blank");
+			} else {
+				reportLink.setHref("");
+				reportLink.setTarget(null);
+			}
+			reportLink.setMedia(media);
+			reportLink.setLabel(m_reportEngine.getName());
 			if (ClientInfo.isMobile()) {				
 				if (selected == null || PDF_OUTPUT_TYPE.equals(selected.getValue())) {
 					attachIFrame();
@@ -1998,39 +2016,57 @@ public class ZkReportViewer extends Window implements EventListener<Event>, IRep
 			if (file == null)
 				return null;
 			try {
-				String fileName = FileUtil.makePrefix(m_reportEngine.getName()) + "." + fileExtension;
-				return new AMedia(fileName, fileExtension, contentType, file, true);
+				String fileName = FileUtil.makeASCIIPrefix(m_reportEngine.getName()) + "." + fileExtension;
+				String mediaContentType = contentType;
+				if (ReportContentType.isInteractiveHTML(contentType)) {
+					IReportViewerRenderer htmlRenderer = rendererMap.get(HTML_OUTPUT_TYPE);
+					if (htmlRenderer != null)
+						mediaContentType = htmlRenderer.getContentType();
+				}
+				return new AMedia(fileName, fileExtension, mediaContentType, file, true);
 			} catch (IOException e) {
 				throw new AdempiereException("Unable to read report content", e);
 			}
 		}
 		
 		IReportViewerRenderer renderer = rendererMap.get(toRendererId(contentType, fileExtension));
-		
+		if (renderer == null)
+			return null;
 		if (renderer.isSameContentForExportAndPreview() && media != null 
 				&& media.getContentType().equals(contentType) && media.getFormat().equals(fileExtension))
 			return media;
 				
-		return renderer != null ? renderer.renderMedia(this, true) : null;
+		return renderer.renderMedia(this, true);
 	}
 
 	public AMedia getMedia(String rendererId) {
+		IReportViewerRenderer renderer = rendererMap.get(rendererId);
+		if (renderer == null)
+			return null;
 		if (reportContentRenderer != null && (PDF_OUTPUT_TYPE.equals(rendererId)
 				|| HTML_OUTPUT_TYPE.equals(rendererId) || XLS_OUTPUT_TYPE.equals(rendererId)
 				|| XLSX_OUTPUT_TYPE.equals(rendererId) || CSV_OUTPUT_TYPE.equals(rendererId))) {
-			return getMedia(JasperPrintRenderer.getMIMEType(rendererId),
-					JasperPrintRenderer.getFileExtension(rendererId));
+			ReportContentType contentType = Arrays.stream(reportContentRenderer.getSupportedContentTypes())
+					.filter(type -> renderer.getFileExtension().equalsIgnoreCase(type.fileExtension()))
+					.sorted((left, right) -> Boolean.compare(
+							ReportContentType.isInteractiveHTML(right.contentType()),
+							ReportContentType.isInteractiveHTML(left.contentType())))
+					.findFirst()
+					.orElse(null);
+			if (contentType != null) {
+				AMedia rendered = getMedia(contentType.contentType(), contentType.fileExtension());
+				if (rendered != null)
+					return rendered;
+			}
 		}
-		IReportViewerRenderer renderer = rendererMap.get(rendererId);
-		if (renderer != null)
-			return renderer.renderMedia(this, false);
-		return null;
+		return renderer.renderMedia(this, false);
 	}
 	
 	@Override
 	public ExportFormat[] getExportFormats() {
 		if (reportContentRenderer != null) {
 			return Arrays.stream(reportContentRenderer.getSupportedContentTypes())
+					.filter(type -> !ReportContentType.isInteractiveHTML(type.contentType()))
 					.map(type -> new ExportFormat(IReportViewerExportSource.getFormatLabel(
 							type.fileExtension(), type.name()), type.fileExtension(), type.contentType()))
 					.toArray(ExportFormat[]::new);
@@ -2088,13 +2124,12 @@ public class ZkReportViewer extends Window implements EventListener<Event>, IRep
 	 */
 	private void updateRowCount() {
 		if(rowCount != null) {
-			if (reportContentRenderer != null) {
+			int count = reportContentRenderer != null ? reportContentRenderer.getRowCount()
+					: m_reportEngine.getPrintData() != null ? m_reportEngine.getPrintData().getRowCount(false) : -1;
+			if (count >= 0)
+				rowCount.setValue(Msg.getMsg(Env.getCtx(), "RowCount", new Object[] {count}));
+			else
 				rowCount.setValue("");
-			} else if (m_reportEngine.getPrintData() != null) {
-				rowCount.setValue(Msg.getMsg(Env.getCtx(), "RowCount", new Object[] {m_reportEngine.getPrintData().getRowCount(false)}));
-			} else {
-				rowCount.setValue("");
-			}
 		}
 	}
 }

--- a/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/report/HTMLReportViewerRenderer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/report/HTMLReportViewerRenderer.java
@@ -32,6 +32,8 @@ import org.compiere.tools.FileUtil;
 import org.compiere.util.CLogger;
 import org.compiere.util.Env;
 import org.compiere.util.Msg;
+import org.idempiere.print.ReportContentRequest;
+import org.idempiere.print.ReportContentType;
 import org.idempiere.print.renderer.HTMLReportRendererConfiguration;
 import org.idempiere.print.renderer.IReportRenderer;
 import org.idempiere.print.renderer.IReportRendererConfiguration;
@@ -99,6 +101,9 @@ public class HTMLReportViewerRenderer implements IReportViewerRenderer {
 					.setExtension(new HTMLExtension(contextPath, "rp", viewer.getUuid()))
 					.setContextPath(contextPath);
 			renderer.renderReport(reportEngine, config);
+			String pipelineContentType = export ? getContentType() : ReportContentType.HTML_INTERACTIVE_CONTENT_TYPE;
+			file = Core.processReportContent(new ReportContentRequest(reportEngine,
+					reportEngine.getProcessInfo(), viewer.getTitle()), pipelineContentType, getFileExtension(), file);
 			return new AMedia(file.getName(), getFileExtension(), getContentType(), file, false);
 		} catch (Exception e) {
 			if (e instanceof RuntimeException)

--- a/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/report/IReportViewerRenderer.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/report/IReportViewerRenderer.java
@@ -23,6 +23,7 @@ package org.idempiere.ui.zk.report;
 
 import org.adempiere.webui.window.ZkReportViewer;
 import org.compiere.print.ReportEngine;
+import org.compiere.tools.FileUtil;
 import org.zkoss.util.media.AMedia;
 
 /**
@@ -106,18 +107,9 @@ public interface IReportViewerRenderer {
 	/**
 	 * Create file name prefix from name
 	 * @param name
-	 * @return file name prefix from name
+	 * @return ASCII-safe file name prefix from name
 	 */
 	default String makePrefix(String name) {
-		StringBuilder prefix = new StringBuilder();
-		char[] nameArray = name.toCharArray();
-		for (char ch : nameArray) {
-			if (Character.isLetterOrDigit(ch)) {
-				prefix.append(ch);
-			} else {
-				prefix.append("_");
-			}
-		}
-		return prefix.toString();
+		return FileUtil.makeASCIIPrefix(name);
 	}
 }

--- a/org.idempiere.test/src/org/idempiere/test/ui/ReportViewerContentRendererFactoryTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/ui/ReportViewerContentRendererFactoryTest.java
@@ -14,6 +14,7 @@ package org.idempiere.test.ui;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -22,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.Hashtable;
 import java.util.List;
@@ -243,7 +245,60 @@ public class ReportViewerContentRendererFactoryTest extends AbstractTestCase {
 		ReportEngine reportEngine = org.mockito.Mockito.mock(ReportEngine.class);
 		ReportContentRequest request = new ReportContentRequest(reportEngine, null, "Test", false);
 
-		assertNotNull(Core.getReportContentRenderer(request));
+		IReportContentRenderer renderer = Core.getReportContentRenderer(request);
+		assertNotNull(renderer);
+		assertTrue(Arrays.stream(renderer.getSupportedContentTypes())
+				.anyMatch(type -> ReportContentType.isInteractiveHTML(type.contentType())));
+		assertNull(renderer.getContent(ReportContentType.HTML_INTERACTIVE_CONTENT_TYPE, "html"));
+	}
+
+	@Test
+	public void testInteractiveHtmlUsesOwnPipelineCacheKey() throws IOException {
+		File content = Files.createTempFile("interactive-report-content-", ".html").toFile();
+		AtomicInteger rendererCalls = new AtomicInteger();
+		IReportContentRenderer renderer = new TestRenderer() {
+			@Override
+			public File getContent(String contentType, String fileExtension) {
+				rendererCalls.incrementAndGet();
+				return content;
+			}
+
+			@Override
+			public ReportContentType[] getSupportedContentTypes() {
+				return new ReportContentType[] { new ReportContentType("Interactive HTML", "html",
+						ReportContentType.HTML_INTERACTIVE_CONTENT_TYPE) };
+			}
+		};
+		List<String> processedContentTypes = new ArrayList<>();
+		IReportContentProcessor processor = new IReportContentProcessor() {
+			@Override
+			public boolean isApplicable(ReportContentRequest request, String contentType, String fileExtension) {
+				return true;
+			}
+
+			@Override
+			public File process(ReportContentRequest request, String contentType, String fileExtension, File input) {
+				processedContentTypes.add(contentType);
+				return input;
+			}
+		};
+		ServiceRegistration<IReportContentRendererFactory> factoryRegistration =
+				registerFactory(request -> renderer, 20);
+		ServiceRegistration<IReportContentProcessor> processorRegistration = registerProcessor(processor, 10);
+		try {
+			IReportContentRenderer cachedRenderer = Core.getReportContentRenderer(emptyRequest());
+			assertNotNull(cachedRenderer);
+			assertSame(content, cachedRenderer.getContent("text/html", "html"));
+			assertSame(content, cachedRenderer.getContent("text/html", "html"));
+			assertSame(content, cachedRenderer.getContent(ReportContentType.HTML_INTERACTIVE_CONTENT_TYPE, "html"));
+			assertSame(content, cachedRenderer.getContent(ReportContentType.HTML_INTERACTIVE_CONTENT_TYPE, "html"));
+			assertEquals(2, rendererCalls.get());
+			assertEquals(List.of("text/html", ReportContentType.HTML_INTERACTIVE_CONTENT_TYPE), processedContentTypes);
+		} finally {
+			content.delete();
+			processorRegistration.unregister();
+			factoryRegistration.unregister();
+		}
 	}
 
 	private ServiceRegistration<IReportContentRendererFactory> registerFactory(


### PR DESCRIPTION
Fixes the regression reported after #3318 (IDEMPIERE-7070 was reopened).

JIRA: https://idempiere.atlassian.net/browse/IDEMPIERE-7070

## Problem

After merging #3318:

- Native HTML previews lost their drill-down links and viewer formatting. The native report engine fallback rendered HTML directly via `ReportEngine.createHTML(...)`, bypassing `HTMLReportViewerRenderer` and therefore `HTMLExtension`, the web context path and viewer-specific CSS/JavaScript.
- The HTML download link failed for localized report names containing non-ASCII characters (e.g. `Offene_Posten__Nur_Überweisung_.html`) with `HTTP ERROR 400 Ambiguous URI path encoding`, because `FileUtil.makePrefix()` preserves Unicode and the raw name was embedded in the dynamic media URI passed to the anchor href.

## Solution

- New internal content type `text/html; mode=interactive` (`ReportContentType.HTML_INTERACTIVE_CONTENT_TYPE`):
  - The native report engine fallback advertises it but returns no content for it.
  - The ZK viewer's `HTMLReportViewerRenderer` renders the interactive preview (with `HTMLExtension`, drill-down links, viewer CSS/JS) and passes it through the report content processor pipeline using the interactive content type.
  - Plain `text/html` export rendering stays separate, so preview and export use the configuration each of them requires.
- Interactive HTML is delivered to the browser as `text/html` only.
- `FileUtil.makeASCIIPrefix()`: media names delivered through viewer URIs are now ASCII-safe (root-cause fix for the Jetty 400; also protects the pdf.js viewer URL). Download file names for CSV/XLS/XLSX keep localized names.
- Report viewer link (`DynamicMediaLink`): HTML and PDF open in a new browser tab via href/target (previous behavior), other formats download the media; the label shows the localized report name.
- Row count and Summary checkbox are visible again for native reports (`IReportContentRenderer.getRowCount()`), hidden for renderers without row data support.
- Defensive fixes: null-safe `rendererMap` lookups and null guard in `DynamicMediaLink`.

## Tests

`ReportViewerContentRendererFactoryTest` additions:

- Native report engine fallback advertises interactive HTML and returns no content for it.
- Interactive HTML uses its own pipeline cache key; processors run separately for preview and export content types.

Plus full reactor build and manual testing of viewer preview/export/download paths with localized (de_DE) report names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for interactive HTML report previews when available.
  - Interactive HTML reports can open directly in the browser.
  - Improved report downloads with safer, more compatible file name prefixes.
  - Export options now distinguish interactive HTML from standard HTML output.

- **Bug Fixes**
  - Improved handling when report content or renderers are unavailable.
  - Prevented unnecessary download actions when opening media in the browser.

- **Style**
  - Limited the preview format selector width on smaller screens for improved usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->