### PR TITLE
IDEMPIERE-6571 Disable stock reservation for order if shipment is not autogenerated

### DIFF
--- a/org.adempiere.base/src/org/compiere/model/MOrder.java
+++ b/org.adempiere.base/src/org/compiere/model/MOrder.java
@@ -1655,10 +1655,18 @@ public class MOrder extends X_C_Order implements DocAction
 			lines = getLines(true, MOrderLine.COLUMNNAME_M_Product_ID);
 
 		// Skip stock reservation when completing an order that generates the shipment immediately
+		boolean hasReservations = false;
+		for (MOrderLine line : lines) {
+			if (line.getQtyReserved().signum() != 0) {
+				hasReservations = true;
+				break;
+			}
+		}
 		boolean waitingForPayment = !m_forceCreation
 				&& MDocType.DOCSUBTYPESO_PrepayOrder.equals(dt.getDocSubTypeSO())
 				&& getC_Payment_ID() == 0 && getC_CashLine_ID() == 0;
-		boolean skipReserveStock = (DOCACTION_Complete.equals(getDocAction())
+		boolean skipReserveStock = !hasReservations
+				&& (DOCACTION_Complete.equals(getDocAction())
 				&& evalAutoGenerateInOutRule(dt.getDocSubTypeSO(), dt.isAutoGenerateInout())
 				&& !waitingForPayment );
 		if (!skipReserveStock) {


### PR DESCRIPTION
- fix the case of not clearing reservations when completed

https://idempiere.atlassian.net/browse/IDEMPIERE-6571?focusedCommentId=76448

# Pull Request Checklist

- [x] My code follows the [code guidelines](https://wiki.idempiere.org/en/Contributing_to_Trunk) of this project
- [x] My code follows the best practices of this project
- [x] I have performed a self-review of my own code
- [x] My code is easy to understand and review. 
- [x] I have checked my code and corrected any misspellings
- [x] In hard-to-understand areas, I have commented my code.
- [x] My changes generate no new warnings
### Tests
- [x] I have tested the direct scenario that my code is solving
- [x] I checked all collaterals that can be affected by my changes, and tested other potential affected scenarios
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added unit tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stock reservation handling for orders with existing reservations.
  - Prevents reservation skipping when an order line is already reserved, including orders that automatically generate shipments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->