### PR TITLE
Fix IDEMPIERE-6571 Disable stock reservation for order if shipment is not autogenerated

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MOrder.java
+++ b/org.adempiere.base/src/org/compiere/model/MOrder.java
@@ -1655,8 +1655,12 @@ public class MOrder extends X_C_Order implements DocAction
 			lines = getLines(true, MOrderLine.COLUMNNAME_M_Product_ID);
 
 		// Skip stock reservation when completing an order that generates the shipment immediately
-		boolean skipReserveStock = ( DOCACTION_Complete.equals(getDocAction()) 
-				&& evalAutoGenerateInOutRule(dt.getDocSubTypeSO(), dt.isAutoGenerateInout()) );
+		boolean waitingForPayment = !m_forceCreation
+				&& MDocType.DOCSUBTYPESO_PrepayOrder.equals(dt.getDocSubTypeSO())
+				&& getC_Payment_ID() == 0 && getC_CashLine_ID() == 0;
+		boolean skipReserveStock = (DOCACTION_Complete.equals(getDocAction())
+				&& evalAutoGenerateInOutRule(dt.getDocSubTypeSO(), dt.isAutoGenerateInout())
+				&& !waitingForPayment );
 		if (!skipReserveStock) {
 			if (!reserveStock(dt, lines))
 			{
@@ -2020,19 +2024,19 @@ public class MOrder extends X_C_Order implements DocAction
 	 * @param lines order lines (ordered by M_Product_ID for deadlock prevention)
 	 */
 	protected void calculateVolumeAndWeight(MOrderLine[] lines) {
-		BigDecimal Volume = Env.ZERO;
-		BigDecimal Weight = Env.ZERO;
+		BigDecimal volume = Env.ZERO;
+		BigDecimal weight = Env.ZERO;
 		for (MOrderLine line : lines) {
 			if (line.getM_Product_ID() > 0) {
 				MProduct product = line.getProduct();
 				if (product != null) {
-					Volume = Volume.add(product.getVolume().multiply(line.getQtyOrdered()));
-					Weight = Weight.add(product.getWeight().multiply(line.getQtyOrdered()));
+					volume = volume.add(product.getVolume().multiply(line.getQtyOrdered()));
+					weight = weight.add(product.getWeight().multiply(line.getQtyOrdered()));
 				}
 			}
 		}
-		setVolume(Volume);
-		setWeight(Weight);
+		setVolume(volume);
+		setWeight(weight);
 	} // calculateVolumeAndWeight
 
 	/**

--- a/org.adempiere.base/src/org/compiere/model/MOrder.java
+++ b/org.adempiere.base/src/org/compiere/model/MOrder.java
@@ -43,7 +43,6 @@ import org.adempiere.util.IReservationTracer;
 import org.adempiere.util.IReservationTracerFactory;
 import org.compiere.print.ReportEngine;
 import org.compiere.process.DocAction;
-import org.idempiere.print.ReportContentRequest;
 import org.compiere.process.DocumentEngine;
 import org.compiere.util.CLogger;
 import org.compiere.util.DB;
@@ -53,6 +52,7 @@ import org.compiere.util.TimeUtil;
 import org.compiere.util.Util;
 import org.eevolution.model.MPPProductBOM;
 import org.eevolution.model.MPPProductBOMLine;
+import org.idempiere.print.ReportContentRequest;
 
 /**
  *  Order Model.
@@ -1654,8 +1654,10 @@ public class MOrder extends X_C_Order implements DocAction
 		if (explodeBOM())
 			lines = getLines(true, MOrderLine.COLUMNNAME_M_Product_ID);
 
-		// Reserve stock if does not generate shipment on complete
-		if (!evalAutoGenerateInOutRule(dt.getDocSubTypeSO(), dt.isAutoGenerateInout())) {
+		// Skip stock reservation when completing an order that generates the shipment immediately
+		boolean skipReserveStock = ( DOCACTION_Complete.equals(getDocAction()) 
+				&& evalAutoGenerateInOutRule(dt.getDocSubTypeSO(), dt.isAutoGenerateInout()) );
+		if (!skipReserveStock) {
 			if (!reserveStock(dt, lines))
 			{
 				String innerMsg = CLogger.retrieveErrorString("");

--- a/org.adempiere.base/src/org/compiere/model/MOrder.java
+++ b/org.adempiere.base/src/org/compiere/model/MOrder.java
@@ -74,9 +74,9 @@ import org.idempiere.print.ReportContentRequest;
 public class MOrder extends X_C_Order implements DocAction
 {
 	/**
-	 * generated serial id
+	 *
 	 */
-	private static final long serialVersionUID = 9095740800513665542L;
+	private static final long serialVersionUID = -7697599534971299336L;
 
 	/** Matching SELECT SQL template */
 	private static final String BASE_MATCHING_SQL =
@@ -1667,6 +1667,9 @@ public class MOrder extends X_C_Order implements DocAction
 				return DocAction.STATUS_Invalid;
 			}
 		}
