### PR TITLE
IDEMPIERE-7096 : CSV import template record save issue when use /KT for single

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MImportTemplate.java
+++ b/org.adempiere.base/src/org/compiere/model/MImportTemplate.java
@@ -508,6 +508,8 @@ public class MImportTemplate extends X_AD_ImportTemplate implements ImmutablePOS
 			// first remove the /K mark
 			if (columnHeader.endsWith("/K"))
 				columnHeader = columnHeader.substring(0, columnHeader.length()-2);
+			else if (columnHeader.endsWith("/KT"))
+				columnHeader = columnHeader.substring(0, columnHeader.length()-3);
 			// check if there is a foreign column that defines the type
 			String foreignColumnName = null;
 			int idxOpen = columnHeader.indexOf("[");

--- a/org.adempiere.base/src/org/compiere/model/MImportTemplate.java
+++ b/org.adempiere.base/src/org/compiere/model/MImportTemplate.java
@@ -442,7 +442,7 @@ public class MImportTemplate extends X_AD_ImportTemplate implements ImmutablePOS
 	 *   Column[ForeignColumn]
 	 *   DetailTableName>Column
 	 *   DetailTableName>Column[ForeignColumn]
-	 *   Any column can end with /K (can be ignored)
+	 *   Any column can end with /K or /KT (can be ignored)
 	 * @return List of expected DisplayType for every column
 	 */
 	private List<Integer> calculateAndValidateColumnTypes() {


### PR DESCRIPTION
https://idempiere.atlassian.net/browse/IDEMPIERE-7096


# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [x] I have added unit tests that prove my fix is effective or that my feature works
### Documentation
- [ ] I have made corresponding changes to the documentation as follows:
- - [ ] New feature (non-breaking change which adds functionality): I have created the New Feature page in the project wiki explaining the functionality and how to use it. If relevant, I have committed sample data to the core seed to have usable examples in GardenWorld.
- - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected): I have documented the change in a clear way that everyone in the community can understand the impact of the change.
- - [ ] Improvement (improves and existing functionality): This documentation is needed if the improvement changes the way the user interacts with the system or the outcome of a process/task changes. If it is just, for instance, a performance improvement, documentation might not be needed. 
- [ ] The changed/added documentation is in the project wiki (not privately-hosted pdf files or links pointing to a company website) and is complete and self-explanatory.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that import template header column names may use either the `/K` or `/KT` suffix.
  - Documentation now reflects the existing handling of these suffixes when identifying column names.
- **Bug Fixes**
  - Corrected documentation to accurately describe supported import template column header formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->