### PR TITLE
IDEMPIERE-7095 Avoid 414 URI too large in web socket server push

### DIFF
--- a/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/ServerPushEndPoint.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/ServerPushEndPoint.java
@@ -63,9 +63,11 @@ import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
 import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactoryBuilder;
 import org.apache.hc.client5.http.ssl.TrustAllStrategy;
 import org.apache.hc.client5.http.utils.DateUtils;
+import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.config.RegistryBuilder;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.apache.hc.core5.util.Timeout;
 import org.compiere.util.CLogger;
@@ -201,10 +203,7 @@ public class ServerPushEndPoint {
 				}
 				setMessageIndicator();
 				
-				StringBuilder fullUrl = new StringBuilder(this.baseUrl)
-		        		.append(uri)
-		        		.append("?")
-		        		.append(content);
+				String url = this.baseUrl + uri;
 
 				String sessionId = null;
 		        try {
@@ -221,9 +220,12 @@ public class ServerPushEndPoint {
 	
 		        synchronized (chainLock) {
 			        try {
-				        // Create POST request
-				        HttpPost httpPost = new HttpPost(fullUrl.toString());
-				        httpPost.setHeader("Content-Type", "application/json");
+				        // Create POST request with the AU content in the body instead of the URL.
+				        // Putting the content into the query string caused the Jetty 8192-byte request
+				        // line limit to be exceeded for large AU payloads (e.g. previewing a large CSV
+				        // spreadsheet), resulting in "URI is too large >8192" (HTTP 414).
+				        HttpPost httpPost = new HttpPost(url);
+				        httpPost.setEntity(new StringEntity(content, ContentType.APPLICATION_FORM_URLENCODED));
 				        httpPost.setHeader("ZK-SID", sid);
 				        httpPost.setHeader("Pragma", "no-cache");
 				        httpPost.setHeader("Cache-Control", "no-cache");

--- a/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/ServerPushEndPoint.java
+++ b/org.adempiere.ui.zk/WEB-INF/src/org/idempiere/ui/zk/websocket/ServerPushEndPoint.java
@@ -201,6 +201,14 @@ public class ServerPushEndPoint {
 					}
 					return;
 				}
+				if (content == null) {
+					try {
+						session.getBasicRemote().sendText(errorResponse("Error: Missing AU content"));
+					} catch (IOException e) {
+						CLogger.getCLogger(getClass()).log(Level.WARNING, e.getMessage(), e);
+					}
+					return;
+				}
 				setMessageIndicator();
 				
 				String url = this.baseUrl + uri;

--- a/org.idempiere.test/META-INF/MANIFEST.MF
+++ b/org.idempiere.test/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Automatic-Module-Name: org.idempiere.test
 Import-Package: com.lowagie.text;version="[1.3.0,2.0.0)",
  com.lowagie.text.pdf;version="[1.3.0,2.0.0)",
  javax.mail.internet;version="[1.6.0,2.0.0]",
+ javax.websocket;version="1.1.0",
  net.sf.jasperreports.export,
  org.adempiere.report.jasper,
  org.assertj.core.api;version="3.22.0",

--- a/org.idempiere.test/src/org/idempiere/test/ui/ServerPushEndPointTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/ui/ServerPushEndPointTest.java
@@ -12,7 +12,7 @@
 package org.idempiere.test.ui;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.mockito.ArgumentMatchers.contains;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -24,6 +24,9 @@ import javax.websocket.Session;
 
 import org.idempiere.ui.zk.websocket.ServerPushEndPoint;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.zkoss.json.JSONObject;
+import org.zkoss.json.parser.JSONParser;
 
 /**
  * Test for the WebSocket server push AU request handling.
@@ -44,7 +47,12 @@ public class ServerPushEndPointTest {
 		assertDoesNotThrow(() -> endpoint.onMessage(session,
 				"zkau;{\"sid\":\"1\",\"dt\":\"desktop1\",\"uri\":\"/zkau?dtid=desktop1\"}"));
 
-		verify(basic).sendText(contains("Missing AU content"));
+		ArgumentCaptor<String> response = ArgumentCaptor.forClass(String.class);
+		verify(basic).sendText(response.capture());
+
+		JSONObject jsonResponse = (JSONObject) new JSONParser().parse(response.getValue());
+		assertEquals(500, jsonResponse.get("status"));
+		assertEquals("Error: Missing AU content", jsonResponse.get("statusText"));
 	}
 
 	private static void setField(Object target, String name, Object value) throws Exception {

--- a/org.idempiere.test/src/org/idempiere/test/ui/ServerPushEndPointTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/ui/ServerPushEndPointTest.java
@@ -1,0 +1,55 @@
+/**********************************************************************
+ * This file is part of iDempiere ERP Open Source                     *
+ * http://www.idempiere.org                                           *
+ *                                                                    *
+ * Copyright (C) Contributors                                         *
+ *                                                                    *
+ * This program is free software; you can redistribute it and/or      *
+ * modify it under the terms of the GNU General Public License         *
+ * as published by the Free Software Foundation; either version 2     *
+ * of the License, or (at your option) any later version.              *
+ **********************************************************************/
+package org.idempiere.test.ui;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+
+import javax.websocket.RemoteEndpoint;
+import javax.websocket.Session;
+
+import org.idempiere.ui.zk.websocket.ServerPushEndPoint;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for the WebSocket server push AU request handling.
+ * Covers IDEMPIERE-7095: reject WebSocket messages without AU content instead of
+ * failing inside the /zkau client with a NullPointerException.
+ */
+public class ServerPushEndPointTest {
+
+	@Test
+	void onMessageWithoutContentIsRejectedWithError() throws Exception {
+		ServerPushEndPoint endpoint = new ServerPushEndPoint();
+		RemoteEndpoint.Basic basic = mock(RemoteEndpoint.Basic.class);
+		Session session = mock(Session.class);
+		when(session.getBasicRemote()).thenReturn(basic);
+		setField(endpoint, "session", session);
+		setField(endpoint, "dtid", "desktop1");
+
+		assertDoesNotThrow(() -> endpoint.onMessage(session,
+				"zkau;{\"sid\":\"1\",\"dt\":\"desktop1\",\"uri\":\"/zkau?dtid=desktop1\"}"));
+
+		verify(basic).sendText(contains("Missing AU content"));
+	}
+
+	private static void setField(Object target, String name, Object value) throws Exception {
+		Field field = ServerPushEndPoint.class.getDeclaredField(name);
+		field.setAccessible(true);
+		field.set(target, value);
+	}
+}


### PR DESCRIPTION
## Summary

Fixes HTTP 414 "URI is too large >8192" for large AU payloads when the WebSocket server push is active (the 14.0 default, IDEMPIERE-3840).

## Root Cause

`org.idempiere.ui.zk.websocket.ServerPushEndPoint.onMessage()` rebuilds the internal `/zkau` request by putting the **entire AU content into the request line** as a query string:

```java
StringBuilder fullUrl = new StringBuilder(this.baseUrl)
        .append(uri)
        .append("?")
        .append(content);   // <-- the full AU payload goes into the URL
...
HttpPost httpPost = new HttpPost(fullUrl.toString());
```

The AU content is url-encoded form data (`zAu.encode(...)`), which in normal ZK AJAX requests travels in the POST body (`application/x-www-form-urlencoded`). Sending it in the request line works for small payloads but exceeds Jetty's **8192-byte request line limit** for large ones - e.g. previewing a large CSV/XLS report in the Keikai spreadsheet in the report viewer - producing:

```
HttpParser.parseLine: URI is too large >8192   (HTTP 414)
```

This only affects the WebSocket server push path (default since 14.0 via IDEMPIERE-3840 / IDEMPIERE-6643). With the Atmosphere server push the AU update travels over the long-lived COMET body and is not affected.

## Fix

Send the AU content as the POST **body** instead of the query string:

```java
HttpPost httpPost = new HttpPost(baseUrl + uri);
httpPost.setEntity(new StringEntity(content, ContentType.APPLICATION_FORM_URLENCODED));
```

## Verification (before/after)

Driven the real Jetty 12.0.24 `HttpParser` (same version as in the iDempiere target platform) with a ~14.7 KB AU payload:

```
AU content size            = 14768 bytes
BEFORE request-line size   = 14804 bytes   <- buggy: content in URL
AFTER  request-line size   = 35 bytes      <- fix:  content as POST body

BEFORE: content in URL  -> REJECTED (Jetty: URI is too large >8192)
AFTER:  content in body -> parsed OK
```

Full reactor `mvn compile` passes.

## Additional Information

- Reported during the review of IDEMPIERE-7070 (PR #3349) - "Open Items (Aging)" report, CSV preview.
- Not caused by the 7070 changes: the CSV/XLS preview flow is identical in r13 and r14; the difference is the server push transport default (Atmosphere in r13 -> WebSocket in r14).
- Workaround until release: start with `-Dorg.idempiere.ui.zk.serverpush=atmosphere`.
- No database migration required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket server-push request handling by sending AU request data in the POST body.
  * Updated request formatting to use the appropriate form-encoded content type for better compatibility with server endpoints.
  * Added a clear error response when AU content is missing, preventing unexpected failures.
  * Improved error reporting by returning a consistent status code and message for invalid server-push requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->