+
+		calculateVolumeAndWeight(lines);
+
 		if (!calculateTaxTotal())
 		{
 			m_processMsg = "Error calculating tax";
@@ -1947,10 +1950,7 @@ public class MOrder extends X_C_Order implements DocAction
 		if (MDocType.DOCSUBTYPESO_StandardOrder.equals(dt.getDocSubTypeSO())
 			|| MDocType.DOCBASETYPE_PurchaseOrder.equals(dt.getDocBaseType()))
 			header_M_Warehouse_ID = 0;		//	don't enforce
-		
-		BigDecimal Volume = Env.ZERO;
-		BigDecimal Weight = Env.ZERO;
-		
+
 		//	Always check and (un) Reserve Inventory		
 		for (int i = 0; i < lines.length; i++)
 		{
@@ -1972,12 +1972,6 @@ public class MOrder extends X_C_Order implements DocAction
 			{
 				if (difference.signum() == 0 || line.getQtyReserved().signum() == 0)
 				{
-					MProduct product = line.getProduct();
-					if (product != null)
-					{
-						Volume = Volume.add(product.getVolume().multiply(line.getQtyOrdered()));
-						Weight = Weight.add(product.getWeight().multiply(line.getQtyOrdered()));
-					}
 					continue;
 				}
 				else if (line.getQtyOrdered().signum() < 0 && line.getQtyReserved().signum() > 0)
@@ -2016,16 +2010,30 @@ public class MOrder extends X_C_Order implements DocAction
 				line.setQtyReserved(line.getQtyReserved().add(difference));
 				if (!line.save(get_TrxName()))
 					return false;
-				//
-				Volume = Volume.add(product.getVolume().multiply(line.getQtyOrdered()));
-				Weight = Weight.add(product.getWeight().multiply(line.getQtyOrdered()));
 			}	//	product
 		}	//	reverse inventory
-		
-		setVolume(Volume);
-		setWeight(Weight);
 		return true;
 	}	//	reserveStock
