### PR TITLE
Fix IDEMPIERE-7101 Infinite loop in workflow approval user search

### DIFF
--- a/org.adempiere.base/src/org/compiere/wf/MWFActivity.java
+++ b/org.adempiere.base/src/org/compiere/wf/MWFActivity.java
@@ -28,8 +28,10 @@ import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.logging.Level;
 
@@ -733,11 +735,24 @@ public class MWFActivity extends X_AD_WF_Activity implements Runnable
 			+ ", Own=" + ownDocument);
 
 		MUser oldUser = null;
+		Set<Integer> visitedUserIds = new HashSet<>();
 		while (user != null)
 		{
 			if (user.equals(oldUser))
 			{
 				if (log.isLoggable(Level.INFO)) log.info("Loop - " + user.getName());
+				user=null;
+				break;
+			}
+			//	Guard against approval hierarchy cycles longer than one step
+			//	(e.g. user A -> supervisor B -> org supervisor A): the oldUser check
+			//	above only catches immediate self repetition and would loop forever,
+			//	burning CPU while holding the workflow transaction (and its DB locks)
+			//	open. Break out so the caller fails cleanly with NoApprover.
+			if (!visitedUserIds.add(Integer.valueOf(user.getAD_User_ID())))
+			{
+				log.warning("Approval hierarchy cycle detected at user "
+					+ user.getName() + " (" + user.getAD_User_ID() + "), aborting approver search");
 				user=null;
 				break;
 			}


### PR DESCRIPTION
JIRA: https://idempiere.atlassian.net/browse/IDEMPIERE-7101

**Problem**
Starting a document workflow with a UserChoice approval node hangs forever when no role in the supervisor/org-supervisor chain can approve the amount. The worker thread spins at ~100% CPU in `MWFActivity.getApprovalUser`, the workflow DB transaction stays open (`idle in transaction`, `RowExclusiveLock` on document/WF tables) and blocks concurrent writers.

**Root cause**
The loop guard in `getApprovalUser` only compares each user with its immediate predecessor, so supervisor/org-supervisor cycles longer than one step (e.g. user -> supervisor -> org supervisor -> same user) never terminate.

**Fix**
Track visited `AD_User_ID`s in a `HashSet`; on revisit log a warning and abort the search (`return -1` -> existing `NoApprover` handling, clean rollback).

**Testing**
- `javac` compile check of `MWFActivity.java` passes.
- Simulated the supervisor/org-supervisor walk from the report: old logic loops unbounded, new logic breaks at the first revisit.
- Live verification with a looping approval setup still pending (draft PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented workflow approval searches from looping indefinitely when approval hierarchies contain cycles.
  * Workflows now stop the search and report a warning when a previously visited approver is encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->