### PR TITLE
IDEMPIERE-7093 Prevent popup-dialog windows from exceeding the viewport on narrow screens

### DIFF
--- a/org.idempiere.zk.iceblue_c.theme/src/metainfo/zk/lang-addon.xml
+++ b/org.idempiere.zk.iceblue_c.theme/src/metainfo/zk/lang-addon.xml
@@ -5,5 +5,5 @@
 
 	<!-- this js module doesn't actually exists and it is here for iceblue_c theme version -->
 	<!-- since loading of js module is on demand, it doesn't cause any error as long as you don't try to load it -->
-	<javascript-module name="idempiere.theme.iceblue_c" version="202607081330" />
+	<javascript-module name="idempiere.theme.iceblue_c" version="202609040000" />
 </language>

--- a/org.idempiere.zk.iceblue_c.theme/src/web/theme/iceblue_c/css/fragment/window-size.css.dsp
+++ b/org.idempiere.zk.iceblue_c.theme/src/web/theme/iceblue_c/css/fragment/window-size.css.dsp
@@ -400,3 +400,7 @@
 		height: 100%;
 	}
 }
+
+.popup-dialog {
+	max-width: calc(100% - 10px);
+}

--- a/org.idempiere.zk.iceblue_c.theme/src/web/theme/iceblue_c/css/fragment/window-size.css.dsp
+++ b/org.idempiere.zk.iceblue_c.theme/src/web/theme/iceblue_c/css/fragment/window-size.css.dsp
@@ -402,5 +402,5 @@
 }
 
 .popup-dialog {
-	max-width: calc(100% - 10px);
+	max-width: 100%;
 }


### PR DESCRIPTION
## Summary

Prevents all `popup-dialog` windows from exceeding the viewport on narrow screens (mobile phones, tablets, small browser windows).

Jira: [IDEMPIERE-7093](https://idempiere.atlassian.net/browse/IDEMPIERE-7093)

## Root Cause

Dialogs created with `ZKUpdateUtil.setWindowWidthX(this, width)` only clamp to 100% when `ClientInfo.get().desktopWidth` is reliably detected as smaller than the requested width. When the desktop width is not correctly reported (e.g. `desktopWidth == 0` on mobile, or the physical screen width is reported instead of the layout viewport width), the dialog keeps a fixed width that can exceed the visible viewport, pushing the close icon out of reach.

## Fix

Added a single CSS rule to the iceblue_c theme (`window-size.css.dsp`):

```css
.popup-dialog {
    max-width: 100%;
}
```

This ensures all `popup-dialog` windows never extend beyond the visible viewport while leaving their normal width behavior unchanged on desktop screens.

## Affected Dialogs

The following dialogs use the `popup-dialog` class and rely on `setWindowWidthX` for sizing (no dedicated theme media-query rule):

| Dialog | File | setWindowWidthX width |
|--------|------|-----------------------|
| `WMediaOptions` | `org.idempiere.ui.zk.media.WMediaOptions` | 400px |
| `WReportExportDialog` | `org.adempiere.webui.window.WReportExportDialog` | 450px |
| `ExportAction` (CSV/XLS) | `org.adempiere.webui.panel.action.ExportAction` | 450px |
| `FileImportAction` | `org.adempiere.webui.panel.action.FileImportAction` | 450px |
| `CSVImportAction` | `org.adempiere.webui.panel.action.CSVImportAction` | 450px |
| `InfoPAttributeInstancePanel` | `org.adempiere.webui.panel.InfoPAttributeInstancePanel` | 700px |

All other `popup-dialog` windows already have dedicated responsive rules in `window-size.css.dsp` (e.g. `.location-dialog`, `.pattribute-dialog`, `.attachment-dialog`, `.chat-dialog`, etc.) and are not affected.

## Testing

- Desktop: no visible change (all dialogs remain at their configured width)
- Mobile / narrow viewport: dialogs are clamped to the viewport width, close icon always accessible
- No database changes required

## Checklist

- [x] Tested with the iceblue_c theme (desktop and narrow viewport)
- [x] No database changes / no migration scripts required
- [x] Theme version timestamp in `lang-addon.xml` updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted popup dialog sizing to use the full available screen width.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


[IDEMPIERE-7093]: https://idempiere.atlassian.net/browse/IDEMPIERE-7093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