+
+	/**
+	 * Calculate the Volume and Weight of the order
+	 * @param lines order lines (ordered by M_Product_ID for deadlock prevention)
+	 */
+	protected void calculateVolumeAndWeight(MOrderLine[] lines) {
+		BigDecimal Volume = Env.ZERO;
+		BigDecimal Weight = Env.ZERO;
+		for (MOrderLine line : lines) {
+			if (line.getM_Product_ID() > 0) {
+				MProduct product = line.getProduct();
+				if (product != null) {
+					Volume = Volume.add(product.getVolume().multiply(line.getQtyOrdered()));
+					Weight = Weight.add(product.getWeight().multiply(line.getQtyOrdered()));
+				}
+			}
+		}
+		setVolume(Volume);
+		setWeight(Weight);
+	} // calculateVolumeAndWeight
 
 	/**
 	 * 	Calculate Tax and Total (delete and re-create C_OrderTax records).

--- a/org.idempiere.test/src/org/idempiere/test/model/SalesOrderTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/SalesOrderTest.java
@@ -1839,7 +1839,11 @@ public class SalesOrderTest extends AbstractTestCase {
 		    order.load(getTrxName());
 		    assertEquals(DocAction.STATUS_WaitingPayment, order.getDocStatus());
 		    order.saveEx();
-	
+
+		    // There must be reservations here on line1 because we don't know when is going to be paid
+			line1.load(getTrxName());
+			assertEquals(1, line1.getQtyReserved().intValue(), "Azalea Bush not reserved after prepare");
+
 		    // Create the payment
 		    MPayment payment = new MPayment(Env.getCtx(), 0, getTrxName());
 		    payment.setC_Order_ID(order.getC_Order_ID());

--- a/org.idempiere.test/src/org/idempiere/test/model/SalesOrderTest.java
+++ b/org.idempiere.test/src/org/idempiere/test/model/SalesOrderTest.java
@@ -1991,4 +1991,76 @@ public class SalesOrderTest extends AbstractTestCase {
 			}
 	    }
 	}
+
+	@Test
+	public void testPOSOrderReservationAndWeight() {
+		Properties ctx = Env.getCtx();
+		String trxName = getTrxName();
+
+		MOrder order = new MOrder(ctx, 0, trxName);
+		order.setBPartner(MBPartner.get(ctx, DictionaryIDs.C_BPartner.JOE_BLOCK.id));
+		order.setC_DocTypeTarget_ID(MOrder.DocSubTypeSO_POS);
+		order.setDeliveryRule(MOrder.DELIVERYRULE_CompleteOrder);
+		order.setDocStatus(DocAction.STATUS_Drafted);
+		order.setDocAction(DocAction.ACTION_Prepare);
+		order.setPaymentRule(MOrder.PAYMENTRULE_Cash);
+		Timestamp today = TimeUtil.getDay(System.currentTimeMillis());
+		order.setDateOrdered(today);
+		order.setDatePromised(today);
+		order.saveEx();
+
+		MOrderLine line1 = new MOrderLine(order);
+		line1.setLine(10);
+		line1.setProduct(MProduct.get(ctx, DictionaryIDs.M_Product.AZALEA_BUSH.id));
+		line1.setQty(new BigDecimal("1"));
+		line1.setDatePromised(today);
+		line1.saveEx();
+
+		MOrderLine line2 = new MOrderLine(order);
+		line2.setLine(20);
+		line2.setProduct(MProduct.get(ctx, DictionaryIDs.M_Product.HOE.id));
+		line2.setQty(new BigDecimal("1"));
+		line2.setDatePromised(today);
+		line2.saveEx();
+
+		// Prepare the order
+		ProcessInfo info = MWorkflow.runDocumentActionWorkflow(order, DocAction.ACTION_Prepare);
+		assertFalse(info.isError(), info.getSummary());
+
+		order.load(trxName);
+		line1.load(trxName);
+		line2.load(trxName);
+
+		// After prepare: check reservations are set
+		assertEquals(1, line1.getQtyReserved().intValue(), "Azalea Bush not reserved after prepare");
+		assertEquals(1, line2.getQtyReserved().intValue(), "Hoe not reserved after prepare");
+
+		// Check weight is set
+		assertTrue(order.getWeight().signum() > 0, "Weight not set after prepare");
+
+		// Now complete the order
+		order.setDocAction(DocAction.ACTION_Complete);
+		order.saveEx();
+		info = MWorkflow.runDocumentActionWorkflow(order, DocAction.ACTION_Complete);
+		assertFalse(info.isError(), info.getSummary());
+
+		order.load(trxName);
+		assertEquals(DocAction.STATUS_Completed, order.getDocStatus());
+
+		line1.load(trxName);
+		line2.load(trxName);
+
+		// After complete: reservations should be cleared (shipment auto-generated)
+		assertEquals(0, line1.getQtyReserved().intValue(), "Azalea Bush reservation not cleared after complete");
+		assertEquals(0, line2.getQtyReserved().intValue(), "Hoe reservation not cleared after complete");
+
+		assertEquals(1, line1.getQtyDelivered().intValue());
+		assertEquals(1, line2.getQtyDelivered().intValue());
+		assertEquals(1, line1.getQtyInvoiced().intValue());
+		assertEquals(1, line2.getQtyInvoiced().intValue());
+
+		MInOut[] shipments = order.getShipments();
+		assertEquals(1, shipments.length);
+		assertEquals(DocAction.STATUS_Completed, shipments[0].getDocStatus());
+	}
 }


### PR DESCRIPTION
must create reservations when preparing

https://idempiere.atlassian.net/browse/IDEMPIERE-6571?focusedCommentId=76316

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [x] New and existing unit tests pass locally with my changes
- [x] I have added unit tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stock reservation during order preparation.
  * Reservations are skipped only when completing an order that immediately generates a shipment and is not awaiting payment.
  * Order volume and weight are calculated consistently from product lines, independently of reservation differences.
  * Tax and payment processing continue correctly after order preparation and shipment handling.
  * POS and prepayment order workflows now preserve expected reservation, delivery, invoicing, and automatic shipment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->