### PR TITLE
IDEMPIERE-7074 Business Partner info window without contact/location selection

### DIFF
--- a/migration/iD14/oracle/202609020900_IDEMPIERE-7074.sql
+++ b/migration/iD14/oracle/202609020900_IDEMPIERE-7074.sql
@@ -1,0 +1,109 @@
+-- IDEMPIERE-7074 Business Partner Info window without contact/location (one row per partner)
+SELECT register_migration_script('202609020900_IDEMPIERE-7074.sql') FROM dual;
+
+-- Sep 2, 2026, 9:00:00 AM
+INSERT INTO AD_InfoWindow (Processing,FromClause,AD_InfoWindow_UU,AD_InfoWindow_ID,AD_Table_ID,EntityType,Name,Description,AD_Client_ID,AD_Org_ID,Created,Updated,UpdatedBy,CreatedBy,IsActive,IsDefault,IsDistinct,OrderByClause,IsValid,ImageURL) VALUES ('N','C_BPartner bp
+LEFT OUTER JOIN C_BPartner_Location l ON (bp.C_BPartner_ID=l.C_BPartner_ID AND l.IsActive=''Y'')
+LEFT OUTER JOIN AD_User c ON (bp.C_BPartner_ID=c.C_BPartner_ID AND (c.C_BPartner_Location_ID IS NULL OR c.C_BPartner_Location_ID=l.C_BPartner_Location_ID) AND c.IsActive=''Y'')
+LEFT OUTER JOIN C_Location a ON (l.C_Location_ID=a.C_Location_ID)','6a7f7db9-ec0b-4620-95dd-937d48c55c4f',200025,291,'D','Business Partner Info (Simple)','Business Partner lookup showing one row per partner, without contact and location columns. Contacts and locations are joined for search criteria only.',0,0,TO_TIMESTAMP('2026-09-02 09:00:00','YYYY-MM-DD HH24:MI:SS'),TO_TIMESTAMP('2026-09-02 09:00:00','YYYY-MM-DD HH24:MI:SS'),100,100,'Y','Y','Y','bp.Value','N','InfoBPartner16.png')
+;
+
+-- Sep 2, 2026, 9:00:01 AM
+-- IDEMPIERE-7074 the default info window for C_BPartner is now the simplified one
+UPDATE AD_InfoWindow SET IsDefault='N',Updated=TO_TIMESTAMP('2026-09-02 09:00:01','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_InfoWindow_ID=200001
+;
+
+-- Sep 2, 2026, 9:00:02 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_InfoColumn_ID,IsQueryCriteria,IsIdentifier,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,QueryOperator,QueryFunction,SelectClause) VALUES (200025,'53d3c203-1f94-4f77-8986-70558cc2a2b7',10,200282,'Y','Y','D','Search key for the record in the format required - must be unique',TO_TIMESTAMP('2026-09-02 09:00:02','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:02','YYYY-MM-DD HH24:MI:SS'),0,0,100,'Search Key','Y','Value','Y','Y',620,10,'Like','Upper','bp.Value')
+;
+
+-- Sep 2, 2026, 9:00:03 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_InfoColumn_ID,IsQueryCriteria,IsIdentifier,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,QueryOperator,QueryFunction,SelectClause) VALUES (200025,'4164b6da-98a2-4611-b7bc-84fadc078661',10,200283,'Y','Y','D','Alphanumeric identifier of the entity',TO_TIMESTAMP('2026-09-02 09:00:03','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:03','YYYY-MM-DD HH24:MI:SS'),0,0,100,'Name','Y','Name','Y','Y',469,20,'Like','Upper','bp.Name')
+;
+
+-- Sep 2, 2026, 9:00:04 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_InfoColumn_ID,IsQueryCriteria,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,QueryOperator,SelectClause) VALUES (200025,'00030160-d0de-49d6-8ec3-6be8ca5cd4ff',12,200284,'N','D','Available Credit based on Credit Limit (not Total Open Balance) and Credit Used',TO_TIMESTAMP('2026-09-02 09:00:04','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:04','YYYY-MM-DD HH24:MI:SS'),0,0,100,'Credit Available','Y','SO_CreditAvailable','Y','Y',1851,30,'=','bp.SO_CreditLimit-bp.SO_CreditUsed AS SO_CreditAvailable')
+;
+
+-- Sep 2, 2026, 9:00:05 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_InfoColumn_ID,IsQueryCriteria,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,SelectClause) VALUES (200025,'9b82defb-78b7-48ff-968d-41bc8635657e',12,200285,'N','D','Current open balance',TO_TIMESTAMP('2026-09-02 09:00:05','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:05','YYYY-MM-DD HH24:MI:SS'),0,0,100,'Credit Used','Y','SO_CreditUsed','Y','Y',554,40,'bp.SO_CreditUsed')
+;
+
+-- Sep 2, 2026, 9:00:06 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_InfoColumn_ID,IsQueryCriteria,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,SelectClause) VALUES (200025,'e6d16a47-fdf5-4d8d-8e0d-4d7a70a69a3b',12,200286,'N','D','Total Open Balance Amount in primary Accounting Currency',TO_TIMESTAMP('2026-09-02 09:00:06','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:06','YYYY-MM-DD HH24:MI:SS'),0,0,100,'Open Balance','Y','TotalOpenBalance','Y','Y',2562,50,'bp.TotalOpenBalance')
+;
+
+-- Sep 2, 2026, 9:00:07 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_InfoColumn_ID,IsQueryCriteria,EntityType,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,ColumnName,IsDisplayed,IsActive,SeqNo,QueryOperator,SelectClause) VALUES (200025,'1cd1efda-65ec-4d06-85c3-8d361a583f1f',12,200287,'N','D',TO_TIMESTAMP('2026-09-02 09:00:07','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:07','YYYY-MM-DD HH24:MI:SS'),0,0,100,'Revenue','Y','Revenue','Y','Y',60,'=','bp.ActualLifetimeValue')
+;
+
+-- Sep 2, 2026, 9:00:08 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_Reference_Value_ID,AD_InfoColumn_ID,IsQueryCriteria,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,DisplayLogic,DefaultValue,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,SeqNoSelection,QueryOperator,SelectClause) VALUES (200025,'52111245-d661-4f50-871e-d593cf403a11',17,319,200288,'Y','D','Indicates if this Business Partner is a Customer',TO_TIMESTAMP('2026-09-02 09:00:08','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:08','YYYY-MM-DD HH24:MI:SS'),0,0,100,'Customer','Y','@IsSOTrx:Y@=Y | @+IgnoreIsSOTrxInBPInfo:N@=Y','@SQL=SELECT CASE WHEN ''@IsSOTrx:X@''=''X'' OR ''@+IgnoreIsSOTrxInBPInfo:N@''=''Y'' THEN '''' WHEN ''@IsSOTrx:X@''=''Y'' THEN ''Y'' ELSE ''N'' END AS DefaultValue FROM DUAL','IsCustomer','N','Y',364,160,10,'=','bp.IsCustomer')
+;
+
+-- Sep 2, 2026, 9:00:09 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_Reference_Value_ID,AD_InfoColumn_ID,IsQueryCriteria,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,DisplayLogic,DefaultValue,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,SeqNoSelection,QueryOperator,SelectClause) VALUES (200025,'554b569a-c7db-4fa1-9ff5-6863868ff117',17,319,200289,'Y','D','Indicates if this Business Partner is a Vendor',TO_TIMESTAMP('2026-09-02 09:00:09','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:09','YYYY-MM-DD HH24:MI:SS'),0,0,100,'Vendor','Y','@IsSOTrx:N@=N | @+IgnoreIsSOTrxInBPInfo:N@=Y','@SQL=SELECT CASE WHEN ''@IsSOTrx:X@''=''X'' OR ''@+IgnoreIsSOTrxInBPInfo:N@''=''Y'' THEN '''' WHEN ''@IsSOTrx:X@''=''N'' THEN ''Y'' ELSE ''N'' END AS DefaultValue FROM DUAL','IsVendor','N','Y',426,170,20,'=','bp.IsVendor')
+;
+
+-- Sep 2, 2026, 9:00:10 AM
+-- IDEMPIERE-7074 search criteria for contact and location (not displayed, they are joined only for filtering)
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_InfoColumn_ID,IsQueryCriteria,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,QueryOperator,QueryFunction,SelectClause) VALUES (200025,'ed45d818-eadd-4744-8ebf-16971ca7a5e9',10,200290,'N','D','Identifies a City',TO_TIMESTAMP('2026-09-02 09:00:10','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:10','YYYY-MM-DD HH24:MI:SS'),0,0,100,'City','Y','City','N','Y',225,90,'Like','Upper','a.City')
+;
+
+-- Sep 2, 2026, 9:00:11 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_InfoColumn_ID,IsQueryCriteria,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,QueryOperator,QueryFunction,SelectClause) VALUES (200025,'2176c78b-cb51-4387-b2af-2f0297ba539a',10,200291,'Y','D','Postal code',TO_TIMESTAMP('2026-09-02 09:00:11','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:11','YYYY-MM-DD HH24:MI:SS'),0,0,100,'ZIP','Y','Postal','N','Y',512,90,'Like','Upper','a.Postal')
+;
+
+-- Sep 2, 2026, 9:00:12 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_InfoColumn_ID,IsQueryCriteria,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,QueryOperator,QueryFunction,SelectClause) VALUES (200025,'f0dec6e7-bfb4-4fe2-8529-628a770cfb84',10,200292,'Y','D','Business Partner Contact Name',TO_TIMESTAMP('2026-09-02 09:00:12','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:12','YYYY-MM-DD HH24:MI:SS'),0,0,100,'Contact Name','Y','ContactName','N','Y',1839,30,'Like','Upper','c.Name')
+;
+
+-- Sep 2, 2026, 9:00:13 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_InfoColumn_ID,IsQueryCriteria,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,QueryOperator,QueryFunction,SelectClause) VALUES (200025,'670d38ba-67dc-477d-ad30-4ad4d7df3733',10,200293,'Y','D','Electronic Mail Address',TO_TIMESTAMP('2026-09-02 09:00:13','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:13','YYYY-MM-DD HH24:MI:SS'),0,0,100,'EMail Address','Y','EMail','N','Y',881,50,'Like','Upper','c.EMail')
+;
+
+-- Sep 2, 2026, 9:00:14 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_InfoColumn_ID,IsQueryCriteria,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,QueryOperator,SelectClause) VALUES (200025,'14ce6808-520f-400c-abd6-2453d80a08a6',10,200294,'Y','D','Identifies a telephone number',TO_TIMESTAMP('2026-09-02 09:00:14','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:14','YYYY-MM-DD HH24:MI:SS'),0,0,100,'Phone','Y','Phone','N','Y',505,80,'Like','c.Phone')
+;
+
+-- Sep 2, 2026, 9:00:15 AM
+-- IDEMPIERE-7074
+UPDATE AD_InfoWindow SET IsValid='Y',Updated=TO_TIMESTAMP('2026-09-02 09:00:15','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_InfoWindow_ID=200025
+;
+
+-- Sep 2, 2026, 9:00:16 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoWindow_Access (AD_InfoWindow_Access_UU,Updated,UpdatedBy,AD_Role_ID,AD_InfoWindow_ID,AD_Client_ID,AD_Org_ID,Created,CreatedBy,IsActive) VALUES ('d887f25d-3eaf-41dc-9031-d36e016de388',TO_TIMESTAMP('2026-09-02 09:00:16','YYYY-MM-DD HH24:MI:SS'),100,50004,200025,11,0,TO_TIMESTAMP('2026-09-02 09:00:16','YYYY-MM-DD HH24:MI:SS'),100,'Y')
+;
+
+-- Sep 2, 2026, 9:00:17 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoWindow_Access (AD_InfoWindow_Access_UU,Updated,UpdatedBy,AD_Role_ID,AD_InfoWindow_ID,AD_Client_ID,AD_Org_ID,Created,CreatedBy,IsActive) VALUES ('939add50-c52a-4682-829d-de5347d19ac2',TO_TIMESTAMP('2026-09-02 09:00:17','YYYY-MM-DD HH24:MI:SS'),100,0,200025,0,0,TO_TIMESTAMP('2026-09-02 09:00:17','YYYY-MM-DD HH24:MI:SS'),100,'Y')
+;
+
+-- Sep 2, 2026, 9:00:18 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoWindow_Access (AD_InfoWindow_Access_UU,Updated,UpdatedBy,AD_Role_ID,AD_InfoWindow_ID,AD_Client_ID,AD_Org_ID,Created,CreatedBy,IsActive) VALUES ('66721aa2-4ef1-4a9c-9296-2f4215ed0a6a',TO_TIMESTAMP('2026-09-02 09:00:18','YYYY-MM-DD HH24:MI:SS'),100,102,200025,11,0,TO_TIMESTAMP('2026-09-02 09:00:18','YYYY-MM-DD HH24:MI:SS'),100,'Y')
+;
+
+-- Sep 2, 2026, 9:00:19 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoWindow_Access (AD_InfoWindow_Access_UU,Updated,UpdatedBy,AD_Role_ID,AD_InfoWindow_ID,AD_Client_ID,AD_Org_ID,Created,CreatedBy,IsActive) VALUES ('0aa8d240-610f-4438-b9b2-29d4c76ee966',TO_TIMESTAMP('2026-09-02 09:00:19','YYYY-MM-DD HH24:MI:SS'),100,103,200025,11,0,TO_TIMESTAMP('2026-09-02 09:00:19','YYYY-MM-DD HH24:MI:SS'),100,'Y')
+;
+
+-- Sep 2, 2026, 9:00:20 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoWindow_Access (AD_InfoWindow_Access_UU,Updated,UpdatedBy,AD_Role_ID,AD_InfoWindow_ID,AD_Client_ID,AD_Org_ID,Created,CreatedBy,IsActive) VALUES ('8d628abc-f5d0-4906-aacd-a5e5e704cdf3',TO_TIMESTAMP('2026-09-02 09:00:20','YYYY-MM-DD HH24:MI:SS'),100,200001,200025,11,0,TO_TIMESTAMP('2026-09-02 09:00:20','YYYY-MM-DD HH24:MI:SS'),100,'Y')
+;

--- a/migration/iD14/oracle/202609020910_IDEMPIERE-7074.sql
+++ b/migration/iD14/oracle/202609020910_IDEMPIERE-7074.sql
@@ -1,0 +1,75 @@
+-- IDEMPIERE-7074 Assign Business Partner fields to the complex (200001) or simplified (200025) info window
+SELECT register_migration_script('202609020910_IDEMPIERE-7074.sql') FROM dual;
+
+-- Sep 2, 2026, 9:10:00 AM
+-- IDEMPIERE-7074
+-- Generic: all existing (old) Business Partner reference columns point to the complex window.
+-- Covers TableDir references by column name (C_BPartner_ID direct and Bill_BPartner_ID
+-- resolved via the hardcoded zoom mapping in MQuery.getZoomColumnName) and Table references
+-- via AD_Ref_Table pointing to the C_BPartner table (DropShip_BPartner_ID, Pay_BPartner_ID,
+-- ReturnBPartner_ID, C_BPartnerSR_ID, C_Employee_ID and user-created custom columns).
+-- The "AD_InfoWindow_ID IS NULL" condition ensures columns created after this script
+-- (new fields) are not touched - they resolve to the table default (simplified window).
+UPDATE AD_Column SET AD_InfoWindow_ID = 200001
+WHERE AD_InfoWindow_ID IS NULL
+  AND ( ColumnName IN ('C_BPartner_ID','Bill_BPartner_ID')
+     OR EXISTS (SELECT 1 FROM AD_Ref_Table rt
+                JOIN AD_Table t ON t.AD_Table_ID = rt.AD_Table_ID
+                WHERE rt.AD_Reference_ID = AD_Column.AD_Reference_Value_ID
+                  AND t.TableName = 'C_BPartner') )
+;
+
+-- Sep 2, 2026, 9:10:01 AM
+-- IDEMPIERE-7074
+-- Explicit: CORE Business Partner fields without User/Location companion fields
+-- are reset to NULL, so they follow the table default info window
+-- (the simplified window - one row per partner, no contact/location columns).
+-- NULL instead of a pinned window id keeps them on the current table default
+-- if the default is changed later.
+UPDATE AD_Column SET AD_InfoWindow_ID = NULL
+WHERE AD_Client_ID = 0
+  AND AD_InfoWindow_ID = 200001
+  AND EXISTS (SELECT 1 FROM AD_Table t
+              WHERE t.AD_Table_ID = AD_Column.AD_Table_ID
+                AND t.TableName || '.' || AD_Column.ColumnName IN (
+                  'C_AllocationLine.C_BPartner_ID',
+                  'C_BankStatementLine.C_BPartner_ID',
+                  'C_BPartner.C_BPartnerSR_ID',
+                  'C_BPartner_Product.C_BPartner_ID',
+                  'C_BP_Customer_Acct.C_BPartner_ID',
+                  'C_BP_Vendor_Acct.C_BPartner_ID',
+                  'C_BP_Employee_Acct.C_BPartner_ID',
+                  'C_BP_Withholding.C_BPartner_ID',
+                  'C_BP_EDI.C_BPartner_ID',
+                  'C_CashPlan.C_BPartner_ID',
+                  'C_CashPlanLine.C_BPartner_ID',
+                  'C_Charge.C_BPartner_ID',
+                  'C_Commission.C_BPartner_ID',
+                  'C_CommissionLine.C_BPartner_ID',
+                  'C_Payment.C_BPartner_ID',
+                  'C_PaymentTransaction.C_BPartner_ID',
+                  'C_PaySelectionCheck.C_BPartner_ID',
+                  'C_Subscription.C_BPartner_ID',
+                  'C_TaxDeclarationAcct.C_BPartner_ID',
+                  'C_TaxDeclarationLine.C_BPartner_ID',
+                  'C_ValidCombination.C_BPartner_ID',
+                  'GL_JournalLine.C_BPartner_ID',
+                  'GL_JournalLine.C_Employee_ID',
+                  'M_BP_Price.C_BPartner_ID',
+                  'M_DiscountSchemaLine.C_BPartner_ID',
+                  'M_Production.C_BPartner_ID',
+                  'M_Product_PO.C_BPartner_ID',
+                  'M_ProductPriceVendorBreak.C_BPartner_ID',
+                  'M_RequisitionLine.C_BPartner_ID',
+                  'M_RMA.C_BPartner_ID',
+                  'M_Shipper.C_BPartner_ID',
+                  'PA_GoalRestriction.C_BPartner_ID',
+                  'PA_ReportSource.C_BPartner_ID',
+                  'PA_SLA_Goal.C_BPartner_ID',
+                  'S_TimeExpense.C_BPartner_ID',
+                  'S_TimeExpenseLine.C_BPartner_ID',
+                  'AD_User.C_BPartner_ID',
+                  'A_Asset_Info_Fin.C_BPartner_ID',
+                  'C_AcctSchema_Element.C_BPartner_ID'
+                ) )
+;

--- a/migration/iD14/oracle/202609020920_IDEMPIERE-7074.sql
+++ b/migration/iD14/oracle/202609020920_IDEMPIERE-7074.sql
@@ -1,0 +1,9 @@
+-- IDEMPIERE-7074 Info Window field on Column tab also for Search reference
+SELECT register_migration_script('202609020920_IDEMPIERE-7074.sql') FROM dual;
+
+-- Sep 2, 2026, 9:20:00 AM
+-- IDEMPIERE-7074 the AD_Column.AD_InfoWindow_ID is now also evaluated for search
+-- fields (Search, AD_Reference_ID 30), not only for buttons (28) -
+-- make the Info Window field on the Column tab visible for those too
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=28 | @AD_Reference_ID@=30',Updated=TO_TIMESTAMP('2026-09-02 09:20:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207143
+;

--- a/migration/iD14/postgresql/202609020900_IDEMPIERE-7074.sql
+++ b/migration/iD14/postgresql/202609020900_IDEMPIERE-7074.sql
@@ -1,0 +1,109 @@
+-- IDEMPIERE-7074 Business Partner Info window without contact/location (one row per partner)
+SELECT register_migration_script('202609020900_IDEMPIERE-7074.sql') FROM dual;
+
+-- Sep 2, 2026, 9:00:00 AM
+INSERT INTO AD_InfoWindow (Processing,FromClause,AD_InfoWindow_UU,AD_InfoWindow_ID,AD_Table_ID,EntityType,Name,Description,AD_Client_ID,AD_Org_ID,Created,Updated,UpdatedBy,CreatedBy,IsActive,IsDefault,IsDistinct,OrderByClause,IsValid,ImageURL) VALUES ('N','C_BPartner bp
+LEFT OUTER JOIN C_BPartner_Location l ON (bp.C_BPartner_ID=l.C_BPartner_ID AND l.IsActive=''Y'')
+LEFT OUTER JOIN AD_User c ON (bp.C_BPartner_ID=c.C_BPartner_ID AND (c.C_BPartner_Location_ID IS NULL OR c.C_BPartner_Location_ID=l.C_BPartner_Location_ID) AND c.IsActive=''Y'')
+LEFT OUTER JOIN C_Location a ON (l.C_Location_ID=a.C_Location_ID)','6a7f7db9-ec0b-4620-95dd-937d48c55c4f',200025,291,'D','Business Partner Info (Simple)','Business Partner lookup showing one row per partner, without contact and location columns. Contacts and locations are joined for search criteria only.',0,0,TO_TIMESTAMP('2026-09-02 09:00:00','YYYY-MM-DD HH24:MI:SS'),TO_TIMESTAMP('2026-09-02 09:00:00','YYYY-MM-DD HH24:MI:SS'),100,100,'Y','Y','Y','bp.Value','N','InfoBPartner16.png')
+;
+
+-- Sep 2, 2026, 9:00:01 AM
+-- IDEMPIERE-7074 the default info window for C_BPartner is now the simplified one
+UPDATE AD_InfoWindow SET IsDefault='N',Updated=TO_TIMESTAMP('2026-09-02 09:00:01','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_InfoWindow_ID=200001
+;
+
+-- Sep 2, 2026, 9:00:02 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_InfoColumn_ID,IsQueryCriteria,IsIdentifier,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,QueryOperator,QueryFunction,SelectClause) VALUES (200025,'53d3c203-1f94-4f77-8986-70558cc2a2b7',10,200282,'Y','Y','D','Search key for the record in the format required - must be unique',TO_TIMESTAMP('2026-09-02 09:00:02','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:02','YYYY-MM-DD HH24:MI:SS'),0,0,100,'Search Key','Y','Value','Y','Y',620,10,'Like','Upper','bp.Value')
+;
+
+-- Sep 2, 2026, 9:00:03 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_InfoColumn_ID,IsQueryCriteria,IsIdentifier,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,QueryOperator,QueryFunction,SelectClause) VALUES (200025,'4164b6da-98a2-4611-b7bc-84fadc078661',10,200283,'Y','Y','D','Alphanumeric identifier of the entity',TO_TIMESTAMP('2026-09-02 09:00:03','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:03','YYYY-MM-DD HH24:MI:SS'),0,0,100,'Name','Y','Name','Y','Y',469,20,'Like','Upper','bp.Name')
+;
+
+-- Sep 2, 2026, 9:00:04 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_InfoColumn_ID,IsQueryCriteria,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,QueryOperator,SelectClause) VALUES (200025,'00030160-d0de-49d6-8ec3-6be8ca5cd4ff',12,200284,'N','D','Available Credit based on Credit Limit (not Total Open Balance) and Credit Used',TO_TIMESTAMP('2026-09-02 09:00:04','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:04','YYYY-MM-DD HH24:MI:SS'),0,0,100,'Credit Available','Y','SO_CreditAvailable','Y','Y',1851,30,'=','bp.SO_CreditLimit-bp.SO_CreditUsed AS SO_CreditAvailable')
+;
+
+-- Sep 2, 2026, 9:00:05 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_InfoColumn_ID,IsQueryCriteria,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,SelectClause) VALUES (200025,'9b82defb-78b7-48ff-968d-41bc8635657e',12,200285,'N','D','Current open balance',TO_TIMESTAMP('2026-09-02 09:00:05','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:05','YYYY-MM-DD HH24:MI:SS'),0,0,100,'Credit Used','Y','SO_CreditUsed','Y','Y',554,40,'bp.SO_CreditUsed')
+;
+
+-- Sep 2, 2026, 9:00:06 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_InfoColumn_ID,IsQueryCriteria,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,SelectClause) VALUES (200025,'e6d16a47-fdf5-4d8d-8e0d-4d7a70a69a3b',12,200286,'N','D','Total Open Balance Amount in primary Accounting Currency',TO_TIMESTAMP('2026-09-02 09:00:06','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:06','YYYY-MM-DD HH24:MI:SS'),0,0,100,'Open Balance','Y','TotalOpenBalance','Y','Y',2562,50,'bp.TotalOpenBalance')
+;
+
+-- Sep 2, 2026, 9:00:07 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_InfoColumn_ID,IsQueryCriteria,EntityType,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,ColumnName,IsDisplayed,IsActive,SeqNo,QueryOperator,SelectClause) VALUES (200025,'1cd1efda-65ec-4d06-85c3-8d361a583f1f',12,200287,'N','D',TO_TIMESTAMP('2026-09-02 09:00:07','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:07','YYYY-MM-DD HH24:MI:SS'),0,0,100,'Revenue','Y','Revenue','Y','Y',60,'=','bp.ActualLifetimeValue')
+;
+
+-- Sep 2, 2026, 9:00:08 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_Reference_Value_ID,AD_InfoColumn_ID,IsQueryCriteria,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,DisplayLogic,DefaultValue,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,SeqNoSelection,QueryOperator,SelectClause) VALUES (200025,'52111245-d661-4f50-871e-d593cf403a11',17,319,200288,'Y','D','Indicates if this Business Partner is a Customer',TO_TIMESTAMP('2026-09-02 09:00:08','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:08','YYYY-MM-DD HH24:MI:SS'),0,0,100,'Customer','Y','@IsSOTrx:Y@=Y | @+IgnoreIsSOTrxInBPInfo:N@=Y','@SQL=SELECT CASE WHEN ''@IsSOTrx:X@''=''X'' OR ''@+IgnoreIsSOTrxInBPInfo:N@''=''Y'' THEN '''' WHEN ''@IsSOTrx:X@''=''Y'' THEN ''Y'' ELSE ''N'' END AS DefaultValue FROM DUAL','IsCustomer','N','Y',364,160,10,'=','bp.IsCustomer')
+;
+
+-- Sep 2, 2026, 9:00:09 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_Reference_Value_ID,AD_InfoColumn_ID,IsQueryCriteria,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,DisplayLogic,DefaultValue,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,SeqNoSelection,QueryOperator,SelectClause) VALUES (200025,'554b569a-c7db-4fa1-9ff5-6863868ff117',17,319,200289,'Y','D','Indicates if this Business Partner is a Vendor',TO_TIMESTAMP('2026-09-02 09:00:09','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:09','YYYY-MM-DD HH24:MI:SS'),0,0,100,'Vendor','Y','@IsSOTrx:N@=N | @+IgnoreIsSOTrxInBPInfo:N@=Y','@SQL=SELECT CASE WHEN ''@IsSOTrx:X@''=''X'' OR ''@+IgnoreIsSOTrxInBPInfo:N@''=''Y'' THEN '''' WHEN ''@IsSOTrx:X@''=''N'' THEN ''Y'' ELSE ''N'' END AS DefaultValue FROM DUAL','IsVendor','N','Y',426,170,20,'=','bp.IsVendor')
+;
+
+-- Sep 2, 2026, 9:00:10 AM
+-- IDEMPIERE-7074 search criteria for contact and location (not displayed, they are joined only for filtering)
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_InfoColumn_ID,IsQueryCriteria,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,QueryOperator,QueryFunction,SelectClause) VALUES (200025,'ed45d818-eadd-4744-8ebf-16971ca7a5e9',10,200290,'N','D','Identifies a City',TO_TIMESTAMP('2026-09-02 09:00:10','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:10','YYYY-MM-DD HH24:MI:SS'),0,0,100,'City','Y','City','N','Y',225,90,'Like','Upper','a.City')
+;
+
+-- Sep 2, 2026, 9:00:11 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_InfoColumn_ID,IsQueryCriteria,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,QueryOperator,QueryFunction,SelectClause) VALUES (200025,'2176c78b-cb51-4387-b2af-2f0297ba539a',10,200291,'Y','D','Postal code',TO_TIMESTAMP('2026-09-02 09:00:11','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:11','YYYY-MM-DD HH24:MI:SS'),0,0,100,'ZIP','Y','Postal','N','Y',512,90,'Like','Upper','a.Postal')
+;
+
+-- Sep 2, 2026, 9:00:12 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_InfoColumn_ID,IsQueryCriteria,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,QueryOperator,QueryFunction,SelectClause) VALUES (200025,'f0dec6e7-bfb4-4fe2-8529-628a770cfb84',10,200292,'Y','D','Business Partner Contact Name',TO_TIMESTAMP('2026-09-02 09:00:12','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:12','YYYY-MM-DD HH24:MI:SS'),0,0,100,'Contact Name','Y','ContactName','N','Y',1839,30,'Like','Upper','c.Name')
+;
+
+-- Sep 2, 2026, 9:00:13 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_InfoColumn_ID,IsQueryCriteria,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,QueryOperator,QueryFunction,SelectClause) VALUES (200025,'670d38ba-67dc-477d-ad30-4ad4d7df3733',10,200293,'Y','D','Electronic Mail Address',TO_TIMESTAMP('2026-09-02 09:00:13','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:13','YYYY-MM-DD HH24:MI:SS'),0,0,100,'EMail Address','Y','EMail','N','Y',881,50,'Like','Upper','c.EMail')
+;
+
+-- Sep 2, 2026, 9:00:14 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoColumn (AD_InfoWindow_ID,AD_InfoColumn_UU,AD_Reference_ID,AD_InfoColumn_ID,IsQueryCriteria,EntityType,Description,Created,CreatedBy,Updated,AD_Client_ID,AD_Org_ID,UpdatedBy,Name,IsCentrallyMaintained,ColumnName,IsDisplayed,IsActive,AD_Element_ID,SeqNo,QueryOperator,SelectClause) VALUES (200025,'14ce6808-520f-400c-abd6-2453d80a08a6',10,200294,'Y','D','Identifies a telephone number',TO_TIMESTAMP('2026-09-02 09:00:14','YYYY-MM-DD HH24:MI:SS'),100,TO_TIMESTAMP('2026-09-02 09:00:14','YYYY-MM-DD HH24:MI:SS'),0,0,100,'Phone','Y','Phone','N','Y',505,80,'Like','c.Phone')
+;
+
+-- Sep 2, 2026, 9:00:15 AM
+-- IDEMPIERE-7074
+UPDATE AD_InfoWindow SET IsValid='Y',Updated=TO_TIMESTAMP('2026-09-02 09:00:15','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_InfoWindow_ID=200025
+;
+
+-- Sep 2, 2026, 9:00:16 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoWindow_Access (AD_InfoWindow_Access_UU,Updated,UpdatedBy,AD_Role_ID,AD_InfoWindow_ID,AD_Client_ID,AD_Org_ID,Created,CreatedBy,IsActive) VALUES ('d887f25d-3eaf-41dc-9031-d36e016de388',TO_TIMESTAMP('2026-09-02 09:00:16','YYYY-MM-DD HH24:MI:SS'),100,50004,200025,11,0,TO_TIMESTAMP('2026-09-02 09:00:16','YYYY-MM-DD HH24:MI:SS'),100,'Y')
+;
+
+-- Sep 2, 2026, 9:00:17 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoWindow_Access (AD_InfoWindow_Access_UU,Updated,UpdatedBy,AD_Role_ID,AD_InfoWindow_ID,AD_Client_ID,AD_Org_ID,Created,CreatedBy,IsActive) VALUES ('939add50-c52a-4682-829d-de5347d19ac2',TO_TIMESTAMP('2026-09-02 09:00:17','YYYY-MM-DD HH24:MI:SS'),100,0,200025,0,0,TO_TIMESTAMP('2026-09-02 09:00:17','YYYY-MM-DD HH24:MI:SS'),100,'Y')
+;
+
+-- Sep 2, 2026, 9:00:18 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoWindow_Access (AD_InfoWindow_Access_UU,Updated,UpdatedBy,AD_Role_ID,AD_InfoWindow_ID,AD_Client_ID,AD_Org_ID,Created,CreatedBy,IsActive) VALUES ('66721aa2-4ef1-4a9c-9296-2f4215ed0a6a',TO_TIMESTAMP('2026-09-02 09:00:18','YYYY-MM-DD HH24:MI:SS'),100,102,200025,11,0,TO_TIMESTAMP('2026-09-02 09:00:18','YYYY-MM-DD HH24:MI:SS'),100,'Y')
+;
+
+-- Sep 2, 2026, 9:00:19 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoWindow_Access (AD_InfoWindow_Access_UU,Updated,UpdatedBy,AD_Role_ID,AD_InfoWindow_ID,AD_Client_ID,AD_Org_ID,Created,CreatedBy,IsActive) VALUES ('0aa8d240-610f-4438-b9b2-29d4c76ee966',TO_TIMESTAMP('2026-09-02 09:00:19','YYYY-MM-DD HH24:MI:SS'),100,103,200025,11,0,TO_TIMESTAMP('2026-09-02 09:00:19','YYYY-MM-DD HH24:MI:SS'),100,'Y')
+;
+
+-- Sep 2, 2026, 9:00:20 AM
+-- IDEMPIERE-7074
+INSERT INTO AD_InfoWindow_Access (AD_InfoWindow_Access_UU,Updated,UpdatedBy,AD_Role_ID,AD_InfoWindow_ID,AD_Client_ID,AD_Org_ID,Created,CreatedBy,IsActive) VALUES ('8d628abc-f5d0-4906-aacd-a5e5e704cdf3',TO_TIMESTAMP('2026-09-02 09:00:20','YYYY-MM-DD HH24:MI:SS'),100,200001,200025,11,0,TO_TIMESTAMP('2026-09-02 09:00:20','YYYY-MM-DD HH24:MI:SS'),100,'Y')
+;

--- a/migration/iD14/postgresql/202609020910_IDEMPIERE-7074.sql
+++ b/migration/iD14/postgresql/202609020910_IDEMPIERE-7074.sql
@@ -1,0 +1,75 @@
+-- IDEMPIERE-7074 Assign Business Partner fields to the complex (200001) or simplified (200025) info window
+SELECT register_migration_script('202609020910_IDEMPIERE-7074.sql') FROM dual;
+
+-- Sep 2, 2026, 9:10:00 AM
+-- IDEMPIERE-7074
+-- Generic: all existing (old) Business Partner reference columns point to the complex window.
+-- Covers TableDir references by column name (C_BPartner_ID direct and Bill_BPartner_ID
+-- resolved via the hardcoded zoom mapping in MQuery.getZoomColumnName) and Table references
+-- via AD_Ref_Table pointing to the C_BPartner table (DropShip_BPartner_ID, Pay_BPartner_ID,
+-- ReturnBPartner_ID, C_BPartnerSR_ID, C_Employee_ID and user-created custom columns).
+-- The "AD_InfoWindow_ID IS NULL" condition ensures columns created after this script
+-- (new fields) are not touched - they resolve to the table default (simplified window).
+UPDATE AD_Column SET AD_InfoWindow_ID = 200001
+WHERE AD_InfoWindow_ID IS NULL
+  AND ( ColumnName IN ('C_BPartner_ID','Bill_BPartner_ID')
+     OR EXISTS (SELECT 1 FROM AD_Ref_Table rt
+                JOIN AD_Table t ON t.AD_Table_ID = rt.AD_Table_ID
+                WHERE rt.AD_Reference_ID = AD_Column.AD_Reference_Value_ID
+                  AND t.TableName = 'C_BPartner') )
+;
+
+-- Sep 2, 2026, 9:10:01 AM
+-- IDEMPIERE-7074
+-- Explicit: CORE Business Partner fields without User/Location companion fields
+-- are reset to NULL, so they follow the table default info window
+-- (the simplified window - one row per partner, no contact/location columns).
+-- NULL instead of a pinned window id keeps them on the current table default
+-- if the default is changed later.
+UPDATE AD_Column SET AD_InfoWindow_ID = NULL
+WHERE AD_Client_ID = 0
+  AND AD_InfoWindow_ID = 200001
+  AND EXISTS (SELECT 1 FROM AD_Table t
+              WHERE t.AD_Table_ID = AD_Column.AD_Table_ID
+                AND t.TableName || '.' || AD_Column.ColumnName IN (
+                  'C_AllocationLine.C_BPartner_ID',
+                  'C_BankStatementLine.C_BPartner_ID',
+                  'C_BPartner.C_BPartnerSR_ID',
+                  'C_BPartner_Product.C_BPartner_ID',
+                  'C_BP_Customer_Acct.C_BPartner_ID',
+                  'C_BP_Vendor_Acct.C_BPartner_ID',
+                  'C_BP_Employee_Acct.C_BPartner_ID',
+                  'C_BP_Withholding.C_BPartner_ID',
+                  'C_BP_EDI.C_BPartner_ID',
+                  'C_CashPlan.C_BPartner_ID',
+                  'C_CashPlanLine.C_BPartner_ID',
+                  'C_Charge.C_BPartner_ID',
+                  'C_Commission.C_BPartner_ID',
+                  'C_CommissionLine.C_BPartner_ID',
+                  'C_Payment.C_BPartner_ID',
+                  'C_PaymentTransaction.C_BPartner_ID',
+                  'C_PaySelectionCheck.C_BPartner_ID',
+                  'C_Subscription.C_BPartner_ID',
+                  'C_TaxDeclarationAcct.C_BPartner_ID',
+                  'C_TaxDeclarationLine.C_BPartner_ID',
+                  'C_ValidCombination.C_BPartner_ID',
+                  'GL_JournalLine.C_BPartner_ID',
+                  'GL_JournalLine.C_Employee_ID',
+                  'M_BP_Price.C_BPartner_ID',
+                  'M_DiscountSchemaLine.C_BPartner_ID',
+                  'M_Production.C_BPartner_ID',
+                  'M_Product_PO.C_BPartner_ID',
+                  'M_ProductPriceVendorBreak.C_BPartner_ID',
+                  'M_RequisitionLine.C_BPartner_ID',
+                  'M_RMA.C_BPartner_ID',
+                  'M_Shipper.C_BPartner_ID',
+                  'PA_GoalRestriction.C_BPartner_ID',
+                  'PA_ReportSource.C_BPartner_ID',
+                  'PA_SLA_Goal.C_BPartner_ID',
+                  'S_TimeExpense.C_BPartner_ID',
+                  'S_TimeExpenseLine.C_BPartner_ID',
+                  'AD_User.C_BPartner_ID',
+                  'A_Asset_Info_Fin.C_BPartner_ID',
+                  'C_AcctSchema_Element.C_BPartner_ID'
+                ) )
+;

--- a/migration/iD14/postgresql/202609020920_IDEMPIERE-7074.sql
+++ b/migration/iD14/postgresql/202609020920_IDEMPIERE-7074.sql
@@ -1,0 +1,9 @@
+-- IDEMPIERE-7074 Info Window field on Column tab also for Search reference
+SELECT register_migration_script('202609020920_IDEMPIERE-7074.sql') FROM dual;
+
+-- Sep 2, 2026, 9:20:00 AM
+-- IDEMPIERE-7074 the AD_Column.AD_InfoWindow_ID is now also evaluated for search
+-- fields (Search, AD_Reference_ID 30), not only for buttons (28) -
+-- make the Info Window field on the Column tab visible for those too
+UPDATE AD_Field SET DisplayLogic='@AD_Reference_ID@=28 | @AD_Reference_ID@=30',Updated=TO_TIMESTAMP('2026-09-02 09:20:00','YYYY-MM-DD HH24:MI:SS'),UpdatedBy=100 WHERE AD_Field_ID=207143
+;

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/InfoManager.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/factory/InfoManager.java
@@ -79,20 +79,29 @@ public class InfoManager
 			String keyColumn, String queryValue, boolean multiSelection,
 			SQLFragment sqlFilter)
 	{
-		Function<IInfoFactory, InfoPanel> funcGetInfoFromService = null;
-		
-		if (lookup instanceof MLookup){
-			final int AD_InfoWindow_ID  = ((MLookup)lookup).getAD_InfoWindow_ID();
-			funcGetInfoFromService = (service) -> {
-				return service.create(lookup, field, tableName, keyColumn, queryValue, multiSelection, AD_InfoWindow_ID, sqlFilter);
-			};
-		}else {
-			funcGetInfoFromService = (service) -> {
-				return service.create(lookup, field, tableName, keyColumn, queryValue, multiSelection, 0, sqlFilter);
-			};
-		}
-		
+		final int adInfoWindowId = getADInfoWindowId(lookup, field);
+		Function<IInfoFactory, InfoPanel> funcGetInfoFromService = (service) -> {
+			return service.create(lookup, field, tableName, keyColumn, queryValue, multiSelection, adInfoWindowId, sqlFilter);
+		};
+
 		return create(funcGetInfoFromService);
+	}
+
+	/**
+	 * Resolve the info window id for a lookup: explicit id from the lookup
+	 * (AD_Ref_Table.AD_InfoWindow_ID) has priority, then the per-field
+	 * override from the column definition (AD_Column.AD_InfoWindow_ID).
+	 * @param lookup
+	 * @param field
+	 * @return resolved AD_InfoWindow_ID (0 = resolve by table default)
+	 */
+	private static int getADInfoWindowId(Lookup lookup, GridField field) {
+		int adInfoWindowId = (lookup instanceof MLookup)
+				? ((MLookup)lookup).getAD_InfoWindow_ID()
+				: 0;
+		if (adInfoWindowId <= 0 && field != null && field.getAD_InfoWindow_ID() > 0)
+			adInfoWindowId = field.getAD_InfoWindow_ID();
+		return adInfoWindowId;
 	}
 	
 	/**
@@ -110,19 +119,11 @@ public class InfoManager
 			String keyColumn, String queryValue, boolean multiSelection,
 			String whereClause)
 	{
-		Function<IInfoFactory, InfoPanel> funcGetInfoFromService = null;
-		
-		if (lookup instanceof MLookup){
-			final int AD_InfoWindow_ID  = ((MLookup)lookup).getAD_InfoWindow_ID();
-			funcGetInfoFromService = (service) -> {
-				return service.create(lookup, field, tableName, keyColumn, queryValue, multiSelection, whereClause, AD_InfoWindow_ID);
-			};
-		}else {
-			funcGetInfoFromService = (service) -> {
-				return service.create(lookup, field, tableName, keyColumn, queryValue, multiSelection, whereClause, 0);
-			};
-		}
-		
+		final int adInfoWindowId = getADInfoWindowId(lookup, field);
+		Function<IInfoFactory, InfoPanel> funcGetInfoFromService = (service) -> {
+			return service.create(lookup, field, tableName, keyColumn, queryValue, multiSelection, whereClause, adInfoWindowId);
+		};
+
 		return create(funcGetInfoFromService);
 	}
 	

--- a/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/FindWindow.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/adempiere/webui/window/FindWindow.java
@@ -1082,6 +1082,11 @@ public class FindWindow extends Window implements EventListener<Event>, ValueCha
 		        			mLookup.getLookupInfo().ValidationCode = findField.getVO().ValidationCodeLookup;
 		        			mLookup.getLookupInfo().IsValidated = false;
 		        		}
+		        		// IDEMPIERE-7074 record search criteria always resolve to the table
+		        		// default info window (not to a per-column or per-reference pinned one)
+		        		// - for filtering records the default window (one row per record) is used
+		        		mLookup.getLookupInfo().InfoWindowId = 0;
+		        		findField.getVO().AD_InfoWindow_ID = 0;
 		        	}
 		        }
 		        findField.setGridTab(null);


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-7074

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Improvement (improves an existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed.
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.

### Summary

When selecting a business partner (e.g. to find invoices) the standard BP info window (AD_InfoWindow 200001) joins contacts and locations, producing multiple rows per partner - the user must pick a contact row although afterwards only the C_BPartner_ID is evaluated.

This PR adds:
- A new default BP info window (AD_InfoWindow 200025, all IDs allocated via the centralized official ID service): IsDistinct='Y' with LEFT JOINs to C_BPartner_Location/AD_User/C_Location **for search criteria only** - the contact/location columns are not displayed, so SELECT DISTINCT shows exactly one row per partner. Search criteria mirror the complex window (Value, Name, Contact, EMail, Phone, ZIP, Customer, Vendor - same fields, same order and same attributes incl. SeqNoSelection and the IsSOTrx default value logic). No menu entry / dashboard position (AD_InfoWindow.SeqNo unset).
- Per-field info window selection for search fields: InfoManager evaluates the existing AD_Column.AD_InfoWindow_ID column (previously only used for buttons) after the AD_Ref_Table id and before the table default. The Info Window field on the Column tab (AD_Field 207143) got a new DisplayLogic (@AD_Reference_ID@=28 | @AD_Reference_ID@=30) so it can also be configured per field for Search references in the UI.
- Migration scripts: the complex window (200001) is pinned to all old BP reference columns; CORE BP fields without User/Location companion fields are reset to NULL so they follow the table default (200025) - newly created fields fall back to the simplified default automatically.

Behavior: with one row per BP the existing auto-select in WSearchEditor applies a unique BP name without opening the window; ambiguous input opens the simplified window (still searchable by contact/location via criteria). Fields that need contact/location (orders, invoices, shipments...) keep the complex window with the previous behavior.

### Tests

- Full maven test suite (org.idempiere.test, 1421 tests) run twice on a freshly imported seed:
  - Baseline **without** the migration scripts: 1 failure (BackDateAveragePOCostingTest.testReverseCorrectMRWithMultiASILines2)
  - **With** the migration scripts: 1 failure (AuditTraceContextTest.testBackgroundJob)
  - Both failures are pre-existing flaky tests in unrelated areas (costing / audit trace propagation); everything else green in both runs.
- Migration applied and verified on a local PostgreSQL development database: script registration, one row per partner (DISTINCT), search criteria parity with window 200001, column assignments, role access, ImageURL.
- Oracle scripts are identical SQL (no database-specific constructs used).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a simplified Business Partner information window showing one row per business partner.
  * Displays financial, customer, and vendor details, with city, ZIP code, contact, email, and phone available as search criteria.
  * Business Partner references can use either simplified or detailed information windows based on configuration.
  * The Info Window setting is now available for search-reference fields.
* **Bug Fixes**
  * Improved selection of the configured Business Partner information window across supported field types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->